### PR TITLE
Add permission tables and repository

### DIFF
--- a/backend/adapters/orm/prisma/migrations/20250722215200_add_permission/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250722215200_add_permission/migration.sql
@@ -1,0 +1,42 @@
+-- CreateTable
+CREATE TABLE "Permission" (
+    "id" TEXT NOT NULL,
+    "permissionKey" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    CONSTRAINT "Permission_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Permission_permissionKey_key" UNIQUE ("permissionKey")
+);
+
+-- CreateTable
+CREATE TABLE "UserPermission" (
+    "userId" TEXT NOT NULL,
+    "permissionId" TEXT NOT NULL,
+    CONSTRAINT "UserPermission_pkey" PRIMARY KEY ("userId","permissionId")
+);
+
+-- CreateTable
+CREATE TABLE "RolePermission" (
+    "roleId" TEXT NOT NULL,
+    "permissionId" TEXT NOT NULL,
+    CONSTRAINT "RolePermission_pkey" PRIMARY KEY ("roleId","permissionId")
+);
+
+-- CreateTable
+CREATE TABLE "DepartmentPermission" (
+    "departmentId" TEXT NOT NULL,
+    "permissionId" TEXT NOT NULL,
+    CONSTRAINT "DepartmentPermission_pkey" PRIMARY KEY ("departmentId","permissionId")
+);
+
+-- AddForeignKey
+ALTER TABLE "UserPermission" ADD CONSTRAINT "UserPermission_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "UserPermission" ADD CONSTRAINT "UserPermission_permissionId_fkey" FOREIGN KEY ("permissionId") REFERENCES "Permission"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "RolePermission" ADD CONSTRAINT "RolePermission_roleId_fkey" FOREIGN KEY ("roleId") REFERENCES "Role"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "RolePermission" ADD CONSTRAINT "RolePermission_permissionId_fkey" FOREIGN KEY ("permissionId") REFERENCES "Permission"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "DepartmentPermission" ADD CONSTRAINT "DepartmentPermission_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "Department"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "DepartmentPermission" ADD CONSTRAINT "DepartmentPermission_permissionId_fkey" FOREIGN KEY ("permissionId") REFERENCES "Permission"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   department   Department @relation(fields: [departmentId], references: [id])
   departmentId String
   roles      UserRole[]
+  permissions UserPermission[]
   managedDepartments Department[] @relation("DepartmentManager")
 }
 
@@ -26,6 +27,7 @@ model Role {
   id    String @id @default(uuid())
   label String
   users UserRole[]
+  permissions RolePermission[]
 }
 
 model Department {
@@ -37,6 +39,7 @@ model Department {
   managerUserId      String?
   manager            User?       @relation("DepartmentManager", fields: [managerUserId], references: [id])
   users              User[]
+  permissions DepartmentPermission[]
 }
 
 model UserRole {
@@ -46,4 +49,40 @@ model UserRole {
   roleId String
 
   @@id([userId, roleId])
+}
+
+model Permission {
+  id            String   @id @default(uuid())
+  permissionKey String   @unique
+  description   String
+  userPermissions       UserPermission[]
+  rolePermissions       RolePermission[]
+  departmentPermissions DepartmentPermission[]
+}
+
+model UserPermission {
+  user        User       @relation(fields: [userId], references: [id])
+  userId      String
+  permission  Permission @relation(fields: [permissionId], references: [id])
+  permissionId String
+
+  @@id([userId, permissionId])
+}
+
+model RolePermission {
+  role        Role       @relation(fields: [roleId], references: [id])
+  roleId      String
+  permission  Permission @relation(fields: [permissionId], references: [id])
+  permissionId String
+
+  @@id([roleId, permissionId])
+}
+
+model DepartmentPermission {
+  department  Department @relation(fields: [departmentId], references: [id])
+  departmentId String
+  permission   Permission @relation(fields: [permissionId], references: [id])
+  permissionId String
+
+  @@id([departmentId, permissionId])
 }

--- a/backend/adapters/repositories/PrismaPermissionRepository.ts
+++ b/backend/adapters/repositories/PrismaPermissionRepository.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from '@prisma/client';
+import { Permission } from '../../domain/entities/Permission';
+import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
+
+/**
+ * Prisma-based implementation of {@link PermissionRepositoryPort}.
+ */
+export class PrismaPermissionRepository implements PermissionRepositoryPort {
+  constructor(private prisma: PrismaClient) {}
+
+  private mapRecord(record: any): Permission {
+    return new Permission(record.id, record.permissionKey, record.description);
+  }
+
+  async findById(id: string): Promise<Permission | null> {
+    const record = await (this.prisma as any).permission.findUnique({ where: { id } });
+    return record ? this.mapRecord(record) : null;
+  }
+
+  async findByKey(permissionKey: string): Promise<Permission | null> {
+    const record = await (this.prisma as any).permission.findFirst({ where: { permissionKey } });
+    return record ? this.mapRecord(record) : null;
+  }
+
+  async create(permission: Permission): Promise<Permission> {
+    const record = await (this.prisma as any).permission.create({
+      data: { id: permission.id, permissionKey: permission.permissionKey, description: permission.description },
+    });
+    return this.mapRecord(record);
+  }
+
+  async update(permission: Permission): Promise<Permission> {
+    const record = await (this.prisma as any).permission.update({
+      where: { id: permission.id },
+      data: { permissionKey: permission.permissionKey, description: permission.description },
+    });
+    return this.mapRecord(record);
+  }
+
+  async delete(id: string): Promise<void> {
+    await (this.prisma as any).permission.delete({ where: { id } });
+  }
+}

--- a/backend/domain/entities/Permission.ts
+++ b/backend/domain/entities/Permission.ts
@@ -1,0 +1,17 @@
+/**
+ * Represents a permission available in the system.
+ */
+export class Permission {
+  /**
+   * Create a new {@link Permission} instance.
+   *
+   * @param id - Unique identifier for the permission.
+   * @param permissionKey - Key representing the permission.
+   * @param description - Human readable description of the permission.
+   */
+  constructor(
+    public readonly id: string,
+    public permissionKey: string,
+    public description: string
+  ) {}
+}

--- a/backend/domain/ports/PermissionRepositoryPort.ts
+++ b/backend/domain/ports/PermissionRepositoryPort.ts
@@ -1,0 +1,45 @@
+import { Permission } from '../entities/Permission';
+
+/**
+ * Defines the contract for permission persistence operations.
+ */
+export interface PermissionRepositoryPort {
+  /**
+   * Find a permission by its identifier.
+   *
+   * @param id - Identifier of the permission to locate.
+   * @returns The matching {@link Permission} or `null` if not found.
+   */
+  findById(id: string): Promise<Permission | null>;
+
+  /**
+   * Retrieve a permission by its key.
+   *
+   * @param permissionKey - Key of the permission to search for.
+   * @returns The corresponding {@link Permission} or `null` if none exists.
+   */
+  findByKey(permissionKey: string): Promise<Permission | null>;
+
+  /**
+   * Persist a new permission.
+   *
+   * @param permission - Permission entity to create.
+   * @returns The created {@link Permission} entity.
+   */
+  create(permission: Permission): Promise<Permission>;
+
+  /**
+   * Update an existing permission.
+   *
+   * @param permission - Updated permission entity.
+   * @returns The persisted {@link Permission} after update.
+   */
+  update(permission: Permission): Promise<Permission>;
+
+  /**
+   * Remove a permission by identifier.
+   *
+   * @param id - Identifier of the permission to delete.
+   */
+  delete(id: string): Promise<void>;
+}

--- a/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
@@ -1,0 +1,96 @@
+import { PrismaClient } from '@prisma/client';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { PrismaPermissionRepository } from '../../../adapters/repositories/PrismaPermissionRepository';
+import { Permission } from '../../../domain/entities/Permission';
+
+describe('PrismaPermissionRepository', () => {
+  let repository: PrismaPermissionRepository;
+  let prisma: DeepMockProxy<PrismaClient>;
+  let prismaAny: any;
+  let perm: Permission;
+
+  beforeEach(() => {
+    prisma = mockDeep<PrismaClient>();
+    prismaAny = prisma as any;
+    repository = new PrismaPermissionRepository(prisma);
+    perm = new Permission('perm-1', 'READ', 'Read access');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findById', () => {
+    it('should return a permission when found', async () => {
+      prismaAny.permission.findUnique.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access' } as any);
+
+      const result = await repository.findById('perm-1');
+
+      expect(result).toEqual(perm);
+      expect(prismaAny.permission.findUnique).toHaveBeenCalledWith({ where: { id: 'perm-1' } });
+    });
+
+    it('should return null when not found', async () => {
+      prismaAny.permission.findUnique.mockResolvedValue(null);
+
+      const result = await repository.findById('unknown');
+
+      expect(result).toBeNull();
+      expect(prismaAny.permission.findUnique).toHaveBeenCalledWith({ where: { id: 'unknown' } });
+    });
+  });
+
+  describe('findByKey', () => {
+    it('should return a permission by key', async () => {
+      prismaAny.permission.findFirst.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access' } as any);
+
+      const result = await repository.findByKey('READ');
+
+      expect(result).toEqual(perm);
+      expect(prismaAny.permission.findFirst).toHaveBeenCalledWith({ where: { permissionKey: 'READ' } });
+    });
+
+    it('should return null when permission not found', async () => {
+      prismaAny.permission.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findByKey('WRITE');
+
+      expect(result).toBeNull();
+      expect(prismaAny.permission.findFirst).toHaveBeenCalledWith({ where: { permissionKey: 'WRITE' } });
+    });
+  });
+
+  describe('create', () => {
+    it('should create a permission', async () => {
+      prismaAny.permission.create.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access' } as any);
+
+      const result = await repository.create(perm);
+
+      expect(result).toEqual(perm);
+      expect(prismaAny.permission.create).toHaveBeenCalledWith({ data: { id: 'perm-1', permissionKey: 'READ', description: 'Read access' } });
+    });
+  });
+
+  describe('update', () => {
+    it('should update a permission', async () => {
+      prismaAny.permission.update.mockResolvedValue({ id: 'perm-1', permissionKey: 'WRITE', description: 'Write access' } as any);
+
+      perm.permissionKey = 'WRITE';
+      perm.description = 'Write access';
+      const result = await repository.update(perm);
+
+      expect(result).toEqual(new Permission('perm-1', 'WRITE', 'Write access'));
+      expect(prismaAny.permission.update).toHaveBeenCalledWith({ where: { id: 'perm-1' }, data: { permissionKey: 'WRITE', description: 'Write access' } });
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a permission', async () => {
+      prismaAny.permission.delete.mockResolvedValue(undefined as any);
+
+      await repository.delete('perm-1');
+
+      expect(prismaAny.permission.delete).toHaveBeenCalledWith({ where: { id: 'perm-1' } });
+    });
+  });
+});

--- a/backend/tests/domain/entities/Permission.test.ts
+++ b/backend/tests/domain/entities/Permission.test.ts
@@ -1,0 +1,19 @@
+import { Permission } from '../../../domain/entities/Permission';
+
+describe('Permission Entity', () => {
+  it('should construct a permission with all properties', () => {
+    const perm = new Permission('perm-1', 'READ', 'Read access');
+    expect(perm.id).toBe('perm-1');
+    expect(perm.permissionKey).toBe('READ');
+    expect(perm.description).toBe('Read access');
+  });
+
+  it('should allow modifying mutable properties', () => {
+    const perm = new Permission('perm-2', 'WRITE', 'Write access');
+    perm.permissionKey = 'EDIT';
+    perm.description = 'Edit access';
+
+    expect(perm.permissionKey).toBe('EDIT');
+    expect(perm.description).toBe('Edit access');
+  });
+});

--- a/backend/tests/domain/ports/PermissionRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/PermissionRepositoryPort.test.ts
@@ -1,0 +1,81 @@
+import { PermissionRepositoryPort } from '../../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../../domain/entities/Permission';
+
+class MockPermissionRepository implements PermissionRepositoryPort {
+  private permissions: Map<string, Permission> = new Map();
+  private keyIndex: Map<string, string> = new Map();
+
+  async findById(id: string): Promise<Permission | null> {
+    return this.permissions.get(id) || null;
+  }
+
+  async findByKey(permissionKey: string): Promise<Permission | null> {
+    const id = this.keyIndex.get(permissionKey);
+    return id ? this.permissions.get(id) || null : null;
+  }
+
+  async create(permission: Permission): Promise<Permission> {
+    this.permissions.set(permission.id, permission);
+    this.keyIndex.set(permission.permissionKey, permission.id);
+    return permission;
+  }
+
+  async update(permission: Permission): Promise<Permission> {
+    if (!this.permissions.has(permission.id)) {
+      throw new Error('Permission not found');
+    }
+    const existing = this.permissions.get(permission.id);
+    if (existing) this.keyIndex.delete(existing.permissionKey);
+    this.permissions.set(permission.id, permission);
+    this.keyIndex.set(permission.permissionKey, permission.id);
+    return permission;
+  }
+
+  async delete(id: string): Promise<void> {
+    const perm = this.permissions.get(id);
+    if (perm) {
+      this.permissions.delete(id);
+      this.keyIndex.delete(perm.permissionKey);
+    }
+  }
+
+  clear(): void {
+    this.permissions.clear();
+    this.keyIndex.clear();
+  }
+}
+
+describe('PermissionRepositoryPort Interface', () => {
+  let repo: MockPermissionRepository;
+  let perm: Permission;
+
+  beforeEach(() => {
+    repo = new MockPermissionRepository();
+    perm = new Permission('perm-1', 'READ', 'Read access');
+  });
+
+  afterEach(() => {
+    repo.clear();
+  });
+
+  it('should create and retrieve a permission', async () => {
+    await repo.create(perm);
+    expect(await repo.findById('perm-1')).toEqual(perm);
+    expect(await repo.findByKey('READ')).toEqual(perm);
+  });
+
+  it('should update an existing permission', async () => {
+    await repo.create(perm);
+    perm.permissionKey = 'WRITE';
+    perm.description = 'Write access';
+    const updated = await repo.update(perm);
+    expect(updated.permissionKey).toBe('WRITE');
+    expect(await repo.findByKey('WRITE')).toEqual(updated);
+  });
+
+  it('should delete a permission', async () => {
+    await repo.create(perm);
+    await repo.delete('perm-1');
+    expect(await repo.findById('perm-1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add Permission entity and repository port
- implement PrismaPermissionRepository adapter
- update prisma schema with permission tables and link tables
- add migration for permission tables
- test Permission domain entity, port and prisma repository

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68800d1b31d08323b9af4c74c43c20ff