### PR TITLE
Fix tests and add coverage

### DIFF
--- a/backend/adapters/repositories/PrismaPermissionRepository.ts
+++ b/backend/adapters/repositories/PrismaPermissionRepository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Permission as PrismaPermission } from '@prisma/client';
 import { Permission } from '../../domain/entities/Permission';
 import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
 
@@ -8,29 +8,29 @@ import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositor
 export class PrismaPermissionRepository implements PermissionRepositoryPort {
   constructor(private prisma: PrismaClient) {}
 
-  private mapRecord(record: any): Permission {
+  private mapRecord(record: PrismaPermission): Permission {
     return new Permission(record.id, record.permissionKey, record.description);
   }
 
   async findById(id: string): Promise<Permission | null> {
-    const record = await (this.prisma as any).permission.findUnique({ where: { id } });
+    const record = await this.prisma.permission.findUnique({ where: { id } });
     return record ? this.mapRecord(record) : null;
   }
 
   async findByKey(permissionKey: string): Promise<Permission | null> {
-    const record = await (this.prisma as any).permission.findFirst({ where: { permissionKey } });
+    const record = await this.prisma.permission.findFirst({ where: { permissionKey } });
     return record ? this.mapRecord(record) : null;
   }
 
   async create(permission: Permission): Promise<Permission> {
-    const record = await (this.prisma as any).permission.create({
+    const record = await this.prisma.permission.create({
       data: { id: permission.id, permissionKey: permission.permissionKey, description: permission.description },
     });
     return this.mapRecord(record);
   }
 
   async update(permission: Permission): Promise<Permission> {
-    const record = await (this.prisma as any).permission.update({
+    const record = await this.prisma.permission.update({
       where: { id: permission.id },
       data: { permissionKey: permission.permissionKey, description: permission.description },
     });
@@ -38,6 +38,6 @@ export class PrismaPermissionRepository implements PermissionRepositoryPort {
   }
 
   async delete(id: string): Promise<void> {
-    await (this.prisma as any).permission.delete({ where: { id } });
+    await this.prisma.permission.delete({ where: { id } });
   }
 }

--- a/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
@@ -157,6 +157,44 @@ describe('PrismaUserRepository', () => {
     });
   });
 
+  describe('findByExternalAuth', () => {
+    it('should return user when found via external provider', async () => {
+      const mockPrismaUser = {
+        id: 'user-123',
+        firstname: 'John',
+        lastname: 'Doe',
+        email: 'john.doe@example.com',
+        password: 'hashed-password',
+        status: 'active',
+        departmentId: 'dept-1',
+        externalProvider: 'google',
+        externalId: 'g123',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        roles: []
+      };
+
+      prismaClient.user.findFirst.mockResolvedValue(mockPrismaUser as any);
+
+      const result = await repository.findByExternalAuth('google', 'g123');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('user-123');
+      expect(prismaClient.user.findFirst).toHaveBeenCalledWith({
+        where: { externalProvider: 'google', externalId: 'g123' },
+        include: { roles: { include: { role: true } } },
+      });
+    });
+
+    it('should return null when user not found via external provider', async () => {
+      prismaClient.user.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findByExternalAuth('google', 'unknown');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('create', () => {
     it('should create user successfully', async () => {
       const mockPrismaCreatedUser = {


### PR DESCRIPTION
## Summary
- add missing findByExternalAuth implementation in test mock
- cover PrismaUserRepository.findByExternalAuth
- fix PrismaPermissionRepository typings
- ensure 100% coverage and lint clean

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880167db1e083238e03953d66b5583b