### PR TITLE
Add user status change and removal use cases

### DIFF
--- a/backend/tests/usecases/user/ChangeUserStatusUseCase.test.ts
+++ b/backend/tests/usecases/user/ChangeUserStatusUseCase.test.ts
@@ -1,0 +1,46 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { ChangeUserStatusUseCase } from '../../../usecases/user/ChangeUserStatusUseCase';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('ChangeUserStatusUseCase', () => {
+  let repository: DeepMockProxy<UserRepositoryPort>;
+  let useCase: ChangeUserStatusUseCase;
+  let user: User;
+  let role: Role;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<UserRepositoryPort>();
+    useCase = new ChangeUserStatusUseCase(repository);
+    role = new Role('role-1', 'Admin');
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+    user = new User('user-1', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+  });
+
+  it('should change user status via repository', async () => {
+    repository.findById.mockResolvedValue(user);
+    repository.update.mockResolvedValue(user);
+
+    const result = await useCase.execute('user-1', 'suspended');
+
+    expect(result).toBe(user);
+    expect(user.status).toBe('suspended');
+    expect(repository.findById).toHaveBeenCalledWith('user-1');
+    expect(repository.update).toHaveBeenCalledWith(user);
+  });
+
+  it('should return null when user is not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing', 'archived');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/user/RemoveUserUseCase.test.ts
+++ b/backend/tests/usecases/user/RemoveUserUseCase.test.ts
@@ -1,0 +1,19 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemoveUserUseCase } from '../../../usecases/user/RemoveUserUseCase';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+
+describe('RemoveUserUseCase', () => {
+  let repository: DeepMockProxy<UserRepositoryPort>;
+  let useCase: RemoveUserUseCase;
+
+  beforeEach(() => {
+    repository = mockDeep<UserRepositoryPort>();
+    useCase = new RemoveUserUseCase(repository);
+  });
+
+  it('should delete user via repository', async () => {
+    await useCase.execute('user-1');
+
+    expect(repository.delete).toHaveBeenCalledWith('user-1');
+  });
+});

--- a/backend/usecases/user/ChangeUserStatusUseCase.ts
+++ b/backend/usecases/user/ChangeUserStatusUseCase.ts
@@ -1,0 +1,25 @@
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { User } from '../../domain/entities/User';
+
+/**
+ * Use case for changing the status of a {@link User} account.
+ */
+export class ChangeUserStatusUseCase {
+  constructor(private readonly userRepository: UserRepositoryPort) {}
+
+  /**
+   * Execute the status update.
+   *
+   * @param userId - Identifier of the user to modify.
+   * @param status - The new status to assign.
+   * @returns The updated {@link User} or `null` if the user was not found.
+   */
+  async execute(userId: string, status: 'active' | 'suspended' | 'archived'): Promise<User | null> {
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      return null;
+    }
+    user.status = status;
+    return this.userRepository.update(user);
+  }
+}

--- a/backend/usecases/user/RemoveUserUseCase.ts
+++ b/backend/usecases/user/RemoveUserUseCase.ts
@@ -1,0 +1,17 @@
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+
+/**
+ * Use case for removing a user and all associated data from the system.
+ */
+export class RemoveUserUseCase {
+  constructor(private readonly userRepository: UserRepositoryPort) {}
+
+  /**
+   * Execute the removal.
+   *
+   * @param userId - Identifier of the user to delete.
+   */
+  async execute(userId: string): Promise<void> {
+    await this.userRepository.delete(userId);
+  }
+}


### PR DESCRIPTION
## Summary
- add `ChangeUserStatusUseCase` for updating a user's status
- add `RemoveUserUseCase` for deleting a user and related data
- test both new use cases

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test` *(fails: coverage threshold for branches 100% not met)*

------
https://chatgpt.com/codex/tasks/task_e_6880edf2fed08323a22fd45d03de7051