### PR TITLE
Add department management use cases

### DIFF
--- a/backend/adapters/repositories/PrismaUserRepository.ts
+++ b/backend/adapters/repositories/PrismaUserRepository.ts
@@ -81,6 +81,19 @@ export class PrismaUserRepository implements UserRepositoryPort {
     return record ? this.mapRecord(record) : null;
   }
 
+  async findByDepartmentId(departmentId: string): Promise<User[]> {
+    const records = await this.prisma.user.findMany({
+      where: { departmentId },
+      include: {
+        roles: { include: { role: true } },
+        department: { include: { site: true } },
+        site: true,
+        permissions: { include: { permission: true } },
+      },
+    });
+    return records.map(r => this.mapRecord(r));
+  }
+
   async create(user: User): Promise<User> {
     const record = await this.prisma.user.create({
       data: {

--- a/backend/domain/ports/UserRepositoryPort.ts
+++ b/backend/domain/ports/UserRepositoryPort.ts
@@ -27,7 +27,15 @@ export interface UserRepositoryPort {
    * @param externalId - Unique identifier from the external provider.
    * @returns The matching {@link User} or `null` if not found.
    */
-  findByExternalAuth(provider: string, externalId: string): Promise<User | null>
+  findByExternalAuth(provider: string, externalId: string): Promise<User | null>;
+
+  /**
+   * Retrieve all users belonging to the specified department.
+   *
+   * @param departmentId - Identifier of the department.
+   * @returns Array of matching {@link User} instances.
+   */
+  findByDepartmentId(departmentId: string): Promise<User[]>;
 
   /**
    * Persist a new user.

--- a/backend/tests/adapters/repositories/PrismaSiteRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaSiteRepository.test.ts
@@ -25,6 +25,15 @@ describe('PrismaSiteRepository', () => {
     expect(prisma.site.findUnique).toHaveBeenCalledWith({ where: { id: 'site-1' } });
   });
 
+  it('should return null when site not found by id', async () => {
+    prisma.site.findUnique.mockResolvedValue(null);
+
+    const result = await repo.findById('missing');
+
+    expect(result).toBeNull();
+    expect(prisma.site.findUnique).toHaveBeenCalledWith({ where: { id: 'missing' } });
+  });
+
   it('should create a site', async () => {
     prisma.site.create.mockResolvedValue({ id: 'site-1', label: 'HQ' } as any);
     const result = await repo.create(site);
@@ -37,6 +46,15 @@ describe('PrismaSiteRepository', () => {
     const result = await repo.findByLabel('HQ');
     expect(result).toEqual(site);
     expect(prisma.site.findFirst).toHaveBeenCalledWith({ where: { label: 'HQ' } });
+  });
+
+  it('should return null when site not found by label', async () => {
+    prisma.site.findFirst.mockResolvedValue(null);
+
+    const result = await repo.findByLabel('missing');
+
+    expect(result).toBeNull();
+    expect(prisma.site.findFirst).toHaveBeenCalledWith({ where: { label: 'missing' } });
   });
 
   it('should update a site', async () => {

--- a/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
@@ -692,6 +692,41 @@ describe('PrismaUserRepository', () => {
     });
   });
 
+  describe('findByDepartmentId', () => {
+    it('should retrieve users by department', async () => {
+      prismaClient.user.findMany.mockResolvedValue([{
+        id: 'user-123',
+        firstname: 'John',
+        lastname: 'Doe',
+        email: 'john.doe@example.com',
+        password: '',
+        status: 'active',
+        departmentId: 'dept-1',
+        siteId: 'site-1',
+        department: { id: 'dept-1', label: 'IT', parentDepartmentId: null, managerUserId: null, siteId: 'site-1', site: { id: 'site-1', label: 'HQ' } },
+        site: { id: 'site-1', label: 'HQ' },
+        picture: null,
+        permissions: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        roles: []
+      }] as any);
+
+      const result = await repository.findByDepartmentId('dept-1');
+
+      expect(result).toHaveLength(1);
+      expect(prismaClient.user.findMany).toHaveBeenCalledWith({
+        where: { departmentId: 'dept-1' },
+        include: {
+          roles: { include: { role: true } },
+          department: { include: { site: true } },
+          site: true,
+          permissions: { include: { permission: true } },
+        },
+      });
+    });
+  });
+
   describe('delete', () => {
     it('should delete user successfully', async () => {
       prismaClient.user.delete.mockResolvedValue(undefined as any);

--- a/backend/tests/domain/entities/Department.test.ts
+++ b/backend/tests/domain/entities/Department.test.ts
@@ -30,4 +30,14 @@ describe('Department Entity', () => {
     expect(dept.managerUserId).toBe('user-2');
     expect(dept.site).toBe(site);
   });
+
+  it('should use default values when optional parameters are omitted', () => {
+    const site = new Site('site-2', 'Branch');
+    const dept = new Department('dept-3', 'Support', undefined as any, undefined as any, site);
+
+    expect(dept.parentDepartmentId).toBeNull();
+    expect(dept.managerUserId).toBeNull();
+    expect(dept.permissions).toEqual([]);
+    expect(dept.site).toBe(site);
+  });
 });

--- a/backend/tests/domain/ports/UserRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/UserRepositoryPort.test.ts
@@ -25,6 +25,16 @@ class MockUserRepository implements UserRepositoryPort {
     return userId ? this.users.get(userId) || null : null;
   }
 
+  async findByDepartmentId(departmentId: string): Promise<User[]> {
+    const result: User[] = [];
+    for (const user of this.users.values()) {
+      if (user.department.id === departmentId) {
+        result.push(user);
+      }
+    }
+    return result;
+  }
+
   async create(user: User): Promise<User> {
     this.users.set(user.id, user);
     this.emailIndex.set(user.email, user.id);
@@ -189,6 +199,22 @@ describe('UserRepositoryPort Interface', () => {
       const result = await repository.findByExternalAuth('github', 'x999');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('findByDepartmentId', () => {
+    it('should return users belonging to department', async () => {
+      await repository.create(testUser);
+
+      const result = await repository.findByDepartmentId('dept-1');
+
+      expect(result).toEqual([testUser]);
+    });
+
+    it('should return empty array when no users match', async () => {
+      const result = await repository.findByDepartmentId('missing');
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/backend/tests/usecases/CreateDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/CreateDepartmentUseCase.test.ts
@@ -1,5 +1,5 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { CreateDepartmentUseCase } from '../../usecases/CreateDepartmentUseCase';
+import { CreateDepartmentUseCase } from '../../usecases/department/CreateDepartmentUseCase';
 import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../domain/entities/Department';
 import { Site } from '../../domain/entities/Site';

--- a/backend/tests/usecases/department/AddChildDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/AddChildDepartmentUseCase.test.ts
@@ -1,0 +1,39 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AddChildDepartmentUseCase } from '../../../usecases/department/AddChildDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('AddChildDepartmentUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: AddChildDepartmentUseCase;
+  let child: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new AddChildDepartmentUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    child = new Department('child', 'IT', null, null, site);
+  });
+
+  it('should set parent on child department', async () => {
+    repository.findById.mockResolvedValue(child);
+    repository.update.mockResolvedValue(child);
+
+    const result = await useCase.execute('parent', 'child');
+
+    expect(result).toBe(child);
+    expect(child.parentDepartmentId).toBe('parent');
+    expect(repository.update).toHaveBeenCalledWith(child);
+  });
+
+  it('should return null when child not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('parent', 'missing');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/AddDepartmentUserUseCase.test.ts
+++ b/backend/tests/usecases/department/AddDepartmentUserUseCase.test.ts
@@ -1,0 +1,51 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AddDepartmentUserUseCase } from '../../../usecases/department/AddDepartmentUserUseCase';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('AddDepartmentUserUseCase', () => {
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let deptRepo: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: AddDepartmentUserUseCase;
+  let user: User;
+  let department: Department;
+  let newDepartment: Department;
+  let role: Role;
+  let site: Site;
+
+  beforeEach(() => {
+    userRepo = mockDeep<UserRepositoryPort>();
+    deptRepo = mockDeep<DepartmentRepositoryPort>();
+    useCase = new AddDepartmentUserUseCase(userRepo, deptRepo);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+    newDepartment = new Department('dept-2', 'HR', null, null, site);
+    role = new Role('role-1', 'Admin');
+    user = new User('user-1', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+  });
+
+  it('should move user to new department', async () => {
+    userRepo.findById.mockResolvedValue(user);
+    deptRepo.findById.mockResolvedValue(newDepartment);
+    userRepo.update.mockResolvedValue(user);
+
+    const result = await useCase.execute('user-1', 'dept-2');
+
+    expect(result).toBe(user);
+    expect(user.department).toBe(newDepartment);
+    expect(userRepo.update).toHaveBeenCalledWith(user);
+  });
+
+  it('should return null when user or department is missing', async () => {
+    userRepo.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing', 'dept-2');
+
+    expect(result).toBeNull();
+    expect(userRepo.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/DeleteDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/DeleteDepartmentUseCase.test.ts
@@ -1,0 +1,43 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { DeleteDepartmentUseCase } from '../../../usecases/department/DeleteDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('DeleteDepartmentUseCase', () => {
+  let deptRepo: DeepMockProxy<DepartmentRepositoryPort>;
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let useCase: DeleteDepartmentUseCase;
+  let department: Department;
+  let site: Site;
+  let user: User;
+  let role: Role;
+
+  beforeEach(() => {
+    deptRepo = mockDeep<DepartmentRepositoryPort>();
+    userRepo = mockDeep<UserRepositoryPort>();
+    useCase = new DeleteDepartmentUseCase(deptRepo, userRepo);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+    role = new Role('role-1', 'Admin');
+    user = new User('user-1', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+  });
+
+  it('should delete a department when no users are attached', async () => {
+    userRepo.findByDepartmentId.mockResolvedValue([]);
+
+    await useCase.execute('dept-1');
+
+    expect(deptRepo.delete).toHaveBeenCalledWith('dept-1');
+  });
+
+  it('should throw when users are attached to the department', async () => {
+    userRepo.findByDepartmentId.mockResolvedValue([user]);
+
+    await expect(useCase.execute('dept-1')).rejects.toThrow('Department has attached users');
+    expect(deptRepo.delete).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/RemoveChildDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveChildDepartmentUseCase.test.ts
@@ -1,0 +1,39 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemoveChildDepartmentUseCase } from '../../../usecases/department/RemoveChildDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('RemoveChildDepartmentUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: RemoveChildDepartmentUseCase;
+  let child: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new RemoveChildDepartmentUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    child = new Department('child', 'IT', 'parent', null, site);
+  });
+
+  it('should remove parent from child department', async () => {
+    repository.findById.mockResolvedValue(child);
+    repository.update.mockResolvedValue(child);
+
+    const result = await useCase.execute('child');
+
+    expect(result).toBe(child);
+    expect(child.parentDepartmentId).toBeNull();
+    expect(repository.update).toHaveBeenCalledWith(child);
+  });
+
+  it('should return null when child not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/RemoveDepartmentManagerUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentManagerUseCase.test.ts
@@ -1,0 +1,39 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemoveDepartmentManagerUseCase } from '../../../usecases/department/RemoveDepartmentManagerUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('RemoveDepartmentManagerUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: RemoveDepartmentManagerUseCase;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new RemoveDepartmentManagerUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, 'manager', site);
+  });
+
+  it('should remove manager from department', async () => {
+    repository.findById.mockResolvedValue(department);
+    repository.update.mockResolvedValue(department);
+
+    const result = await useCase.execute('dept-1');
+
+    expect(result).toBe(department);
+    expect(department.managerUserId).toBeNull();
+    expect(repository.update).toHaveBeenCalledWith(department);
+  });
+
+  it('should return null when department not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/RemoveDepartmentParentDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentParentDepartmentUseCase.test.ts
@@ -1,0 +1,39 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemoveDepartmentParentDepartmentUseCase } from '../../../usecases/department/RemoveDepartmentParentDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('RemoveDepartmentParentDepartmentUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: RemoveDepartmentParentDepartmentUseCase;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new RemoveDepartmentParentDepartmentUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', 'parent', null, site);
+  });
+
+  it('should remove parent department', async () => {
+    repository.findById.mockResolvedValue(department);
+    repository.update.mockResolvedValue(department);
+
+    const result = await useCase.execute('dept-1');
+
+    expect(result).toBe(department);
+    expect(department.parentDepartmentId).toBeNull();
+    expect(repository.update).toHaveBeenCalledWith(department);
+  });
+
+  it('should return null when department not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/RemoveDepartmentPermissionUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentPermissionUseCase.test.ts
@@ -1,0 +1,42 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemoveDepartmentPermissionUseCase } from '../../../usecases/department/RemoveDepartmentPermissionUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Permission } from '../../../domain/entities/Permission';
+import { Site } from '../../../domain/entities/Site';
+
+describe('RemoveDepartmentPermissionUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: RemoveDepartmentPermissionUseCase;
+  let department: Department;
+  let permission: Permission;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new RemoveDepartmentPermissionUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    permission = new Permission('perm-1', 'READ', 'read');
+    department = new Department('dept-1', 'IT', null, null, site, [permission]);
+  });
+
+  it('should remove permission from department', async () => {
+    repository.findById.mockResolvedValue(department);
+    repository.update.mockResolvedValue(department);
+
+    const result = await useCase.execute('dept-1', 'perm-1');
+
+    expect(result).toBe(department);
+    expect(department.permissions).toHaveLength(0);
+    expect(repository.update).toHaveBeenCalledWith(department);
+  });
+
+  it('should return null when department not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing', 'perm-1');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/RemoveDepartmentUserUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentUserUseCase.test.ts
@@ -1,0 +1,45 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemoveDepartmentUserUseCase } from '../../../usecases/department/RemoveDepartmentUserUseCase';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('RemoveDepartmentUserUseCase', () => {
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let useCase: RemoveDepartmentUserUseCase;
+  let user: User;
+  let role: Role;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    userRepo = mockDeep<UserRepositoryPort>();
+    useCase = new RemoveDepartmentUserUseCase(userRepo);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+    role = new Role('role-1', 'Admin');
+    user = new User('user-1', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+  });
+
+  it('should remove user from department', async () => {
+    userRepo.findById.mockResolvedValue(user);
+    userRepo.update.mockResolvedValue(user);
+
+    const result = await useCase.execute('user-1');
+
+    expect(result).toBe(user);
+    expect(user.department).toBeNull();
+    expect(userRepo.update).toHaveBeenCalledWith(user);
+  });
+
+  it('should return null when user not found', async () => {
+    userRepo.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing');
+
+    expect(result).toBeNull();
+    expect(userRepo.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/SetDepartmentManagerUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentManagerUseCase.test.ts
@@ -1,0 +1,39 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { SetDepartmentManagerUseCase } from '../../../usecases/department/SetDepartmentManagerUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('SetDepartmentManagerUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: SetDepartmentManagerUseCase;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new SetDepartmentManagerUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+  });
+
+  it('should set manager on department', async () => {
+    repository.findById.mockResolvedValue(department);
+    repository.update.mockResolvedValue(department);
+
+    const result = await useCase.execute('dept-1', 'user-1');
+
+    expect(result).toBe(department);
+    expect(department.managerUserId).toBe('user-1');
+    expect(repository.update).toHaveBeenCalledWith(department);
+  });
+
+  it('should return null when department not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing', 'user-1');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/SetDepartmentParentDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentParentDepartmentUseCase.test.ts
@@ -1,0 +1,39 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { SetDepartmentParentDepartmentUseCase } from '../../../usecases/department/SetDepartmentParentDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('SetDepartmentParentDepartmentUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: SetDepartmentParentDepartmentUseCase;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new SetDepartmentParentDepartmentUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+  });
+
+  it('should set parent department', async () => {
+    repository.findById.mockResolvedValue(department);
+    repository.update.mockResolvedValue(department);
+
+    const result = await useCase.execute('dept-1', 'parent-1');
+
+    expect(result).toBe(department);
+    expect(department.parentDepartmentId).toBe('parent-1');
+    expect(repository.update).toHaveBeenCalledWith(department);
+  });
+
+  it('should return null when department not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing', 'parent');
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/SetDepartmentPermissionUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentPermissionUseCase.test.ts
@@ -1,0 +1,42 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { SetDepartmentPermissionUseCase } from '../../../usecases/department/SetDepartmentPermissionUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Permission } from '../../../domain/entities/Permission';
+import { Site } from '../../../domain/entities/Site';
+
+describe('SetDepartmentPermissionUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: SetDepartmentPermissionUseCase;
+  let department: Department;
+  let permission: Permission;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new SetDepartmentPermissionUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+    permission = new Permission('perm-1', 'READ', 'read');
+  });
+
+  it('should add permission to department', async () => {
+    repository.findById.mockResolvedValue(department);
+    repository.update.mockResolvedValue(department);
+
+    const result = await useCase.execute('dept-1', permission);
+
+    expect(result).toBe(department);
+    expect(department.permissions).toContain(permission);
+    expect(repository.update).toHaveBeenCalledWith(department);
+  });
+
+  it('should return null when department not found', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    const result = await useCase.execute('missing', permission);
+
+    expect(result).toBeNull();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/UpdateDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/UpdateDepartmentUseCase.test.ts
@@ -1,0 +1,28 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { UpdateDepartmentUseCase } from '../../../usecases/department/UpdateDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('UpdateDepartmentUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: UpdateDepartmentUseCase;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new UpdateDepartmentUseCase(repository);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+  });
+
+  it('should update a department via repository', async () => {
+    repository.update.mockResolvedValue(department);
+
+    const result = await useCase.execute(department);
+
+    expect(result).toBe(department);
+    expect(repository.update).toHaveBeenCalledWith(department);
+  });
+});

--- a/backend/usecases/department/AddChildDepartmentUseCase.ts
+++ b/backend/usecases/department/AddChildDepartmentUseCase.ts
@@ -1,0 +1,25 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for adding a department as a child of another department.
+ */
+export class AddChildDepartmentUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the child department addition.
+   *
+   * @param parentId - Identifier of the parent department.
+   * @param childId - Identifier of the department to become a child.
+   * @returns The updated child {@link Department} or `null` if not found.
+   */
+  async execute(parentId: string, childId: string): Promise<Department | null> {
+    const child = await this.departmentRepository.findById(childId);
+    if (!child) {
+      return null;
+    }
+    child.parentDepartmentId = parentId;
+    return this.departmentRepository.update(child);
+  }
+}

--- a/backend/usecases/department/AddDepartmentUserUseCase.ts
+++ b/backend/usecases/department/AddDepartmentUserUseCase.ts
@@ -1,0 +1,30 @@
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { User } from '../../domain/entities/User';
+
+/**
+ * Use case for adding a user to a department.
+ */
+export class AddDepartmentUserUseCase {
+  constructor(
+    private readonly userRepository: UserRepositoryPort,
+    private readonly departmentRepository: DepartmentRepositoryPort,
+  ) {}
+
+  /**
+   * Execute the association.
+   *
+   * @param userId - Identifier of the user to update.
+   * @param departmentId - Identifier of the department to assign.
+   * @returns The updated {@link User} or `null` if the user or department is missing.
+   */
+  async execute(userId: string, departmentId: string): Promise<User | null> {
+    const user = await this.userRepository.findById(userId);
+    const department = await this.departmentRepository.findById(departmentId);
+    if (!user || !department) {
+      return null;
+    }
+    user.department = department;
+    return this.userRepository.update(user);
+  }
+}

--- a/backend/usecases/department/CreateDepartmentUseCase.ts
+++ b/backend/usecases/department/CreateDepartmentUseCase.ts
@@ -1,5 +1,5 @@
-import { DepartmentRepositoryPort } from '../domain/ports/DepartmentRepositoryPort';
-import { Department } from '../domain/entities/Department';
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../domain/entities/Department';
 
 /**
  * Use case responsible for creating a {@link Department}.

--- a/backend/usecases/department/DeleteDepartmentUseCase.ts
+++ b/backend/usecases/department/DeleteDepartmentUseCase.ts
@@ -1,0 +1,25 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+
+/**
+ * Use case for deleting a department only when no user is attached to it.
+ */
+export class DeleteDepartmentUseCase {
+  constructor(
+    private readonly departmentRepository: DepartmentRepositoryPort,
+    private readonly userRepository: UserRepositoryPort,
+  ) {}
+
+  /**
+   * Execute the deletion.
+   *
+   * @param departmentId - Identifier of the department to delete.
+   */
+  async execute(departmentId: string): Promise<void> {
+    const users = await this.userRepository.findByDepartmentId(departmentId);
+    if (users.length > 0) {
+      throw new Error('Department has attached users');
+    }
+    await this.departmentRepository.delete(departmentId);
+  }
+}

--- a/backend/usecases/department/RemoveChildDepartmentUseCase.ts
+++ b/backend/usecases/department/RemoveChildDepartmentUseCase.ts
@@ -1,0 +1,24 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for removing a child department from its parent.
+ */
+export class RemoveChildDepartmentUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the removal.
+   *
+   * @param childId - Identifier of the child department.
+   * @returns The updated child {@link Department} or `null` if not found.
+   */
+  async execute(childId: string): Promise<Department | null> {
+    const child = await this.departmentRepository.findById(childId);
+    if (!child) {
+      return null;
+    }
+    child.parentDepartmentId = null;
+    return this.departmentRepository.update(child);
+  }
+}

--- a/backend/usecases/department/RemoveDepartmentManagerUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentManagerUseCase.ts
@@ -1,0 +1,24 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for removing the manager from a department.
+ */
+export class RemoveDepartmentManagerUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the removal.
+   *
+   * @param departmentId - Identifier of the department to update.
+   * @returns The updated {@link Department} or `null` if not found.
+   */
+  async execute(departmentId: string): Promise<Department | null> {
+    const department = await this.departmentRepository.findById(departmentId);
+    if (!department) {
+      return null;
+    }
+    department.managerUserId = null;
+    return this.departmentRepository.update(department);
+  }
+}

--- a/backend/usecases/department/RemoveDepartmentParentDepartmentUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentParentDepartmentUseCase.ts
@@ -1,0 +1,24 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for removing the parent department of a department.
+ */
+export class RemoveDepartmentParentDepartmentUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the removal of the parent department.
+   *
+   * @param departmentId - Identifier of the department to update.
+   * @returns The updated {@link Department} or `null` if not found.
+   */
+  async execute(departmentId: string): Promise<Department | null> {
+    const department = await this.departmentRepository.findById(departmentId);
+    if (!department) {
+      return null;
+    }
+    department.parentDepartmentId = null;
+    return this.departmentRepository.update(department);
+  }
+}

--- a/backend/usecases/department/RemoveDepartmentPermissionUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentPermissionUseCase.ts
@@ -1,0 +1,25 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for removing a permission from a department.
+ */
+export class RemoveDepartmentPermissionUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the permission removal.
+   *
+   * @param departmentId - Identifier of the department to update.
+   * @param permissionId - Identifier of the permission to remove.
+   * @returns The updated {@link Department} or `null` if not found.
+   */
+  async execute(departmentId: string, permissionId: string): Promise<Department | null> {
+    const department = await this.departmentRepository.findById(departmentId);
+    if (!department) {
+      return null;
+    }
+    department.permissions = department.permissions.filter(p => p.id !== permissionId);
+    return this.departmentRepository.update(department);
+  }
+}

--- a/backend/usecases/department/RemoveDepartmentUserUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentUserUseCase.ts
@@ -1,0 +1,29 @@
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+import type { User } from '../../domain/entities/User';
+
+/**
+ * Use case for removing a user from a department.
+ *
+ * Note: the current domain model requires a user to always reference a
+ * {@link Department}. The implementation therefore sets the department
+ * reference to `null` through a cast.
+ */
+export class RemoveDepartmentUserUseCase {
+  constructor(private readonly userRepository: UserRepositoryPort) {}
+
+  /**
+   * Execute the removal.
+   *
+   * @param userId - Identifier of the user to update.
+   * @returns The updated {@link User} or `null` if not found.
+   */
+  async execute(userId: string): Promise<User | null> {
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      return null;
+    }
+    user.department = null as unknown as Department;
+    return this.userRepository.update(user);
+  }
+}

--- a/backend/usecases/department/SetDepartmentManagerUseCase.ts
+++ b/backend/usecases/department/SetDepartmentManagerUseCase.ts
@@ -1,0 +1,25 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for assigning a manager to a department.
+ */
+export class SetDepartmentManagerUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the manager assignment.
+   *
+   * @param departmentId - Identifier of the department to update.
+   * @param userId - Identifier of the manager user.
+   * @returns The updated {@link Department} or `null` if not found.
+   */
+  async execute(departmentId: string, userId: string): Promise<Department | null> {
+    const department = await this.departmentRepository.findById(departmentId);
+    if (!department) {
+      return null;
+    }
+    department.managerUserId = userId;
+    return this.departmentRepository.update(department);
+  }
+}

--- a/backend/usecases/department/SetDepartmentParentDepartmentUseCase.ts
+++ b/backend/usecases/department/SetDepartmentParentDepartmentUseCase.ts
@@ -1,0 +1,25 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for defining the parent department of a department.
+ */
+export class SetDepartmentParentDepartmentUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the parent department assignment.
+   *
+   * @param departmentId - Identifier of the department to update.
+   * @param parentDepartmentId - Identifier of the parent department.
+   * @returns The updated {@link Department} or `null` if not found.
+   */
+  async execute(departmentId: string, parentDepartmentId: string): Promise<Department | null> {
+    const department = await this.departmentRepository.findById(departmentId);
+    if (!department) {
+      return null;
+    }
+    department.parentDepartmentId = parentDepartmentId;
+    return this.departmentRepository.update(department);
+  }
+}

--- a/backend/usecases/department/SetDepartmentPermissionUseCase.ts
+++ b/backend/usecases/department/SetDepartmentPermissionUseCase.ts
@@ -1,0 +1,26 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+import type { Permission } from '../../domain/entities/Permission';
+
+/**
+ * Use case for adding a permission to a department.
+ */
+export class SetDepartmentPermissionUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the permission addition.
+   *
+   * @param departmentId - Identifier of the department to update.
+   * @param permission - Permission to add.
+   * @returns The updated {@link Department} or `null` if not found.
+   */
+  async execute(departmentId: string, permission: Permission): Promise<Department | null> {
+    const department = await this.departmentRepository.findById(departmentId);
+    if (!department) {
+      return null;
+    }
+    department.permissions.push(permission);
+    return this.departmentRepository.update(department);
+  }
+}

--- a/backend/usecases/department/UpdateDepartmentUseCase.ts
+++ b/backend/usecases/department/UpdateDepartmentUseCase.ts
@@ -1,0 +1,19 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import type { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for updating an existing {@link Department}.
+ */
+export class UpdateDepartmentUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the update.
+   *
+   * @param department - Updated department entity.
+   * @returns The persisted {@link Department} after update.
+   */
+  async execute(department: Department): Promise<Department> {
+    return this.departmentRepository.update(department);
+  }
+}


### PR DESCRIPTION
## Summary
- move `CreateDepartmentUseCase` to `usecases/department`
- add many department management use cases (update, delete, etc.)
- extend `UserRepositoryPort` with `findByDepartmentId`
- implement new method in `PrismaUserRepository`
- add comprehensive unit tests for new use cases and repository changes
- update existing tests for new paths and add coverage for repository and entity defaults

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6880fdb6c3c4832381925045fde93afe