### PR TITLE
Refactor permission use cases

### DIFF
--- a/backend/tests/usecases/department/RemoveDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentUseCase.test.ts
@@ -1,5 +1,5 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { DeleteDepartmentUseCase } from '../../../usecases/department/DeleteDepartmentUseCase';
+import { RemoveDepartmentUseCase } from '../../../usecases/department/RemoveDepartmentUseCase';
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { User } from '../../../domain/entities/User';
@@ -7,10 +7,10 @@ import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
 
-describe('DeleteDepartmentUseCase', () => {
+describe('RemoveDepartmentUseCase', () => {
   let deptRepo: DeepMockProxy<DepartmentRepositoryPort>;
   let userRepo: DeepMockProxy<UserRepositoryPort>;
-  let useCase: DeleteDepartmentUseCase;
+  let useCase: RemoveDepartmentUseCase;
   let department: Department;
   let site: Site;
   let user: User;
@@ -19,7 +19,7 @@ describe('DeleteDepartmentUseCase', () => {
   beforeEach(() => {
     deptRepo = mockDeep<DepartmentRepositoryPort>();
     userRepo = mockDeep<UserRepositoryPort>();
-    useCase = new DeleteDepartmentUseCase(deptRepo, userRepo);
+    useCase = new RemoveDepartmentUseCase(deptRepo, userRepo);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
     role = new Role('role-1', 'Admin');

--- a/backend/tests/usecases/permission/CreatePermissionUseCase.test.ts
+++ b/backend/tests/usecases/permission/CreatePermissionUseCase.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { CreatePermissionUseCase } from '../../usecases/CreatePermissionUseCase';
-import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
-import { Permission } from '../../domain/entities/Permission';
+import { CreatePermissionUseCase } from '../../../usecases/permission/CreatePermissionUseCase';
+import { PermissionRepositoryPort } from '../../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../../domain/entities/Permission';
 
 describe('CreatePermissionUseCase', () => {
   let repository: DeepMockProxy<PermissionRepositoryPort>;

--- a/backend/tests/usecases/permission/RemovePermissionUseCase.test.ts
+++ b/backend/tests/usecases/permission/RemovePermissionUseCase.test.ts
@@ -1,0 +1,19 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemovePermissionUseCase } from '../../../usecases/permission/RemovePermissionUseCase';
+import { PermissionRepositoryPort } from '../../../domain/ports/PermissionRepositoryPort';
+
+describe('RemovePermissionUseCase', () => {
+  let repository: DeepMockProxy<PermissionRepositoryPort>;
+  let useCase: RemovePermissionUseCase;
+
+  beforeEach(() => {
+    repository = mockDeep<PermissionRepositoryPort>();
+    useCase = new RemovePermissionUseCase(repository);
+  });
+
+  it('should remove permission via repository', async () => {
+    await useCase.execute('perm-1');
+
+    expect(repository.delete).toHaveBeenCalledWith('perm-1');
+  });
+});

--- a/backend/tests/usecases/permission/UpdatePermissionUseCase.test.ts
+++ b/backend/tests/usecases/permission/UpdatePermissionUseCase.test.ts
@@ -1,0 +1,25 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { UpdatePermissionUseCase } from '../../../usecases/permission/UpdatePermissionUseCase';
+import { PermissionRepositoryPort } from '../../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../../domain/entities/Permission';
+
+describe('UpdatePermissionUseCase', () => {
+  let repository: DeepMockProxy<PermissionRepositoryPort>;
+  let useCase: UpdatePermissionUseCase;
+  let permission: Permission;
+
+  beforeEach(() => {
+    repository = mockDeep<PermissionRepositoryPort>();
+    useCase = new UpdatePermissionUseCase(repository);
+    permission = new Permission('perm-1', 'READ', 'read');
+  });
+
+  it('should update a permission via repository', async () => {
+    repository.update.mockResolvedValue(permission);
+
+    const result = await useCase.execute(permission);
+
+    expect(result).toBe(permission);
+    expect(repository.update).toHaveBeenCalledWith(permission);
+  });
+});

--- a/backend/usecases/department/RemoveDepartmentUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentUseCase.ts
@@ -2,9 +2,9 @@ import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositor
 import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
 
 /**
- * Use case for deleting a department only when no user is attached to it.
+ * Use case for removing a department only when no user is attached to it.
  */
-export class DeleteDepartmentUseCase {
+export class RemoveDepartmentUseCase {
   constructor(
     private readonly departmentRepository: DepartmentRepositoryPort,
     private readonly userRepository: UserRepositoryPort,

--- a/backend/usecases/permission/CreatePermissionUseCase.ts
+++ b/backend/usecases/permission/CreatePermissionUseCase.ts
@@ -1,5 +1,5 @@
-import { PermissionRepositoryPort } from '../domain/ports/PermissionRepositoryPort';
-import { Permission } from '../domain/entities/Permission';
+import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../domain/entities/Permission';
 
 /**
  * Use case responsible for creating a {@link Permission}.

--- a/backend/usecases/permission/RemovePermissionUseCase.ts
+++ b/backend/usecases/permission/RemovePermissionUseCase.ts
@@ -1,0 +1,17 @@
+import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
+
+/**
+ * Use case for removing a permission and all related records.
+ */
+export class RemovePermissionUseCase {
+  constructor(private readonly permissionRepository: PermissionRepositoryPort) {}
+
+  /**
+   * Execute the removal.
+   *
+   * @param permissionId - Identifier of the permission to delete.
+   */
+  async execute(permissionId: string): Promise<void> {
+    await this.permissionRepository.delete(permissionId);
+  }
+}

--- a/backend/usecases/permission/UpdatePermissionUseCase.ts
+++ b/backend/usecases/permission/UpdatePermissionUseCase.ts
@@ -1,0 +1,19 @@
+import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../domain/entities/Permission';
+
+/**
+ * Use case responsible for updating an existing {@link Permission}.
+ */
+export class UpdatePermissionUseCase {
+  constructor(private readonly permissionRepository: PermissionRepositoryPort) {}
+
+  /**
+   * Execute the update.
+   *
+   * @param permission - Updated permission entity.
+   * @returns The persisted {@link Permission} after update.
+   */
+  async execute(permission: Permission): Promise<Permission> {
+    return this.permissionRepository.update(permission);
+  }
+}


### PR DESCRIPTION
## Summary
- organize permission use cases in dedicated folder
- add update and remove permission use cases
- rename DeleteDepartmentUseCase to RemoveDepartmentUseCase
- update and extend unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688113b3496c8323a0c7b2ca00b7126c