### PR TITLE
Add site update and remove usecases

### DIFF
--- a/backend/adapters/repositories/PrismaDepartmentRepository.ts
+++ b/backend/adapters/repositories/PrismaDepartmentRepository.ts
@@ -60,4 +60,12 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
   async delete(id: string): Promise<void> {
     await this.prisma.department.delete({ where: { id } });
   }
+
+  async findBySiteId(siteId: string): Promise<Department[]> {
+    const records = await this.prisma.department.findMany({
+      where: { siteId },
+      include: { site: true },
+    });
+    return records.map(r => this.mapRecord(r));
+  }
 }

--- a/backend/adapters/repositories/PrismaUserRepository.ts
+++ b/backend/adapters/repositories/PrismaUserRepository.ts
@@ -107,6 +107,19 @@ export class PrismaUserRepository implements UserRepositoryPort {
     return records.map(r => this.mapRecord(r));
   }
 
+  async findBySiteId(siteId: string): Promise<User[]> {
+    const records = await this.prisma.user.findMany({
+      where: { siteId },
+      include: {
+        roles: { include: { role: true } },
+        department: { include: { site: true } },
+        site: true,
+        permissions: { include: { permission: true } },
+      },
+    });
+    return records.map(r => this.mapRecord(r));
+  }
+
   async create(user: User): Promise<User> {
     const record = await this.prisma.user.create({
       data: {

--- a/backend/domain/ports/DepartmentRepositoryPort.ts
+++ b/backend/domain/ports/DepartmentRepositoryPort.ts
@@ -42,4 +42,12 @@ export interface DepartmentRepositoryPort {
    * @param id - Identifier of the department to delete.
    */
   delete(id: string): Promise<void>;
+
+  /**
+   * Retrieve all departments located at the specified site.
+   *
+   * @param siteId - Identifier of the site.
+   * @returns Array of matching {@link Department} instances.
+   */
+  findBySiteId(siteId: string): Promise<Department[]>;
 }

--- a/backend/domain/ports/UserRepositoryPort.ts
+++ b/backend/domain/ports/UserRepositoryPort.ts
@@ -46,6 +46,14 @@ export interface UserRepositoryPort {
   findByRoleId(roleId: string): Promise<User[]>;
 
   /**
+   * Retrieve all users located at the specified site.
+   *
+   * @param siteId - Identifier of the site.
+   * @returns Array of matching {@link User} instances.
+   */
+  findBySiteId(siteId: string): Promise<User[]>;
+
+  /**
    * Persist a new user.
    *
    * @param user - User entity to create.

--- a/backend/tests/adapters/repositories/PrismaDepartmentRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaDepartmentRepository.test.ts
@@ -117,6 +117,23 @@ describe('PrismaDepartmentRepository', () => {
     });
   });
 
+  it('should find departments by site id', async () => {
+    prisma.department.findMany.mockResolvedValue([
+      {
+        id: 'dept-1',
+        label: 'IT',
+        parentDepartmentId: null,
+        managerUserId: 'user-1',
+        siteId: 'site-1',
+        site: { id: 'site-1', label: 'HQ' }
+      }
+    ] as any);
+
+    const result = await repo.findBySiteId('site-1');
+    expect(result).toEqual([dept]);
+    expect(prisma.department.findMany).toHaveBeenCalledWith({ where: { siteId: 'site-1' }, include: { site: true } });
+  });
+
   it('should delete a department', async () => {
     prisma.department.delete.mockResolvedValue(undefined as any);
 

--- a/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
@@ -729,7 +729,7 @@ describe('PrismaUserRepository', () => {
 
   describe('findByRoleId', () => {
     it('should retrieve users by role', async () => {
-      prismaClient.user.findMany.mockResolvedValue([{
+      prismaClient.user.findMany.mockResolvedValue([{ 
         id: 'user-123',
         firstname: 'John',
         lastname: 'Doe',
@@ -752,6 +752,41 @@ describe('PrismaUserRepository', () => {
       expect(result).toHaveLength(1);
       expect(prismaClient.user.findMany).toHaveBeenCalledWith({
         where: { roles: { some: { roleId: 'role-1' } } },
+        include: {
+          roles: { include: { role: true } },
+          department: { include: { site: true } },
+          site: true,
+          permissions: { include: { permission: true } },
+        },
+      });
+    });
+  });
+
+  describe('findBySiteId', () => {
+    it('should retrieve users by site', async () => {
+      prismaClient.user.findMany.mockResolvedValue([{ 
+        id: 'user-123',
+        firstname: 'John',
+        lastname: 'Doe',
+        email: 'john.doe@example.com',
+        password: '',
+        status: 'active',
+        departmentId: 'dept-1',
+        siteId: 'site-1',
+        department: { id: 'dept-1', label: 'IT', parentDepartmentId: null, managerUserId: null, siteId: 'site-1', site: { id: 'site-1', label: 'HQ' } },
+        site: { id: 'site-1', label: 'HQ' },
+        picture: null,
+        permissions: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        roles: []
+      }] as any);
+
+      const result = await repository.findBySiteId('site-1');
+
+      expect(result).toHaveLength(1);
+      expect(prismaClient.user.findMany).toHaveBeenCalledWith({
+        where: { siteId: 'site-1' },
         include: {
           roles: { include: { role: true } },
           department: { include: { site: true } },

--- a/backend/tests/domain/ports/DepartmentRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/DepartmentRepositoryPort.test.ts
@@ -40,6 +40,16 @@ class MockDepartmentRepository implements DepartmentRepositoryPort {
     }
   }
 
+  async findBySiteId(siteId: string): Promise<Department[]> {
+    const result: Department[] = [];
+    for (const dept of this.depts.values()) {
+      if (dept.site.id === siteId) {
+        result.push(dept);
+      }
+    }
+    return result;
+  }
+
   clear(): void {
     this.depts.clear();
     this.labelIndex.clear();
@@ -75,6 +85,16 @@ describe('DepartmentRepositoryPort Interface', () => {
     expect(updated.label).toBe('Tech');
     expect(await repo.findByLabel('Tech')).toEqual(dept);
     expect(updated.site).toBe(site);
+  });
+
+  it('should return departments by site id', async () => {
+    await repo.create(dept);
+    const otherSite = new Site('site-2', 'Branch');
+    const dept2 = new Department('dept-2', 'HR', null, null, otherSite);
+    await repo.create(dept2);
+
+    const result = await repo.findBySiteId('site-1');
+    expect(result).toEqual([dept]);
   });
 
   it('should delete a department', async () => {

--- a/backend/tests/domain/ports/UserRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/UserRepositoryPort.test.ts
@@ -45,6 +45,16 @@ class MockUserRepository implements UserRepositoryPort {
     return result;
   }
 
+  async findBySiteId(siteId: string): Promise<User[]> {
+    const result: User[] = [];
+    for (const user of this.users.values()) {
+      if (user.site.id === siteId) {
+        result.push(user);
+      }
+    }
+    return result;
+  }
+
   async create(user: User): Promise<User> {
     this.users.set(user.id, user);
     this.emailIndex.set(user.email, user.id);
@@ -239,6 +249,22 @@ describe('UserRepositoryPort Interface', () => {
 
     it('should return empty array when no users have role', async () => {
       const result = await repository.findByRoleId('missing');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findBySiteId', () => {
+    it('should return users belonging to a site', async () => {
+      await repository.create(testUser);
+
+      const result = await repository.findBySiteId('site-1');
+
+      expect(result).toEqual([testUser]);
+    });
+
+    it('should return empty array when no users belong to site', async () => {
+      const result = await repository.findBySiteId('missing');
 
       expect(result).toEqual([]);
     });

--- a/backend/tests/usecases/RemoveSiteUseCase.test.ts
+++ b/backend/tests/usecases/RemoveSiteUseCase.test.ts
@@ -1,0 +1,56 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RemoveSiteUseCase } from '../../usecases/RemoveSiteUseCase';
+import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import { Site } from '../../domain/entities/Site';
+import { User } from '../../domain/entities/User';
+import { Department } from '../../domain/entities/Department';
+import { Role } from '../../domain/entities/Role';
+
+describe('RemoveSiteUseCase', () => {
+  let siteRepo: DeepMockProxy<SiteRepositoryPort>;
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let departmentRepo: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: RemoveSiteUseCase;
+  let site: Site;
+  let department: Department;
+  let user: User;
+  let role: Role;
+
+  beforeEach(() => {
+    siteRepo = mockDeep<SiteRepositoryPort>();
+    userRepo = mockDeep<UserRepositoryPort>();
+    departmentRepo = mockDeep<DepartmentRepositoryPort>();
+    useCase = new RemoveSiteUseCase(siteRepo, userRepo, departmentRepo);
+    site = new Site('site-1', 'HQ');
+    department = new Department('dept-1', 'IT', null, null, site);
+    role = new Role('role-1', 'Admin');
+    user = new User('user-1', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+  });
+
+  it('should delete a site when no dependencies', async () => {
+    userRepo.findBySiteId.mockResolvedValue([]);
+    departmentRepo.findBySiteId.mockResolvedValue([]);
+
+    await useCase.execute('site-1');
+
+    expect(siteRepo.delete).toHaveBeenCalledWith('site-1');
+  });
+
+  it('should throw when users are attached to the site', async () => {
+    userRepo.findBySiteId.mockResolvedValue([user]);
+    departmentRepo.findBySiteId.mockResolvedValue([]);
+
+    await expect(useCase.execute('site-1')).rejects.toThrow('Site has attached users');
+    expect(siteRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('should throw when departments are attached to the site', async () => {
+    userRepo.findBySiteId.mockResolvedValue([]);
+    departmentRepo.findBySiteId.mockResolvedValue([department]);
+
+    await expect(useCase.execute('site-1')).rejects.toThrow('Site has attached departments');
+    expect(siteRepo.delete).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/UpdateSiteUseCase.test.ts
+++ b/backend/tests/usecases/UpdateSiteUseCase.test.ts
@@ -1,25 +1,25 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { CreateSiteUseCase } from '../../usecases/site/CreateSiteUseCase';
+import { UpdateSiteUseCase } from '../../usecases/UpdateSiteUseCase';
 import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
 import { Site } from '../../domain/entities/Site';
 
-describe('CreateSiteUseCase', () => {
+describe('UpdateSiteUseCase', () => {
   let repository: DeepMockProxy<SiteRepositoryPort>;
-  let useCase: CreateSiteUseCase;
+  let useCase: UpdateSiteUseCase;
   let site: Site;
 
   beforeEach(() => {
     repository = mockDeep<SiteRepositoryPort>();
-    useCase = new CreateSiteUseCase(repository);
+    useCase = new UpdateSiteUseCase(repository);
     site = new Site('site-1', 'HQ');
   });
 
-  it('should create a site via repository', async () => {
-    repository.create.mockResolvedValue(site);
+  it('should update a site via repository', async () => {
+    repository.update.mockResolvedValue(site);
 
     const result = await useCase.execute(site);
 
     expect(result).toBe(site);
-    expect(repository.create).toHaveBeenCalledWith(site);
+    expect(repository.update).toHaveBeenCalledWith(site);
   });
 });

--- a/backend/usecases/RemoveSiteUseCase.ts
+++ b/backend/usecases/RemoveSiteUseCase.ts
@@ -1,0 +1,33 @@
+import { SiteRepositoryPort } from '../domain/ports/SiteRepositoryPort';
+import { UserRepositoryPort } from '../domain/ports/UserRepositoryPort';
+import { DepartmentRepositoryPort } from '../domain/ports/DepartmentRepositoryPort';
+
+/**
+ * Use case for removing a site only when no user or department is attached to it.
+ */
+export class RemoveSiteUseCase {
+  constructor(
+    private readonly siteRepository: SiteRepositoryPort,
+    private readonly userRepository: UserRepositoryPort,
+    private readonly departmentRepository: DepartmentRepositoryPort,
+  ) {}
+
+  /**
+   * Execute the deletion.
+   *
+   * @param siteId - Identifier of the site to delete.
+   */
+  async execute(siteId: string): Promise<void> {
+    const users = await this.userRepository.findBySiteId(siteId);
+    if (users.length > 0) {
+      throw new Error('Site has attached users');
+    }
+
+    const departments = await this.departmentRepository.findBySiteId(siteId);
+    if (departments.length > 0) {
+      throw new Error('Site has attached departments');
+    }
+
+    await this.siteRepository.delete(siteId);
+  }
+}

--- a/backend/usecases/UpdateSiteUseCase.ts
+++ b/backend/usecases/UpdateSiteUseCase.ts
@@ -2,18 +2,18 @@ import { SiteRepositoryPort } from '../domain/ports/SiteRepositoryPort';
 import { Site } from '../domain/entities/Site';
 
 /**
- * Use case responsible for creating a {@link Site}.
+ * Use case responsible for updating an existing {@link Site}.
  */
-export class CreateSiteUseCase {
+export class UpdateSiteUseCase {
   constructor(private readonly siteRepository: SiteRepositoryPort) {}
 
   /**
-   * Execute the use case.
+   * Execute the update.
    *
-   * @param site - The site to persist.
-   * @returns The created {@link Site}.
+   * @param site - Updated site entity.
+   * @returns The persisted {@link Site} after update.
    */
   async execute(site: Site): Promise<Site> {
-    return this.siteRepository.create(site);
+    return this.siteRepository.update(site);
   }
 }

--- a/backend/usecases/site/CreateSiteUseCase.ts
+++ b/backend/usecases/site/CreateSiteUseCase.ts
@@ -1,0 +1,19 @@
+import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../domain/entities/Site';
+
+/**
+ * Use case responsible for creating a {@link Site}.
+ */
+export class CreateSiteUseCase {
+  constructor(private readonly siteRepository: SiteRepositoryPort) {}
+
+  /**
+   * Execute the use case.
+   *
+   * @param site - The site to persist.
+   * @returns The created {@link Site}.
+   */
+  async execute(site: Site): Promise<Site> {
+    return this.siteRepository.create(site);
+  }
+}


### PR DESCRIPTION
## Summary
- move `CreateSiteUseCase` into `usecases/site`
- add `UpdateSiteUseCase` and `RemoveSiteUseCase`
- extend repository ports with `findBySiteId`
- implement new repository methods and tests
- test new site usecases

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68812c90aa448323b58e04b98ac99c18