### PR TITLE
Add logging utilities and integrate them

### DIFF
--- a/backend/adapters/auth/CompositeAuthService.ts
+++ b/backend/adapters/auth/CompositeAuthService.ts
@@ -1,5 +1,7 @@
 import { AuthServicePort } from '../../domain/ports/AuthServicePort';
 import { User } from '../../domain/entities/User';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
 
 /**
  * Authentication service that delegates verification to multiple underlying services.
@@ -7,14 +9,20 @@ import { User } from '../../domain/entities/User';
 export class CompositeAuthService implements AuthServicePort {
   /**
    * @param services - Ordered list of authentication services to try.
+   * @param logger - Logger used to record authentication attempts.
    */
-  constructor(private readonly services: AuthServicePort[]) {}
+  constructor(
+    private readonly services: AuthServicePort[],
+    private readonly logger: LoggerPort,
+  ) {}
 
   async authenticate(email: string, password: string): Promise<User> {
+    this.logger.info('Authenticating user', getContext());
     return this.services[0].authenticate(email, password);
   }
 
   async authenticateWithProvider(provider: string, token: string): Promise<User> {
+    this.logger.info(`Authenticating with ${provider}`, getContext());
     for (const service of this.services) {
       try {
         return await service.authenticateWithProvider(provider, token);
@@ -26,14 +34,17 @@ export class CompositeAuthService implements AuthServicePort {
   }
 
   async requestPasswordReset(email: string): Promise<void> {
+    this.logger.info('Requesting password reset', getContext());
     await this.services[0].requestPasswordReset(email);
   }
 
   async resetPassword(token: string, newPassword: string): Promise<void> {
+    this.logger.info('Resetting password', getContext());
     await this.services[0].resetPassword(token, newPassword);
   }
 
   async verifyToken(token: string): Promise<User> {
+    this.logger.debug('Verifying token', getContext());
     for (const service of this.services) {
       try {
         return await service.verifyToken(token);

--- a/backend/adapters/auth/OIDCAuthServiceAdapter.ts
+++ b/backend/adapters/auth/OIDCAuthServiceAdapter.ts
@@ -2,6 +2,8 @@ import jwt from 'jsonwebtoken';
 import { AuthServicePort } from '../../domain/ports/AuthServicePort';
 import { User } from '../../domain/entities/User';
 import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
 
 /**
  * Authentication adapter for verifying tokens issued by an OpenID Connect provider.
@@ -18,30 +20,36 @@ export class OIDCAuthServiceAdapter implements AuthServicePort {
     private readonly secret: string,
     private readonly issuer: string,
     private readonly userRepository: UserRepositoryPort,
+    private readonly logger: LoggerPort,
   ) {}
 
   async authenticate(_email: string, _password: string): Promise<User> {
     void _email;
     void _password;
+    this.logger.debug('authenticate not supported', getContext());
     throw new Error('Not supported');
   }
 
   async authenticateWithProvider(_provider: string, token: string): Promise<User> {
+    this.logger.debug('Authenticating with OIDC token', getContext());
     return this.verifyToken(token);
   }
 
   async requestPasswordReset(_email: string): Promise<void> {
     void _email;
+    this.logger.warn('requestPasswordReset not implemented', getContext());
     throw new Error('Not implemented');
   }
 
   async resetPassword(_token: string, _newPassword: string): Promise<void> {
     void _token;
     void _newPassword;
+    this.logger.warn('resetPassword not implemented', getContext());
     throw new Error('Not implemented');
   }
 
   async verifyToken(token: string): Promise<User> {
+    this.logger.debug('Verifying OIDC token', getContext());
     const payload = jwt.verify(token, this.secret, {
       algorithms: ['HS256'],
       issuer: this.issuer,

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -2,6 +2,8 @@ import express, { Request, Response, Router } from 'express';
 import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { GetCurrentUserProfileUseCase } from '../../../usecases/user/GetCurrentUserProfileUseCase';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { getContext } from '../../../infrastructure/loggerContext';
 import { User } from '../../../domain/entities/User';
 
 /**
@@ -14,10 +16,15 @@ interface AuthedRequest extends Request {
   user: User;
 }
 
-export function createUserRouter(authService: AuthServicePort, userRepository: UserRepositoryPort): Router {
+export function createUserRouter(
+  authService: AuthServicePort,
+  userRepository: UserRepositoryPort,
+  logger: LoggerPort,
+): Router {
   const router = express.Router();
 
   const authMiddleware: express.RequestHandler = async (req, res, next) => {
+    logger.debug('REST auth middleware', getContext());
     const header = req.headers.authorization;
     if (!header?.startsWith('Bearer ')) {
       res.status(401).end();
@@ -27,8 +34,10 @@ export function createUserRouter(authService: AuthServicePort, userRepository: U
     try {
       const user = await authService.verifyToken(token);
       (req as AuthedRequest).user = user;
+      logger.debug('REST auth success', getContext());
       next();
     } catch {
+      logger.warn('REST auth failed', getContext());
       res.status(401).end();
     }
   };
@@ -36,12 +45,15 @@ export function createUserRouter(authService: AuthServicePort, userRepository: U
   router.use(authMiddleware);
 
   router.get('/users/me', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /users/me', getContext());
     const useCase = new GetCurrentUserProfileUseCase(userRepository);
     const user = await useCase.execute((req as AuthedRequest).user.id);
     if (!user) {
+      logger.warn('Current user not found', getContext());
       res.status(404).end();
       return;
     }
+    logger.debug('Current user returned', getContext());
     res.json(user);
   });
 

--- a/backend/adapters/repositories/PrismaDepartmentRepository.ts
+++ b/backend/adapters/repositories/PrismaDepartmentRepository.ts
@@ -2,12 +2,17 @@ import { PrismaClient, Department as PrismaDepartment, Site as PrismaSite } from
 import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../domain/entities/Department';
 import { Site } from '../../domain/entities/Site';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
 
 /**
  * Prisma-based implementation of {@link DepartmentRepositoryPort}.
  */
 export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
-  constructor(private prisma: PrismaClient) {}
+  constructor(
+    private prisma: PrismaClient,
+    private readonly logger: LoggerPort,
+  ) {}
 
   private mapRecord(record: PrismaDepartment & { site: PrismaSite }): Department {
     return new Department(
@@ -20,16 +25,19 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
   }
 
   async findById(id: string): Promise<Department | null> {
+    this.logger.debug('Department findById', getContext());
     const record = await this.prisma.department.findUnique({ where: { id }, include: { site: true } });
     return record ? this.mapRecord(record) : null;
   }
 
   async findByLabel(label: string): Promise<Department | null> {
+    this.logger.debug('Department findByLabel', getContext());
     const record = await this.prisma.department.findFirst({ where: { label }, include: { site: true } });
     return record ? this.mapRecord(record) : null;
   }
 
   async create(department: Department): Promise<Department> {
+    this.logger.info('Creating department', getContext());
     const record = await this.prisma.department.create({
       data: {
         id: department.id,
@@ -44,6 +52,7 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
   }
 
   async update(department: Department): Promise<Department> {
+    this.logger.info('Updating department', getContext());
     const record = await this.prisma.department.update({
       where: { id: department.id },
       data: {
@@ -58,10 +67,12 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
   }
 
   async delete(id: string): Promise<void> {
+    this.logger.info('Deleting department', getContext());
     await this.prisma.department.delete({ where: { id } });
   }
 
   async findBySiteId(siteId: string): Promise<Department[]> {
+    this.logger.debug('Department findBySiteId', getContext());
     const records = await this.prisma.department.findMany({
       where: { siteId },
       include: { site: true },

--- a/backend/adapters/repositories/PrismaPermissionRepository.ts
+++ b/backend/adapters/repositories/PrismaPermissionRepository.ts
@@ -1,28 +1,36 @@
 import { PrismaClient, Permission as PrismaPermission } from '@prisma/client';
 import { Permission } from '../../domain/entities/Permission';
 import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
 
 /**
  * Prisma-based implementation of {@link PermissionRepositoryPort}.
  */
 export class PrismaPermissionRepository implements PermissionRepositoryPort {
-  constructor(private prisma: PrismaClient) {}
+  constructor(
+    private prisma: PrismaClient,
+    private readonly logger: LoggerPort,
+  ) {}
 
   private mapRecord(record: PrismaPermission): Permission {
     return new Permission(record.id, record.permissionKey, record.description);
   }
 
   async findById(id: string): Promise<Permission | null> {
+    this.logger.debug('Permission findById', getContext());
     const record = await this.prisma.permission.findUnique({ where: { id } });
     return record ? this.mapRecord(record) : null;
   }
 
   async findByKey(permissionKey: string): Promise<Permission | null> {
+    this.logger.debug('Permission findByKey', getContext());
     const record = await this.prisma.permission.findFirst({ where: { permissionKey } });
     return record ? this.mapRecord(record) : null;
   }
 
   async create(permission: Permission): Promise<Permission> {
+    this.logger.info('Creating permission', getContext());
     const record = await this.prisma.permission.create({
       data: { id: permission.id, permissionKey: permission.permissionKey, description: permission.description },
     });
@@ -30,6 +38,7 @@ export class PrismaPermissionRepository implements PermissionRepositoryPort {
   }
 
   async update(permission: Permission): Promise<Permission> {
+    this.logger.info('Updating permission', getContext());
     const record = await this.prisma.permission.update({
       where: { id: permission.id },
       data: { permissionKey: permission.permissionKey, description: permission.description },
@@ -38,6 +47,7 @@ export class PrismaPermissionRepository implements PermissionRepositoryPort {
   }
 
   async delete(id: string): Promise<void> {
+    this.logger.info('Deleting permission', getContext());
     await this.prisma.permission.delete({ where: { id } });
   }
 }

--- a/backend/adapters/repositories/PrismaRoleRepository.ts
+++ b/backend/adapters/repositories/PrismaRoleRepository.ts
@@ -1,28 +1,36 @@
 import { PrismaClient, Role as PrismaRole } from '@prisma/client';
 import { RoleRepositoryPort } from '../../domain/ports/RoleRepositoryPort';
 import { Role } from '../../domain/entities/Role';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
 
 /**
  * Prisma-based implementation of {@link RoleRepositoryPort}.
  */
 export class PrismaRoleRepository implements RoleRepositoryPort {
-  constructor(private prisma: PrismaClient) {}
+  constructor(
+    private prisma: PrismaClient,
+    private readonly logger: LoggerPort,
+  ) {}
 
   private mapRecord(record: PrismaRole): Role {
     return new Role(record.id, record.label);
   }
 
   async findById(id: string): Promise<Role | null> {
+    this.logger.debug('Role findById', getContext());
     const record = await this.prisma.role.findUnique({ where: { id } });
     return record ? this.mapRecord(record) : null;
   }
 
   async findByLabel(label: string): Promise<Role | null> {
+    this.logger.debug('Role findByLabel', getContext());
     const record = await this.prisma.role.findFirst({ where: { label } });
     return record ? this.mapRecord(record) : null;
   }
 
   async create(role: Role): Promise<Role> {
+    this.logger.info('Creating role', getContext());
     const record = await this.prisma.role.create({
       data: { id: role.id, label: role.label },
     });
@@ -30,6 +38,7 @@ export class PrismaRoleRepository implements RoleRepositoryPort {
   }
 
   async update(role: Role): Promise<Role> {
+    this.logger.info('Updating role', getContext());
     const record = await this.prisma.role.update({
       where: { id: role.id },
       data: { label: role.label },
@@ -38,6 +47,7 @@ export class PrismaRoleRepository implements RoleRepositoryPort {
   }
 
   async delete(id: string): Promise<void> {
+    this.logger.info('Deleting role', getContext());
     await this.prisma.role.delete({ where: { id } });
   }
 }

--- a/backend/adapters/repositories/PrismaSiteRepository.ts
+++ b/backend/adapters/repositories/PrismaSiteRepository.ts
@@ -1,28 +1,36 @@
 import { PrismaClient, Site as PrismaSite } from '@prisma/client';
 import { Site } from '../../domain/entities/Site';
 import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
 
 /**
  * Prisma-based implementation of {@link SiteRepositoryPort}.
  */
 export class PrismaSiteRepository implements SiteRepositoryPort {
-  constructor(private prisma: PrismaClient) {}
+  constructor(
+    private prisma: PrismaClient,
+    private readonly logger: LoggerPort,
+  ) {}
 
   private mapRecord(record: PrismaSite): Site {
     return new Site(record.id, record.label);
   }
 
   async findById(id: string): Promise<Site | null> {
+    this.logger.debug('Site findById', getContext());
     const record = await this.prisma.site.findUnique({ where: { id } });
     return record ? this.mapRecord(record) : null;
   }
 
   async findByLabel(label: string): Promise<Site | null> {
+    this.logger.debug('Site findByLabel', getContext());
     const record = await this.prisma.site.findFirst({ where: { label } });
     return record ? this.mapRecord(record) : null;
   }
 
   async create(site: Site): Promise<Site> {
+    this.logger.info('Creating site', getContext());
     const record = await this.prisma.site.create({
       data: { id: site.id, label: site.label },
     });
@@ -30,6 +38,7 @@ export class PrismaSiteRepository implements SiteRepositoryPort {
   }
 
   async update(site: Site): Promise<Site> {
+    this.logger.info('Updating site', getContext());
     const record = await this.prisma.site.update({
       where: { id: site.id },
       data: { label: site.label },
@@ -38,6 +47,7 @@ export class PrismaSiteRepository implements SiteRepositoryPort {
   }
 
   async delete(id: string): Promise<void> {
+    this.logger.info('Deleting site', getContext());
     await this.prisma.site.delete({ where: { id } });
   }
 }

--- a/backend/adapters/repositories/PrismaUserRepository.ts
+++ b/backend/adapters/repositories/PrismaUserRepository.ts
@@ -5,9 +5,14 @@ import { Role } from '../../domain/entities/Role';
 import { Department } from '../../domain/entities/Department';
 import { Site } from '../../domain/entities/Site';
 import { Permission } from '../../domain/entities/Permission';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
 
 export class PrismaUserRepository implements UserRepositoryPort {
-  constructor(private prisma: PrismaClient) {}
+  constructor(
+    private prisma: PrismaClient,
+    private readonly logger: LoggerPort,
+  ) {}
 
   private mapRecord(
     record: PrismaUser & {
@@ -40,6 +45,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async findById(id: string): Promise<User | null> {
+    this.logger.debug('User findById', getContext());
     const record = await this.prisma.user.findUnique({
       where: { id },
       include: {
@@ -53,6 +59,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async findByEmail(email: string): Promise<User | null> {
+    this.logger.debug('User findByEmail', getContext());
     const record = await this.prisma.user.findUnique({
       where: { email },
       include: {
@@ -66,6 +73,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async findByExternalAuth(provider: string, externalId: string): Promise<User | null> {
+    this.logger.debug('User findByExternalAuth', getContext());
     const record = await this.prisma.user.findFirst({
       where: { 
         externalProvider: provider,
@@ -82,6 +90,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async findByDepartmentId(departmentId: string): Promise<User[]> {
+    this.logger.debug('User findByDepartmentId', getContext());
     const records = await this.prisma.user.findMany({
       where: { departmentId },
       include: {
@@ -95,6 +104,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async findByRoleId(roleId: string): Promise<User[]> {
+    this.logger.debug('User findByRoleId', getContext());
     const records = await this.prisma.user.findMany({
       where: { roles: { some: { roleId } } },
       include: {
@@ -108,6 +118,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async findBySiteId(siteId: string): Promise<User[]> {
+    this.logger.debug('User findBySiteId', getContext());
     const records = await this.prisma.user.findMany({
       where: { siteId },
       include: {
@@ -121,6 +132,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async create(user: User): Promise<User> {
+    this.logger.info('Creating user', getContext());
     const record = await this.prisma.user.create({
       data: {
         id: user.id,
@@ -150,6 +162,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async update(user: User): Promise<User> {
+    this.logger.info('Updating user', getContext());
     const record = await this.prisma.user.update({
       where: { id: user.id },
       data: {
@@ -180,6 +193,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
   }
 
   async delete(id: string): Promise<void> {
+    this.logger.info('Deleting user', getContext());
     await this.prisma.user.delete({ where: { id } });
   }
 }

--- a/backend/infrastructure/createPrisma.ts
+++ b/backend/infrastructure/createPrisma.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from '@prisma/client';
+import { LoggerPort } from '../domain/ports/LoggerPort';
+import { getContext } from './loggerContext';
+
+/**
+ * Instantiate a {@link PrismaClient} configured to forward query logs to the
+ * provided {@link LoggerPort}.
+ *
+ * @param logger - Logger used to record SQL queries at trace level.
+ * @returns Configured Prisma client.
+ */
+export function createPrisma(logger: LoggerPort): PrismaClient {
+  const prisma = new PrismaClient({ log: ['query'] });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (prisma as any).$on('query', (e: any) => {
+    logger.trace(`SQL: ${e.query} -- ${e.params}`, getContext());
+  });
+
+  return prisma;
+}

--- a/backend/infrastructure/loggerContext.ts
+++ b/backend/infrastructure/loggerContext.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+/** Storage used to keep contextual values for the current async execution. */
+const storage = new AsyncLocalStorage<Record<string, unknown>>();
+
+/**
+ * Execute the provided function within the given context.
+ *
+ * @param context - Context object shared across the execution.
+ * @param fn - Function to run inside the context.
+ * @returns Result of the function execution.
+ */
+export function withContext<T>(context: Record<string, unknown>, fn: () => T): T {
+  return storage.run(context, fn);
+}
+
+/**
+ * Retrieve the current context or undefined if none is set.
+ *
+ * @returns The stored context for the current async execution.
+ */
+export function getContext(): Record<string, unknown> | undefined {
+  return storage.getStore();
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -1,41 +1,50 @@
 import express from 'express';
 import http from 'http';
 import { Server as SocketIOServer } from 'socket.io';
-import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
 
 import { createUserRouter } from '../adapters/controllers/rest/userController';
 import { registerUserGateway } from '../adapters/controllers/websocket/userGateway';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { JWTAuthServiceAdapter } from '../adapters/auth/JWTAuthServiceAdapter';
+import { ConsoleLoggerAdapter } from '../adapters/logger/ConsoleLoggerAdapter';
+import { createPrisma } from './createPrisma';
+import { withContext, getContext } from './loggerContext';
 
 async function bootstrap(): Promise<void> {
-  const prisma = new PrismaClient();
+  const logger = new ConsoleLoggerAdapter();
+  const prisma = createPrisma(logger);
   await prisma.$connect();
-  console.log('Database connected');
+  logger.info('Database connected');
 
-  const userRepository = new PrismaUserRepository(prisma);
+  const userRepository = new PrismaUserRepository(prisma, logger);
 
   const authService = new JWTAuthServiceAdapter(
     process.env.JWT_SECRET ?? 'secret',
     userRepository,
+    logger,
   );
 
   const app = express();
   app.use(express.json());
+  app.use((req, _res, next) => {
+    withContext({ requestId: randomUUID() }, () => next());
+  });
 
-  app.use('/api', createUserRouter(authService, userRepository));
+  app.use('/api', createUserRouter(authService, userRepository, logger));
 
   const httpServer = http.createServer(app);
   const io = new SocketIOServer(httpServer);
-  registerUserGateway(io, authService);
+  registerUserGateway(io, authService, logger);
 
   const port = parseInt(process.env.PORT ?? '3000', 10);
   httpServer.listen(port, () => {
-    console.log(`Server listening on port ${port}`);
+    logger.info(`Server listening on port ${port}`, getContext());
   });
 }
 
 bootstrap().catch((err) => {
-  console.error('Failed to start server', err);
+  const logger = new ConsoleLoggerAdapter();
+  logger.error('Failed to start server', { error: err });
   process.exit(1);
 });

--- a/backend/tests/adapters/auth/CompositeAuthService.test.ts
+++ b/backend/tests/adapters/auth/CompositeAuthService.test.ts
@@ -1,6 +1,7 @@
 import { CompositeAuthService } from '../../../adapters/auth/CompositeAuthService';
 import { mockDeep } from 'jest-mock-extended';
 import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
@@ -9,6 +10,7 @@ import { Site } from '../../../domain/entities/Site';
 describe('CompositeAuthService', () => {
   let primary: ReturnType<typeof mockDeep<AuthServicePort>>;
   let secondary: ReturnType<typeof mockDeep<AuthServicePort>>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let service: CompositeAuthService;
   let user: User;
   let role: Role;
@@ -18,7 +20,8 @@ describe('CompositeAuthService', () => {
   beforeEach(() => {
     primary = mockDeep<AuthServicePort>();
     secondary = mockDeep<AuthServicePort>();
-    service = new CompositeAuthService([primary, secondary]);
+    logger = mockDeep<LoggerPort>();
+    service = new CompositeAuthService([primary, secondary], logger);
     role = new Role('r', 'Role');
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);

--- a/backend/tests/adapters/auth/JWTAuthServiceAdapter.test.ts
+++ b/backend/tests/adapters/auth/JWTAuthServiceAdapter.test.ts
@@ -6,10 +6,12 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 describe('JWTAuthServiceAdapter', () => {
   const secret = 'secret';
   let repo: DeepMockProxy<UserRepositoryPort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let adapter: JWTAuthServiceAdapter;
   let user: User;
   let role: Role;
@@ -18,11 +20,12 @@ describe('JWTAuthServiceAdapter', () => {
 
   beforeEach(() => {
     repo = mockDeep<UserRepositoryPort>();
+    logger = mockDeep<LoggerPort>();
     role = new Role('r', 'Role');
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
-    adapter = new JWTAuthServiceAdapter(secret, repo);
+    adapter = new JWTAuthServiceAdapter(secret, repo, logger);
   });
 
   it('should verify token and return user', async () => {

--- a/backend/tests/adapters/auth/OIDCAuthServiceAdapter.test.ts
+++ b/backend/tests/adapters/auth/OIDCAuthServiceAdapter.test.ts
@@ -6,11 +6,13 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 const secret = 'oidc-secret';
 
 describe('OIDCAuthServiceAdapter', () => {
   let repo: DeepMockProxy<UserRepositoryPort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let adapter: OIDCAuthServiceAdapter;
   let user: User;
   let role: Role;
@@ -19,11 +21,12 @@ describe('OIDCAuthServiceAdapter', () => {
 
   beforeEach(() => {
     repo = mockDeep<UserRepositoryPort>();
+    logger = mockDeep<LoggerPort>();
     role = new Role('r', 'Role');
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
-    adapter = new OIDCAuthServiceAdapter(secret, 'issuer', repo);
+    adapter = new OIDCAuthServiceAdapter(secret, 'issuer', repo, logger);
   });
 
   it('should verify token with issuer', async () => {

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -8,11 +8,13 @@ import { User } from '../../../../domain/entities/User';
 import { Role } from '../../../../domain/entities/Role';
 import { Department } from '../../../../domain/entities/Department';
 import { Site } from '../../../../domain/entities/Site';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
 
 describe('User REST controller', () => {
   let app: express.Express;
   let auth: DeepMockProxy<AuthServicePort>;
   let repo: DeepMockProxy<UserRepositoryPort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let user: User;
   let role: Role;
   let department: Department;
@@ -21,6 +23,7 @@ describe('User REST controller', () => {
   beforeEach(() => {
     auth = mockDeep<AuthServicePort>();
     repo = mockDeep<UserRepositoryPort>();
+    logger = mockDeep<LoggerPort>();
     role = new Role('r', 'Role');
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
@@ -28,7 +31,7 @@ describe('User REST controller', () => {
     repo.findById.mockResolvedValue(user);
     auth.verifyToken.mockResolvedValue(user);
     app = express();
-    app.use('/api', createUserRouter(auth, repo));
+    app.use('/api', createUserRouter(auth, repo, logger));
   });
 
   it('should return current user profile', async () => {

--- a/backend/tests/adapters/controllers/websocket/userGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/userGateway.test.ts
@@ -8,12 +8,14 @@ import { User } from '../../../../domain/entities/User';
 import { Role } from '../../../../domain/entities/Role';
 import { Department } from '../../../../domain/entities/Department';
 import { Site } from '../../../../domain/entities/Site';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
 
 describe('User WebSocket gateway', () => {
   let io: Server;
   let httpServer: ReturnType<typeof createServer>;
   let url: string;
   let auth: DeepMockProxy<AuthServicePort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let user: User;
   let role: Role;
   let department: Department;
@@ -23,12 +25,13 @@ describe('User WebSocket gateway', () => {
     httpServer = createServer();
     io = new Server(httpServer);
     auth = mockDeep<AuthServicePort>();
+    logger = mockDeep<LoggerPort>();
     role = new Role('r', 'Role');
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
     auth.verifyToken.mockResolvedValue(user);
-    registerUserGateway(io, auth);
+    registerUserGateway(io, auth, logger);
     httpServer.listen(() => {
       const address = httpServer.address() as any;
       url = `http://localhost:${address.port}`;

--- a/backend/tests/adapters/repositories/PrismaDepartmentRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaDepartmentRepository.test.ts
@@ -3,16 +3,19 @@ import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { PrismaDepartmentRepository } from '../../../adapters/repositories/PrismaDepartmentRepository';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 describe('PrismaDepartmentRepository', () => {
   let repo: PrismaDepartmentRepository;
   let prisma: DeepMockProxy<PrismaClient>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let dept: Department;
   let site: Site;
 
   beforeEach(() => {
     prisma = mockDeep<PrismaClient>();
-    repo = new PrismaDepartmentRepository(prisma);
+    logger = mockDeep<LoggerPort>();
+    repo = new PrismaDepartmentRepository(prisma, logger);
     site = new Site('site-1', 'HQ');
     dept = new Department('dept-1', 'IT', null, 'user-1', site);
   });

--- a/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
@@ -2,17 +2,20 @@ import { PrismaClient } from '@prisma/client';
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { PrismaPermissionRepository } from '../../../adapters/repositories/PrismaPermissionRepository';
 import { Permission } from '../../../domain/entities/Permission';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 describe('PrismaPermissionRepository', () => {
   let repository: PrismaPermissionRepository;
   let prisma: DeepMockProxy<PrismaClient>;
   let prismaAny: any;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let perm: Permission;
 
   beforeEach(() => {
     prisma = mockDeep<PrismaClient>();
     prismaAny = prisma as any;
-    repository = new PrismaPermissionRepository(prisma);
+    logger = mockDeep<LoggerPort>();
+    repository = new PrismaPermissionRepository(prisma, logger);
     perm = new Permission('perm-1', 'READ', 'Read access');
   });
 

--- a/backend/tests/adapters/repositories/PrismaRoleRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaRoleRepository.test.ts
@@ -2,15 +2,18 @@ import { PrismaClient } from '@prisma/client';
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { PrismaRoleRepository } from '../../../adapters/repositories/PrismaRoleRepository';
 import { Role } from '../../../domain/entities/Role';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 describe('PrismaRoleRepository', () => {
   let repository: PrismaRoleRepository;
   let prisma: DeepMockProxy<PrismaClient>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let role: Role;
 
   beforeEach(() => {
     prisma = mockDeep<PrismaClient>();
-    repository = new PrismaRoleRepository(prisma);
+    logger = mockDeep<LoggerPort>();
+    repository = new PrismaRoleRepository(prisma, logger);
     role = new Role('role-1', 'Admin');
   });
 

--- a/backend/tests/adapters/repositories/PrismaSiteRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaSiteRepository.test.ts
@@ -2,15 +2,18 @@ import { PrismaClient } from '@prisma/client';
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { PrismaSiteRepository } from '../../../adapters/repositories/PrismaSiteRepository';
 import { Site } from '../../../domain/entities/Site';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 describe('PrismaSiteRepository', () => {
   let repo: PrismaSiteRepository;
   let prisma: DeepMockProxy<PrismaClient>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let site: Site;
 
   beforeEach(() => {
     prisma = mockDeep<PrismaClient>();
-    repo = new PrismaSiteRepository(prisma);
+    logger = mockDeep<LoggerPort>();
+    repo = new PrismaSiteRepository(prisma, logger);
     site = new Site('site-1', 'HQ');
   });
 

--- a/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
@@ -6,10 +6,12 @@ import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Permission } from '../../../domain/entities/Permission';
 import { Site } from '../../../domain/entities/Site';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 describe('PrismaUserRepository', () => {
   let repository: PrismaUserRepository;
   let prismaClient: DeepMockProxy<PrismaClient>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let mockUser: User;
   let mockRole: Role;
   let department: Department;
@@ -18,7 +20,8 @@ describe('PrismaUserRepository', () => {
   beforeEach(() => {
     // Create deep mock of Prisma client
     prismaClient = mockDeep<PrismaClient>();
-    repository = new PrismaUserRepository(prismaClient);
+    logger = mockDeep<LoggerPort>();
+    repository = new PrismaUserRepository(prismaClient, logger);
 
     // Setup test data
     mockRole = new Role('role-123', 'Admin');

--- a/backend/tests/infrastructure/createPrisma.test.ts
+++ b/backend/tests/infrastructure/createPrisma.test.ts
@@ -1,0 +1,31 @@
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      $on: jest.fn(),
+    })),
+  };
+});
+
+import { createPrisma } from '../../infrastructure/createPrisma';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { mockDeep } from 'jest-mock-extended';
+import { withContext } from '../../infrastructure/loggerContext';
+
+describe('createPrisma', () => {
+  it('should register query listener', () => {
+    const logger = mockDeep<LoggerPort>();
+    const prisma = createPrisma(logger);
+    const mockClient: any = (prisma as any);
+    expect(mockClient.$on).toHaveBeenCalledWith('query', expect.any(Function));
+  });
+
+  it('should forward query events to logger with context', () => {
+    const logger = mockDeep<LoggerPort>();
+    const prisma = createPrisma(logger);
+    const handler = (prisma as any).$on.mock.calls[0][1];
+    withContext({ requestId: '1' }, () => {
+      handler({ query: 'SELECT 1', params: '[]' });
+    });
+    expect(logger.trace).toHaveBeenCalledWith('SQL: SELECT 1 -- []', { requestId: '1' });
+  });
+});

--- a/backend/tests/infrastructure/loggerContext.test.ts
+++ b/backend/tests/infrastructure/loggerContext.test.ts
@@ -1,0 +1,10 @@
+import { withContext, getContext } from '../../infrastructure/loggerContext';
+
+describe('logger context utilities', () => {
+  it('should store and retrieve context', () => {
+    expect(getContext()).toBeUndefined();
+    const result = withContext({ requestId: '1' }, () => getContext());
+    expect(result).toEqual({ requestId: '1' });
+    expect(getContext()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce AsyncLocalStorage utilities for request context
- add `createPrisma` helper to forward Prisma queries to logger
- use logger and context in server bootstrap
- inject logger into all adapters and log key operations
- update tests and add new coverage for logging utils

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814759309c8323a7342ca5cdbd2ed6