### PR TITLE
Fix Swagger route order

### DIFF
--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -33,8 +33,8 @@ async function bootstrap(): Promise<void> {
     withContext({ requestId: randomUUID() }, () => next());
   });
 
-  app.use('/api', createUserRouter(authService, userRepository, logger));
   setupSwagger(app);
+  app.use('/api', createUserRouter(authService, userRepository, logger));
   
   const httpServer = http.createServer(app);
   const io = new SocketIOServer(httpServer);


### PR DESCRIPTION
## Summary
- serve Swagger docs before applying authentication routes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688178230efc8323a31ff9c9712e57a9