### PR TITLE
Improve OpenAPI documentation

### DIFF
--- a/backend/adapters/controllers/rest/departmentController.ts
+++ b/backend/adapters/controllers/rest/departmentController.ts
@@ -25,45 +25,59 @@ import { RemoveDepartmentUserUseCase } from '../../../usecases/department/Remove
  * components:
  *   schemas:
  *     Site:
+ *       description: Location that hosts departments within the organization.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the site.
  *         label:
  *           type: string
+ *           description: Human readable name of the site.
  *       required:
  *         - id
  *         - label
  *     Permission:
+ *       description: Capability that can be granted to a department.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the permission.
  *         permissionKey:
  *           type: string
+ *           description: Machine readable key used to check access.
  *         description:
  *           type: string
+ *           description: Human readable explanation of the permission.
  *       required:
  *         - id
  *         - permissionKey
  *         - description
  *     Department:
+ *       description: Organizational division containing users and permissions.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the department.
  *         label:
  *           type: string
+ *           description: Department name.
  *         parentDepartmentId:
  *           type: string
  *           nullable: true
+ *           description: Identifier of the parent department when nested.
  *         managerUserId:
  *           type: string
  *           nullable: true
+ *           description: User responsible for the department.
  *         site:
  *           $ref: '#/components/schemas/Site'
+ *           description: Site where the department is located.
  *         permissions:
  *           type: array
+ *           description: Permissions granted to the department.
  *           items:
  *             $ref: '#/components/schemas/Permission'
  *       required:
@@ -105,21 +119,25 @@ export function createDepartmentRouter(
   /**
    * @openapi
    * /departments:
-   *   post:
-   *     summary: Create a department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Create a department.
+ *     description: |
+ *       Creates a new department within a site. Authentication with
+ *       administrator privileges is required.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       description: Department information to create.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Department'
    *     responses:
-   *       201:
-   *         description: Department created
+ *       201:
+ *         description: Newly created department
    *         content:
    *           application/json:
    *             schema:
@@ -136,21 +154,30 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}:
-  *   put:
-  *     summary: Update a department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Update a department.
+ *     description: Modify a department's label, parent, manager or permissions.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department to update.
+ *     requestBody:
+ *       description: Updated department information.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Department'
    *     responses:
-   *       200:
-   *         description: Updated department
+ *       200:
+ *         description: Department after update
    *         content:
    *           application/json:
    *             schema:
@@ -168,15 +195,31 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/children/{childId}:
-  *   post:
-  *     summary: Add a child department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Updated department
+ *   post:
+ *     summary: Add a child department.
+ *     description: |
+ *       Attaches an existing department as a child of another department.
+ *       Requires authentication with administrative rights.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the parent department.
+ *       - in: path
+ *         name: childId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the child department to attach.
+ *     responses:
+ *       200:
+ *         description: Department with new child attached
    *         content:
    *           application/json:
    *             schema:
@@ -198,15 +241,31 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/children/{childId}:
-  *   delete:
-  *     summary: Remove a child department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Updated department
+ *   delete:
+ *     summary: Remove a child department.
+ *     description: |
+ *       Detaches a child department from its parent. Authentication and
+ *       administrative privileges are required.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the parent department.
+ *       - in: path
+ *         name: childId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the child department to detach.
+ *     responses:
+ *       200:
+ *         description: Department without the removed child
    *         content:
    *           application/json:
    *             schema:
@@ -228,14 +287,25 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/manager:
-  *   put:
-  *     summary: Set department manager.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Set department manager.
+ *     description: |
+ *       Assigns a user as the manager of the department. Requires
+ *       administrator privileges.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department.
+ *     requestBody:
+ *       description: User identifier to set as manager.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
@@ -246,8 +316,8 @@ export function createDepartmentRouter(
    *             required:
    *               - userId
    *     responses:
-   *       200:
-   *         description: Updated department
+ *       200:
+ *         description: Department with manager assigned
    *         content:
    *           application/json:
    *             schema:
@@ -269,15 +339,25 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/manager:
-  *   delete:
-  *     summary: Remove department manager.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Updated department
+ *   delete:
+ *     summary: Remove department manager.
+ *     description: |
+ *       Clears the manager of the department. The caller must be authenticated
+ *       as an administrator.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department.
+ *     responses:
+ *       200:
+ *         description: Department without manager
    *         content:
    *           application/json:
    *             schema:
@@ -299,14 +379,25 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/parent:
-  *   put:
-  *     summary: Set parent department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Set parent department.
+ *     description: |
+ *       Defines the parent department for hierarchical organization. Requires
+ *       administrator privileges.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department to update.
+ *     requestBody:
+ *       description: Identifier of the new parent department.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
@@ -317,8 +408,8 @@ export function createDepartmentRouter(
    *             required:
    *               - parentId
    *     responses:
-   *       200:
-   *         description: Updated department
+ *       200:
+ *         description: Department with updated parent
    *         content:
    *           application/json:
    *             schema:
@@ -340,15 +431,25 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/parent:
-  *   delete:
-  *     summary: Remove parent department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Updated department
+ *   delete:
+ *     summary: Remove parent department.
+ *     description: |
+ *       Detaches the department from its current parent. Administrator
+ *       authentication is required.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department.
+ *     responses:
+ *       200:
+ *         description: Department without parent
    *         content:
    *           application/json:
    *             schema:
@@ -370,21 +471,32 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/permissions:
-  *   put:
-  *     summary: Add permission to department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Add permission to department.
+ *     description: |
+ *       Grants a specific permission to the department. Administrator
+ *       authentication is required.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department to update.
+ *     requestBody:
+ *       description: Permission data to add.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Permission'
    *     responses:
-   *       200:
-   *         description: Updated department
+ *       200:
+ *         description: Department with new permission
    *         content:
    *           application/json:
    *             schema:
@@ -407,15 +519,31 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/permissions/{permissionId}:
-  *   delete:
-  *     summary: Remove a permission from department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Updated department
+ *   delete:
+ *     summary: Remove a permission from department.
+ *     description: |
+ *       Revokes a previously granted permission from the department.
+ *       Administrator authentication is required.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department.
+ *       - in: path
+ *         name: permissionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the permission to remove.
+ *     responses:
+ *       200:
+ *         description: Department after permission removal
    *         content:
    *           application/json:
    *             schema:
@@ -437,15 +565,31 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/users/{userId}:
-  *   put:
-  *     summary: Attach user to department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Updated department
+ *   put:
+ *     summary: Attach user to department.
+ *     description: |
+ *       Adds an existing user to the specified department. Requires
+ *       administrative privileges.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the target department.
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the user to attach.
+ *     responses:
+ *       200:
+ *         description: Department with user attached
    *         content:
    *           application/json:
    *             schema:
@@ -467,15 +611,31 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/users/{userId}:
-  *   delete:
-  *     summary: Detach user from department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Updated department
+ *   delete:
+ *     summary: Detach user from department.
+ *     description: |
+ *       Removes the association between a user and a department. Requires
+ *       administrator authentication.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department.
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the user to detach.
+ *     responses:
+ *       200:
+ *         description: Department after user removal
    *         content:
    *           application/json:
    *             schema:
@@ -497,17 +657,27 @@ export function createDepartmentRouter(
   /**
    * @openapi
    * /departments/{id}:
-  *   delete:
-  *     summary: Remove a department.
-   *     tags:
-   *       - Department
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       204:
-   *         description: Department deleted
-   *       400:
-   *         description: Operation failed
+ *   delete:
+ *     summary: Remove a department.
+ *     description: |
+ *       Permanently deletes a department. The operation fails if users are
+ *       still attached. Requires administrator privileges.
+ *     tags:
+ *       - Department
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the department to delete.
+ *     responses:
+ *       204:
+ *         description: Department successfully deleted
+ *       400:
+ *         description: Operation failed
    */
   router.delete('/departments/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /departments/:id', getContext());

--- a/backend/adapters/controllers/rest/permissionController.ts
+++ b/backend/adapters/controllers/rest/permissionController.ts
@@ -12,14 +12,18 @@ import { RemovePermissionUseCase } from '../../../usecases/permission/RemovePerm
  * components:
  *   schemas:
  *     Permission:
+ *       description: Individual capability that can be granted to roles or users.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the permission.
  *         permissionKey:
  *           type: string
+ *           description: Machine readable key used in access checks.
  *         description:
  *           type: string
+ *           description: Human readable explanation of the permission.
  *       required:
  *         - id
  *         - permissionKey
@@ -46,21 +50,25 @@ export function createPermissionRouter(
   /**
    * @openapi
   * /permissions:
-  *   post:
-  *     summary: Create a permission.
-   *     tags:
-   *       - Permission
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Create a permission.
+ *     description: |
+ *       Registers a new permission in the system. Only authenticated
+ *       administrators should use this endpoint.
+ *     tags:
+ *       - Permission
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       description: Permission details to create.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Permission'
    *     responses:
-   *       201:
-   *         description: Permission created
+ *       201:
+ *         description: Newly created permission
    *         content:
    *           application/json:
    *             schema:
@@ -77,21 +85,30 @@ export function createPermissionRouter(
   /**
    * @openapi
   * /permissions/{id}:
-  *   put:
-  *     summary: Update a permission.
-   *     tags:
-   *       - Permission
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Update a permission.
+ *     description: Modify the key or description of an existing permission.
+ *     tags:
+ *       - Permission
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the permission to update.
+ *     requestBody:
+ *       description: Updated permission information.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Permission'
    *     responses:
-   *       200:
-   *         description: Updated permission
+ *       200:
+ *         description: Permission after update
    *         content:
    *           application/json:
    *             schema:
@@ -109,15 +126,24 @@ export function createPermissionRouter(
   /**
    * @openapi
   * /permissions/{id}:
-  *   delete:
-  *     summary: Remove a permission.
-   *     tags:
-   *       - Permission
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       204:
-   *         description: Permission removed
+ *   delete:
+ *     summary: Remove a permission.
+ *     description: Deletes an existing permission. It should no longer be
+ *       referenced by any role before calling this endpoint.
+ *     tags:
+ *       - Permission
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the permission to delete.
+ *     responses:
+ *       204:
+ *         description: Permission successfully removed
    */
   router.delete('/permissions/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /permissions/:id', getContext());

--- a/backend/adapters/controllers/rest/roleController.ts
+++ b/backend/adapters/controllers/rest/roleController.ts
@@ -14,27 +14,35 @@ import { RemoveRoleUseCase } from '../../../usecases/role/RemoveRoleUseCase';
  * components:
  *   schemas:
  *     Permission:
+ *       description: Individual capability that can be assigned to a role.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the permission.
  *         permissionKey:
  *           type: string
+ *           description: Machine readable key used in permission checks.
  *         description:
  *           type: string
+ *           description: Human readable explanation of the permission.
  *       required:
  *         - id
  *         - permissionKey
  *         - description
  *     Role:
+ *       description: Set of permissions granted to users assigned this role.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the role.
  *         label:
  *           type: string
+ *           description: Human readable role name.
  *         permissions:
  *           type: array
+ *           description: Permissions attached to the role.
  *           items:
  *             $ref: '#/components/schemas/Permission'
  *       required:
@@ -69,21 +77,25 @@ export function createRoleRouter(
   /**
    * @openapi
   * /roles:
-  *   post:
-  *     summary: Create a role.
-   *     tags:
-   *       - Role
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Create a role.
+ *     description: |
+ *       Registers a new role grouping a set of permissions. Requires
+ *       authentication and administrative rights.
+ *     tags:
+ *       - Role
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       description: Role information to store.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Role'
    *     responses:
-   *       201:
-   *         description: Role created
+ *       201:
+ *         description: Newly created role
    *         content:
    *           application/json:
    *             schema:
@@ -100,21 +112,30 @@ export function createRoleRouter(
   /**
    * @openapi
   * /roles/{id}:
-  *   put:
-  *     summary: Update a role.
-   *     tags:
-   *       - Role
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Update a role.
+ *     description: Modify the label or permissions of an existing role.
+ *     tags:
+ *       - Role
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the role to update.
+ *     requestBody:
+ *       description: Updated role data.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Role'
    *     responses:
-   *       200:
-   *         description: Updated role
+ *       200:
+ *         description: Role after update
    *         content:
    *           application/json:
    *             schema:
@@ -132,17 +153,27 @@ export function createRoleRouter(
   /**
    * @openapi
   * /roles/{id}:
-  *   delete:
-  *     summary: Remove a role.
-   *     tags:
-   *       - Role
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       204:
-   *         description: Role deleted
-   *       400:
-   *         description: Operation failed
+ *   delete:
+ *     summary: Remove a role.
+ *     description: |
+ *       Deletes a role. The operation fails if users are still associated with
+ *       it. Requires administrative privileges.
+ *     tags:
+ *       - Role
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the role to delete.
+ *     responses:
+ *       204:
+ *         description: Role successfully deleted
+ *       400:
+ *         description: Deletion failed because the role is still in use
    */
   router.delete('/roles/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /roles/:id', getContext());

--- a/backend/adapters/controllers/rest/siteController.ts
+++ b/backend/adapters/controllers/rest/siteController.ts
@@ -14,12 +14,15 @@ import { getContext } from '../../../infrastructure/loggerContext';
  * components:
  *   schemas:
  *     Site:
+ *       description: Physical office or facility managed by the organization.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the site.
  *         label:
  *           type: string
+ *           description: Human readable name of the site.
  *       required:
  *         - id
  *         - label
@@ -43,21 +46,25 @@ export function createSiteRouter(
   /**
    * @openapi
   * /sites:
-  *   post:
-  *     summary: Create a site.
-   *     tags:
-   *       - Site
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Create a site.
+ *     description: |
+ *       Adds a new physical site to the system. Authentication is required and
+ *       the caller must have administrator privileges.
+ *     tags:
+ *       - Site
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       description: Site information to create.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Site'
    *     responses:
-   *       201:
-   *         description: Site created
+ *       201:
+ *         description: Newly created site
    *         content:
    *           application/json:
    *             schema:
@@ -75,21 +82,31 @@ export function createSiteRouter(
   /**
    * @openapi
   * /sites/{id}:
-  *   put:
-  *     summary: Update a site.
-   *     tags:
-   *       - Site
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Update a site.
+ *     description: Modify the label of an existing site. Requires
+ *       administrator privileges.
+ *     tags:
+ *       - Site
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the site to update.
+ *     requestBody:
+ *       description: New site data.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/Site'
    *     responses:
-   *       200:
-   *         description: Updated site
+ *       200:
+ *         description: Site after update
    *         content:
    *           application/json:
    *             schema:
@@ -108,17 +125,27 @@ export function createSiteRouter(
   /**
    * @openapi
   * /sites/{id}:
-  *   delete:
-  *     summary: Remove a site.
-   *     tags:
-   *       - Site
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       204:
-   *         description: Site deleted
-   *       400:
-   *         description: Operation failed
+ *   delete:
+ *     summary: Remove a site.
+ *     description: |
+ *       Deletes a site. The operation fails when users or departments are still
+ *       attached to it. Requires administrator privileges.
+ *     tags:
+ *       - Site
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the site to delete.
+ *     responses:
+ *       204:
+ *         description: Site successfully deleted
+ *       400:
+ *         description: Operation failed due to existing attachments
    */
   router.delete('/sites/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /sites/:id', getContext());

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -23,87 +23,115 @@ import { Permission } from '../../../domain/entities/Permission';
  * components:
  *   schemas:
  *     Site:
+ *       description: Physical location where users and departments operate.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the site.
  *         label:
  *           type: string
+ *           description: Human readable site name.
  *       required:
  *         - id
  *         - label
  *     Department:
+ *       description: Organizational unit grouping users within a site.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the department.
  *         label:
  *           type: string
+ *           description: Department name.
  *         parentDepartmentId:
  *           type: string
  *           nullable: true
+ *           description: Identifier of the parent department if applicable.
  *         managerUserId:
  *           type: string
  *           nullable: true
+ *           description: Identifier of the user managing this department.
  *         site:
  *           $ref: '#/components/schemas/Site'
+ *           description: Site where the department is located.
  *       required:
  *         - id
  *         - label
  *         - site
  *     Permission:
+ *       description: Authorization item representing an allowed action.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the permission.
  *         permissionKey:
  *           type: string
+ *           description: Machine readable key for the permission.
  *         description:
  *           type: string
+ *           description: Human readable explanation of the permission.
  *       required:
  *         - id
  *         - permissionKey
  *         - description
  *     Role:
+ *       description: Collection of permissions that can be assigned to users.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the role.
  *         label:
  *           type: string
+ *           description: Human readable role name.
  *         permissions:
  *           type: array
+ *           description: Permissions granted by the role.
  *           items:
  *             $ref: '#/components/schemas/Permission'
  *       required:
  *         - id
  *         - label
  *     User:
+ *       description: Application user with profile and access information.
  *       type: object
  *       properties:
  *         id:
  *           type: string
+ *           description: Unique identifier of the user.
  *         firstName:
  *           type: string
+ *           description: Given name of the user.
  *         lastName:
  *           type: string
+ *           description: Family name of the user.
  *         email:
  *           type: string
+ *           description: Email address used for communication and login.
  *         roles:
  *           type: array
+ *           description: Roles assigned to the user.
  *           items:
  *             $ref: '#/components/schemas/Role'
  *         status:
  *           type: string
  *           enum: [active, suspended, archived]
+ *           description: Current account status.
  *         department:
  *           $ref: '#/components/schemas/Department'
+ *           description: Department the user belongs to.
  *         site:
  *           $ref: '#/components/schemas/Site'
+ *           description: Site where the user is located.
  *         picture:
  *           type: string
+ *           description: Optional URL of the profile picture.
  *         permissions:
  *           type: array
+ *           description: Permissions granted directly to the user.
  *           items:
  *             $ref: '#/components/schemas/Permission'
  *       required:
@@ -197,23 +225,27 @@ export function createUserRouter(
   /**
    * @openapi
   * /users:
-  *   post:
-  *     summary: Register a new user.
-   *     tags:
-   *       - User
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         application/json:
-   *           schema:
-   *             $ref: '#/components/schemas/User'
-   *     responses:
-   *       201:
-   *         description: User created
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/User'
+ *   post:
+ *     summary: Register a new user.
+ *     description: |
+ *       Creates a user account for a new participant. This endpoint is open
+ *       to unauthenticated clients and is typically used during onboarding.
+ *     tags:
+ *       - User
+ *     requestBody:
+ *       description: Data describing the user to create.
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/User'
+ *     responses:
+ *       201:
+ *         description: Newly created user profile.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/User'
    */
   router.post('/users', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /users', getContext());
@@ -226,12 +258,16 @@ export function createUserRouter(
   /**
    * @openapi
   * /auth/login:
-  *   post:
-  *     summary: Authenticate a user with email and password.
-   *     tags:
-   *       - User
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Authenticate a user with email and password.
+ *     description: |
+ *       Validates the provided credentials and returns the corresponding user
+ *       profile if the login succeeds.
+ *     tags:
+ *       - User
+ *     requestBody:
+ *       description: Email and password used to authenticate.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
@@ -245,8 +281,8 @@ export function createUserRouter(
    *               - email
    *               - password
    *     responses:
-   *       200:
-   *         description: Authenticated user
+ *       200:
+ *         description: User successfully authenticated
    *         content:
    *           application/json:
    *             schema:
@@ -269,12 +305,16 @@ export function createUserRouter(
   /**
    * @openapi
   * /auth/provider:
-  *   post:
-  *     summary: Authenticate a user with an external provider.
-   *     tags:
-   *       - User
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Authenticate a user with an external provider.
+ *     description: |
+ *       Exchanges a provider issued token (e.g. OAuth) for a local session and
+ *       returns the associated user profile.
+ *     tags:
+ *       - User
+ *     requestBody:
+ *       description: Provider name and issued token.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
@@ -288,8 +328,8 @@ export function createUserRouter(
    *               - provider
    *               - token
    *     responses:
-   *       200:
-   *         description: Authenticated user
+ *       200:
+ *         description: User successfully authenticated with the provider
    *         content:
    *           application/json:
    *             schema:
@@ -312,12 +352,14 @@ export function createUserRouter(
   /**
    * @openapi
   * /auth/request-reset:
-  *   post:
-  *     summary: Request a password reset email.
-   *     tags:
-   *       - User
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Request a password reset email.
+ *     description: Sends a password reset link to the provided email address.
+ *     tags:
+ *       - User
+ *     requestBody:
+ *       description: Email address of the account requesting a reset.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
@@ -328,8 +370,8 @@ export function createUserRouter(
    *             required:
    *               - email
    *     responses:
-   *       204:
-   *         description: Request accepted
+ *       204:
+ *         description: Reset request processed, no content returned
    */
   router.post('/auth/request-reset', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /auth/request-reset', getContext());
@@ -343,12 +385,16 @@ export function createUserRouter(
   /**
    * @openapi
   * /auth/reset:
-  *   post:
-  *     summary: Reset a user password.
-   *     tags:
-   *       - User
-   *     requestBody:
-   *       required: true
+ *   post:
+ *     summary: Reset a user password.
+ *     description: |
+ *       Completes the password reset process using a valid reset token and the
+ *       new password provided.
+ *     tags:
+ *       - User
+ *     requestBody:
+ *       description: Reset token and the new password.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
@@ -362,8 +408,8 @@ export function createUserRouter(
    *               - token
    *               - password
    *     responses:
-   *       204:
-   *         description: Password reset
+ *       204:
+ *         description: Password successfully changed
    */
   router.post('/auth/reset', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /auth/reset', getContext());
@@ -379,15 +425,18 @@ export function createUserRouter(
   /**
    * @openapi
   * /users/me:
-  *   get:
-  *     summary: Returns the current user profile.
-   *     tags:
-   *       - User
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       200:
-   *         description: Current user profile
+ *   get:
+ *     summary: Returns the current user profile.
+ *     description: |
+ *       Retrieves information about the authenticated user. A valid bearer
+ *       token must be supplied in the `Authorization` header.
+ *     tags:
+ *       - User
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Profile of the authenticated user
    *         content:
    *           application/json:
    *             schema:
@@ -409,21 +458,32 @@ export function createUserRouter(
   /**
    * @openapi
   * /users/{id}:
-  *   put:
-  *     summary: Update a user profile.
-   *     tags:
-   *       - User
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Update a user profile.
+ *     description: |
+ *       Updates information about an existing user. Authentication is required
+ *       and only authorized administrators should call this endpoint.
+ *     tags:
+ *       - User
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the user to update.
+ *     requestBody:
+ *       description: Updated user information.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             $ref: '#/components/schemas/User'
    *     responses:
-   *       200:
-   *         description: Updated user
+ *       200:
+ *         description: The user profile after update
    *         content:
    *           application/json:
    *             schema:
@@ -441,14 +501,25 @@ export function createUserRouter(
   /**
    * @openapi
   * /users/{id}/status:
-  *   put:
-  *     summary: Change user status.
-   *     tags:
-   *       - User
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       required: true
+ *   put:
+ *     summary: Change user status.
+ *     description: |
+ *       Updates the account status (active, suspended or archived) of a user.
+ *       Requires administrator privileges.
+ *     tags:
+ *       - User
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the user to update.
+ *     requestBody:
+ *       description: The new status value.
+ *       required: true
    *       content:
    *         application/json:
    *           schema:
@@ -460,8 +531,8 @@ export function createUserRouter(
    *             required:
    *               - status
    *     responses:
-   *       200:
-   *         description: Updated user status
+ *       200:
+ *         description: User with the updated status
    *         content:
    *           application/json:
    *             schema:
@@ -484,15 +555,25 @@ export function createUserRouter(
   /**
    * @openapi
   * /users/{id}:
-  *   delete:
-  *     summary: Remove a user.
-   *     tags:
-   *       - User
-   *     security:
-   *       - bearerAuth: []
-   *     responses:
-   *       204:
-   *         description: User removed
+ *   delete:
+ *     summary: Remove a user.
+ *     description: |
+ *       Permanently deletes a user account. This operation cannot be undone
+ *       and requires administrative privileges.
+ *     tags:
+ *       - User
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identifier of the user to delete.
+ *     responses:
+ *       204:
+ *         description: User successfully removed
    */
   router.delete('/users/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /users/:id', getContext());


### PR DESCRIPTION
## Summary
- expand component schema descriptions for all controllers
- document authentication and parameters for every route
- describe request bodies and responses for clarity

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688251bc59f083239fa9bc93844ac90d