### PR TITLE
Add list/detail REST endpoints with docs

### DIFF
--- a/backend/adapters/controllers/rest/departmentController.ts
+++ b/backend/adapters/controllers/rest/departmentController.ts
@@ -19,6 +19,8 @@ import { AddChildDepartmentUseCase } from '../../../usecases/department/AddChild
 import { RemoveChildDepartmentUseCase } from '../../../usecases/department/RemoveChildDepartmentUseCase';
 import { AddDepartmentUserUseCase } from '../../../usecases/department/AddDepartmentUserUseCase';
 import { RemoveDepartmentUserUseCase } from '../../../usecases/department/RemoveDepartmentUserUseCase';
+import { GetDepartmentsUseCase } from '../../../usecases/department/GetDepartmentsUseCase';
+import { GetDepartmentUseCase } from '../../../usecases/department/GetDepartmentUseCase';
 
 /**
  * @openapi
@@ -115,6 +117,74 @@ export function createDepartmentRouter(
   logger: LoggerPort,
 ): Router {
   const router = express.Router();
+
+  /**
+   * @openapi
+   * /departments:
+   *   get:
+   *     summary: Get all departments
+   *     description: Returns the list of all departments.
+   *     tags:
+   *       - Department
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Array of department objects.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/Department'
+   */
+  router.get('/departments', async (_req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /departments', getContext());
+    const useCase = new GetDepartmentsUseCase(departmentRepository);
+    const departments = await useCase.execute();
+    logger.debug('Departments retrieved', getContext());
+    res.json(departments);
+  });
+
+  /**
+   * @openapi
+   * /departments/{id}:
+   *   get:
+   *     summary: Get department by ID
+   *     description: Returns detailed information about a specific department.
+   *     tags:
+   *       - Department
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: id
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique identifier of the department.
+   *     responses:
+   *       200:
+   *         description: Department details.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Department'
+   *       404:
+   *         description: Department not found.
+   */
+  router.get('/departments/:id', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /departments/:id', getContext());
+    const useCase = new GetDepartmentUseCase(departmentRepository);
+    const department = await useCase.execute(req.params.id);
+    if (!department) {
+      logger.warn('Department not found', getContext());
+      res.status(404).end();
+      return;
+    }
+    logger.debug('Department retrieved', getContext());
+    res.json(department);
+  });
 
   /**
    * @openapi

--- a/backend/adapters/controllers/rest/permissionController.ts
+++ b/backend/adapters/controllers/rest/permissionController.ts
@@ -6,6 +6,8 @@ import { Permission } from '../../../domain/entities/Permission';
 import { CreatePermissionUseCase } from '../../../usecases/permission/CreatePermissionUseCase';
 import { UpdatePermissionUseCase } from '../../../usecases/permission/UpdatePermissionUseCase';
 import { RemovePermissionUseCase } from '../../../usecases/permission/RemovePermissionUseCase';
+import { GetPermissionsUseCase } from '../../../usecases/permission/GetPermissionsUseCase';
+import { GetPermissionUseCase } from '../../../usecases/permission/GetPermissionUseCase';
 
 /**
  * @openapi
@@ -46,6 +48,74 @@ export function createPermissionRouter(
   logger: LoggerPort,
 ): Router {
   const router = express.Router();
+
+  /**
+   * @openapi
+   * /permissions:
+   *   get:
+   *     summary: Get all permissions
+   *     description: Returns the list of all permissions.
+   *     tags:
+   *       - Permission
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Array of permission objects.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/Permission'
+   */
+  router.get('/permissions', async (_req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /permissions', getContext());
+    const useCase = new GetPermissionsUseCase(repository);
+    const permissions = await useCase.execute();
+    logger.debug('Permissions retrieved', getContext());
+    res.json(permissions);
+  });
+
+  /**
+   * @openapi
+   * /permissions/{id}:
+   *   get:
+   *     summary: Get permission by ID
+   *     description: Returns detailed information about a specific permission.
+   *     tags:
+   *       - Permission
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: id
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique identifier of the permission.
+   *     responses:
+   *       200:
+   *         description: Permission details.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Permission'
+   *       404:
+   *         description: Permission not found.
+   */
+  router.get('/permissions/:id', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /permissions/:id', getContext());
+    const useCase = new GetPermissionUseCase(repository);
+    const permission = await useCase.execute(req.params.id);
+    if (!permission) {
+      logger.warn('Permission not found', getContext());
+      res.status(404).end();
+      return;
+    }
+    logger.debug('Permission retrieved', getContext());
+    res.json(permission);
+  });
 
   /**
    * @openapi

--- a/backend/adapters/controllers/rest/roleController.ts
+++ b/backend/adapters/controllers/rest/roleController.ts
@@ -8,6 +8,8 @@ import { Permission } from '../../../domain/entities/Permission';
 import { CreateRoleUseCase } from '../../../usecases/role/CreateRoleUseCase';
 import { UpdateRoleUseCase } from '../../../usecases/role/UpdateRoleUseCase';
 import { RemoveRoleUseCase } from '../../../usecases/role/RemoveRoleUseCase';
+import { GetRolesUseCase } from '../../../usecases/role/GetRolesUseCase';
+import { GetRoleUseCase } from '../../../usecases/role/GetRoleUseCase';
 
 /**
  * @openapi
@@ -73,6 +75,74 @@ export function createRoleRouter(
   logger: LoggerPort,
 ): Router {
   const router = express.Router();
+
+  /**
+   * @openapi
+   * /roles:
+   *   get:
+   *     summary: Get all roles
+   *     description: Returns the list of all roles.
+   *     tags:
+   *       - Role
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Array of role objects.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/Role'
+   */
+  router.get('/roles', async (_req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /roles', getContext());
+    const useCase = new GetRolesUseCase(roleRepository);
+    const roles = await useCase.execute();
+    logger.debug('Roles retrieved', getContext());
+    res.json(roles);
+  });
+
+  /**
+   * @openapi
+   * /roles/{id}:
+   *   get:
+   *     summary: Get role by ID
+   *     description: Returns detailed information about a specific role.
+   *     tags:
+   *       - Role
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: id
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique identifier of the role.
+   *     responses:
+   *       200:
+   *         description: Role details.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Role'
+   *       404:
+   *         description: Role not found.
+   */
+  router.get('/roles/:id', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /roles/:id', getContext());
+    const useCase = new GetRoleUseCase(roleRepository);
+    const role = await useCase.execute(req.params.id);
+    if (!role) {
+      logger.warn('Role not found', getContext());
+      res.status(404).end();
+      return;
+    }
+    logger.debug('Role retrieved', getContext());
+    res.json(role);
+  });
 
   /**
    * @openapi

--- a/backend/adapters/controllers/rest/siteController.ts
+++ b/backend/adapters/controllers/rest/siteController.ts
@@ -5,6 +5,8 @@ import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentReposi
 import { CreateSiteUseCase } from '../../../usecases/site/CreateSiteUseCase';
 import { UpdateSiteUseCase } from '../../../usecases/site/UpdateSiteUseCase';
 import { RemoveSiteUseCase } from '../../../usecases/site/RemoveSiteUseCase';
+import { GetSitesUseCase } from '../../../usecases/site/GetSitesUseCase';
+import { GetSiteUseCase } from '../../../usecases/site/GetSiteUseCase';
 import { Site } from '../../../domain/entities/Site';
 import { LoggerPort } from '../../../domain/ports/LoggerPort';
 import { getContext } from '../../../infrastructure/loggerContext';
@@ -42,6 +44,74 @@ export function createSiteRouter(
   logger: LoggerPort,
 ): Router {
   const router = express.Router();
+
+  /**
+   * @openapi
+   * /sites:
+   *   get:
+   *     summary: Get all sites
+   *     description: Returns the list of all sites.
+   *     tags:
+   *       - Site
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Array of site objects.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/Site'
+   */
+  router.get('/sites', async (_req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /sites', getContext());
+    const useCase = new GetSitesUseCase(siteRepository);
+    const sites = await useCase.execute();
+    logger.debug('Sites retrieved', getContext());
+    res.json(sites);
+  });
+
+  /**
+   * @openapi
+   * /sites/{id}:
+   *   get:
+   *     summary: Get site by ID
+   *     description: Returns detailed information about a specific site.
+   *     tags:
+   *       - Site
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - name: id
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique identifier of the site.
+   *     responses:
+   *       200:
+   *         description: Site details.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Site'
+   *       404:
+   *         description: Site not found.
+   */
+  router.get('/sites/:id', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /sites/:id', getContext());
+    const useCase = new GetSiteUseCase(siteRepository);
+    const site = await useCase.execute(req.params.id);
+    if (!site) {
+      logger.warn('Site not found', getContext());
+      res.status(404).end();
+      return;
+    }
+    logger.debug('Site retrieved', getContext());
+    res.json(site);
+  });
 
   /**
    * @openapi

--- a/backend/adapters/repositories/PrismaDepartmentRepository.ts
+++ b/backend/adapters/repositories/PrismaDepartmentRepository.ts
@@ -30,6 +30,12 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
     return record ? this.mapRecord(record) : null;
   }
 
+  async findAll(): Promise<Department[]> {
+    this.logger.debug('Department findAll', getContext());
+    const records = await this.prisma.department.findMany({ include: { site: true } });
+    return records.map(r => this.mapRecord(r));
+  }
+
   async findByLabel(label: string): Promise<Department | null> {
     this.logger.debug('Department findByLabel', getContext());
     const record = await this.prisma.department.findFirst({ where: { label }, include: { site: true } });

--- a/backend/adapters/repositories/PrismaPermissionRepository.ts
+++ b/backend/adapters/repositories/PrismaPermissionRepository.ts
@@ -23,6 +23,12 @@ export class PrismaPermissionRepository implements PermissionRepositoryPort {
     return record ? this.mapRecord(record) : null;
   }
 
+  async findAll(): Promise<Permission[]> {
+    this.logger.debug('Permission findAll', getContext());
+    const records = await this.prisma.permission.findMany();
+    return records.map(r => this.mapRecord(r));
+  }
+
   async findByKey(permissionKey: string): Promise<Permission | null> {
     this.logger.debug('Permission findByKey', getContext());
     const record = await this.prisma.permission.findFirst({ where: { permissionKey } });

--- a/backend/adapters/repositories/PrismaRoleRepository.ts
+++ b/backend/adapters/repositories/PrismaRoleRepository.ts
@@ -23,6 +23,12 @@ export class PrismaRoleRepository implements RoleRepositoryPort {
     return record ? this.mapRecord(record) : null;
   }
 
+  async findAll(): Promise<Role[]> {
+    this.logger.debug('Role findAll', getContext());
+    const records = await this.prisma.role.findMany();
+    return records.map(r => this.mapRecord(r));
+  }
+
   async findByLabel(label: string): Promise<Role | null> {
     this.logger.debug('Role findByLabel', getContext());
     const record = await this.prisma.role.findFirst({ where: { label } });

--- a/backend/adapters/repositories/PrismaSiteRepository.ts
+++ b/backend/adapters/repositories/PrismaSiteRepository.ts
@@ -23,6 +23,12 @@ export class PrismaSiteRepository implements SiteRepositoryPort {
     return record ? this.mapRecord(record) : null;
   }
 
+  async findAll(): Promise<Site[]> {
+    this.logger.debug('Site findAll', getContext());
+    const records = await this.prisma.site.findMany();
+    return records.map(r => this.mapRecord(r));
+  }
+
   async findByLabel(label: string): Promise<Site | null> {
     this.logger.debug('Site findByLabel', getContext());
     const record = await this.prisma.site.findFirst({ where: { label } });

--- a/backend/adapters/repositories/PrismaUserRepository.ts
+++ b/backend/adapters/repositories/PrismaUserRepository.ts
@@ -58,6 +58,19 @@ export class PrismaUserRepository implements UserRepositoryPort {
     return record ? this.mapRecord(record) : null;
   }
 
+  async findAll(): Promise<User[]> {
+    this.logger.debug('User findAll', getContext());
+    const records = await this.prisma.user.findMany({
+      include: {
+        roles: { include: { role: true } },
+        department: { include: { site: true } },
+        site: true,
+        permissions: { include: { permission: true } },
+      },
+    });
+    return records.map(r => this.mapRecord(r));
+  }
+
   async findByEmail(email: string): Promise<User | null> {
     this.logger.debug('User findByEmail', getContext());
     const record = await this.prisma.user.findUnique({

--- a/backend/domain/ports/DepartmentRepositoryPort.ts
+++ b/backend/domain/ports/DepartmentRepositoryPort.ts
@@ -13,6 +13,13 @@ export interface DepartmentRepositoryPort {
   findById(id: string): Promise<Department | null>;
 
   /**
+   * Retrieve all departments.
+   *
+   * @returns Array of all {@link Department} instances.
+   */
+  findAll(): Promise<Department[]>;
+
+  /**
    * Retrieve a department by its label.
    *
    * @param label - Label of the department to search for.

--- a/backend/domain/ports/PermissionRepositoryPort.ts
+++ b/backend/domain/ports/PermissionRepositoryPort.ts
@@ -13,6 +13,13 @@ export interface PermissionRepositoryPort {
   findById(id: string): Promise<Permission | null>;
 
   /**
+   * Retrieve all permissions.
+   *
+   * @returns Array of all available {@link Permission} instances.
+   */
+  findAll(): Promise<Permission[]>;
+
+  /**
    * Retrieve a permission by its key.
    *
    * @param permissionKey - Key of the permission to search for.

--- a/backend/domain/ports/RoleRepositoryPort.ts
+++ b/backend/domain/ports/RoleRepositoryPort.ts
@@ -13,6 +13,13 @@ export interface RoleRepositoryPort {
   findById(id: string): Promise<Role | null>;
 
   /**
+   * Retrieve all roles.
+   *
+   * @returns Array of available {@link Role} instances.
+   */
+  findAll(): Promise<Role[]>;
+
+  /**
    * Retrieve a role by its label.
    *
    * @param label - Label of the role to search for.

--- a/backend/domain/ports/SiteRepositoryPort.ts
+++ b/backend/domain/ports/SiteRepositoryPort.ts
@@ -13,6 +13,13 @@ export interface SiteRepositoryPort {
   findById(id: string): Promise<Site | null>;
 
   /**
+   * Retrieve all sites.
+   *
+   * @returns Array of registered {@link Site} instances.
+   */
+  findAll(): Promise<Site[]>;
+
+  /**
    * Retrieve a site by its label.
    *
    * @param label - Label of the site to search for.

--- a/backend/domain/ports/UserRepositoryPort.ts
+++ b/backend/domain/ports/UserRepositoryPort.ts
@@ -13,6 +13,13 @@ export interface UserRepositoryPort {
   findById(id: string): Promise<User | null>;
 
   /**
+   * Retrieve all users.
+   *
+   * @returns Array of every stored {@link User}.
+   */
+  findAll(): Promise<User[]>;
+
+  /**
    * Retrieve a user by their email address.
    *
    * @param email - Email to search for.

--- a/backend/tests/adapters/controllers/rest/departmentController.test.ts
+++ b/backend/tests/adapters/controllers/rest/departmentController.test.ts
@@ -44,6 +44,26 @@ describe('Department REST controller', () => {
     app.use('/api', createDepartmentRouter(deptRepo, userRepo, logger));
   });
 
+  it('should list departments', async () => {
+    deptRepo.findAll.mockResolvedValue([department]);
+
+    const res = await request(app).get('/api/departments');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'd', label: 'Dept', parentDepartmentId: null, managerUserId: null, site: { id: 's', label: 'Site' }, permissions: [] }]);
+    expect(deptRepo.findAll).toHaveBeenCalled();
+  });
+
+  it('should get department by id', async () => {
+    deptRepo.findById.mockResolvedValue(department);
+
+    const res = await request(app).get('/api/departments/d');
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('d');
+    expect(deptRepo.findById).toHaveBeenCalledWith('d');
+  });
+
   it('should create a department', async () => {
     const res = await request(app)
       .post('/api/departments')

--- a/backend/tests/adapters/controllers/rest/permissionController.test.ts
+++ b/backend/tests/adapters/controllers/rest/permissionController.test.ts
@@ -24,6 +24,26 @@ describe('Permission REST controller', () => {
     app.use('/api', createPermissionRouter(repo, logger));
   });
 
+  it('should list permissions', async () => {
+    repo.findAll.mockResolvedValue([permission]);
+
+    const res = await request(app).get('/api/permissions');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'p', permissionKey: 'KEY', description: 'desc' }]);
+    expect(repo.findAll).toHaveBeenCalled();
+  });
+
+  it('should get permission by id', async () => {
+    repo.findById.mockResolvedValue(permission);
+
+    const res = await request(app).get('/api/permissions/p');
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('p');
+    expect(repo.findById).toHaveBeenCalledWith('p');
+  });
+
   it('should create a permission', async () => {
     const res = await request(app)
       .post('/api/permissions')

--- a/backend/tests/adapters/controllers/rest/roleController.test.ts
+++ b/backend/tests/adapters/controllers/rest/roleController.test.ts
@@ -32,6 +32,26 @@ describe('Role REST controller', () => {
     app.use('/api', createRoleRouter(roleRepo, userRepo, logger));
   });
 
+  it('should list roles', async () => {
+    roleRepo.findAll.mockResolvedValue([role]);
+
+    const res = await request(app).get('/api/roles');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'r', label: 'Role', permissions: [{ id: 'p', permissionKey: 'P', description: 'desc' }] }]);
+    expect(roleRepo.findAll).toHaveBeenCalled();
+  });
+
+  it('should get role by id', async () => {
+    roleRepo.findById.mockResolvedValue(role);
+
+    const res = await request(app).get('/api/roles/r');
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('r');
+    expect(roleRepo.findById).toHaveBeenCalledWith('r');
+  });
+
   it('should create a role', async () => {
     const res = await request(app)
       .post('/api/roles')

--- a/backend/tests/adapters/controllers/rest/siteController.test.ts
+++ b/backend/tests/adapters/controllers/rest/siteController.test.ts
@@ -30,6 +30,26 @@ describe('Site REST controller', () => {
     app.use('/api', createSiteRouter(siteRepo, userRepo, deptRepo, logger));
   });
 
+  it('should list sites', async () => {
+    siteRepo.findAll.mockResolvedValue([site]);
+
+    const res = await request(app).get('/api/sites');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 's', label: 'Site' }]);
+    expect(siteRepo.findAll).toHaveBeenCalled();
+  });
+
+  it('should get site by id', async () => {
+    siteRepo.findById.mockResolvedValue(site);
+
+    const res = await request(app).get('/api/sites/s');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 's', label: 'Site' });
+    expect(siteRepo.findById).toHaveBeenCalledWith('s');
+  });
+
   it('should create a site', async () => {
     siteRepo.create.mockResolvedValue(site);
 

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -161,6 +161,30 @@ describe('User REST controller', () => {
     expect(auth.resetPassword).toHaveBeenCalledWith('tok', 'new');
   });
 
+  it('should list users', async () => {
+    repo.findAll.mockResolvedValue([user]);
+
+    const res = await request(app)
+      .get('/api/users')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].id).toBe('u');
+    expect(repo.findAll).toHaveBeenCalled();
+  });
+
+  it('should get user by id', async () => {
+    repo.findById.mockResolvedValue(user);
+
+    const res = await request(app)
+      .get('/api/users/u')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('u');
+    expect(repo.findById).toHaveBeenCalledWith('u');
+  });
+
   it('should update user profile', async () => {
     const res = await request(app)
       .put('/api/users/u')

--- a/backend/tests/domain/ports/DepartmentRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/DepartmentRepositoryPort.test.ts
@@ -15,6 +15,10 @@ class MockDepartmentRepository implements DepartmentRepositoryPort {
     return id ? this.depts.get(id) || null : null;
   }
 
+  async findAll(): Promise<Department[]> {
+    return Array.from(this.depts.values());
+  }
+
   async create(dept: Department): Promise<Department> {
     this.depts.set(dept.id, dept);
     this.labelIndex.set(dept.label, dept.id);
@@ -76,6 +80,7 @@ describe('DepartmentRepositoryPort Interface', () => {
     expect(await repo.findById('dept-1')).toEqual(dept);
     expect(await repo.findByLabel('IT')).toEqual(dept);
     expect((await repo.findById('dept-1'))?.site).toBe(site);
+    expect(await repo.findAll()).toEqual([dept]);
   });
 
   it('should update an existing department', async () => {
@@ -95,6 +100,13 @@ describe('DepartmentRepositoryPort Interface', () => {
 
     const result = await repo.findBySiteId('site-1');
     expect(result).toEqual([dept]);
+  });
+
+  it('should list all departments', async () => {
+    await repo.create(dept);
+    const dept2 = new Department('dept-2', 'HR', null, null, site);
+    await repo.create(dept2);
+    expect(await repo.findAll()).toEqual([dept, dept2]);
   });
 
   it('should delete a department', async () => {

--- a/backend/tests/domain/ports/PermissionRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/PermissionRepositoryPort.test.ts
@@ -14,6 +14,10 @@ class MockPermissionRepository implements PermissionRepositoryPort {
     return id ? this.permissions.get(id) || null : null;
   }
 
+  async findAll(): Promise<Permission[]> {
+    return Array.from(this.permissions.values());
+  }
+
   async create(permission: Permission): Promise<Permission> {
     this.permissions.set(permission.id, permission);
     this.keyIndex.set(permission.permissionKey, permission.id);
@@ -62,6 +66,7 @@ describe('PermissionRepositoryPort Interface', () => {
     await repo.create(perm);
     expect(await repo.findById('perm-1')).toEqual(perm);
     expect(await repo.findByKey('READ')).toEqual(perm);
+    expect(await repo.findAll()).toEqual([perm]);
   });
 
   it('should update an existing permission', async () => {
@@ -77,5 +82,12 @@ describe('PermissionRepositoryPort Interface', () => {
     await repo.create(perm);
     await repo.delete('perm-1');
     expect(await repo.findById('perm-1')).toBeNull();
+  });
+
+  it('should list all permissions', async () => {
+    await repo.create(perm);
+    const perm2 = new Permission('perm-2', 'WRITE', 'Write');
+    await repo.create(perm2);
+    expect(await repo.findAll()).toEqual([perm, perm2]);
   });
 });

--- a/backend/tests/domain/ports/RoleRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/RoleRepositoryPort.test.ts
@@ -15,6 +15,10 @@ class MockRoleRepository implements RoleRepositoryPort {
     return roleId ? this.roles.get(roleId) || null : null;
   }
 
+  async findAll(): Promise<Role[]> {
+    return Array.from(this.roles.values());
+  }
+
   async create(role: Role): Promise<Role> {
     this.roles.set(role.id, role);
     this.labelIndex.set(role.label, role.id);
@@ -71,6 +75,7 @@ describe('RoleRepositoryPort Interface', () => {
 
       expect(foundById).toEqual(adminRole);
       expect(foundByLabel).toEqual(adminRole);
+      expect(await repository.findAll()).toEqual([adminRole]);
     });
   });
 
@@ -98,6 +103,13 @@ describe('RoleRepositoryPort Interface', () => {
       expect(await repository.findById('role-1')).toBeNull();
       expect(await repository.findByLabel('Admin')).toBeNull();
     });
+  });
+
+  it('should list all roles', async () => {
+    await repository.create(adminRole);
+    const other = new Role('role-2', 'User');
+    await repository.create(other);
+    expect(await repository.findAll()).toEqual([adminRole, other]);
   });
 
   describe('integration scenario', () => {

--- a/backend/tests/domain/ports/SiteRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/SiteRepositoryPort.test.ts
@@ -14,6 +14,10 @@ class MockSiteRepository implements SiteRepositoryPort {
     return id ? this.sites.get(id) || null : null;
   }
 
+  async findAll(): Promise<Site[]> {
+    return Array.from(this.sites.values());
+  }
+
   async create(site: Site): Promise<Site> {
     this.sites.set(site.id, site);
     this.labelIndex.set(site.label, site.id);
@@ -62,6 +66,7 @@ describe('SiteRepositoryPort Interface', () => {
     await repo.create(site);
     expect(await repo.findById('site-1')).toEqual(site);
     expect(await repo.findByLabel('HQ')).toEqual(site);
+    expect(await repo.findAll()).toEqual([site]);
   });
 
   it('should update an existing site', async () => {
@@ -76,5 +81,12 @@ describe('SiteRepositoryPort Interface', () => {
     await repo.create(site);
     await repo.delete('site-1');
     expect(await repo.findById('site-1')).toBeNull();
+  });
+
+  it('should list all sites', async () => {
+    await repo.create(site);
+    const other = new Site('s2', 'Branch');
+    await repo.create(other);
+    expect(await repo.findAll()).toEqual([site, other]);
   });
 });

--- a/backend/tests/domain/ports/UserRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/UserRepositoryPort.test.ts
@@ -14,6 +14,10 @@ class MockUserRepository implements UserRepositoryPort {
     return this.users.get(id) || null;
   }
 
+  async findAll(): Promise<User[]> {
+    return Array.from(this.users.values());
+  }
+
   async findByEmail(email: string): Promise<User | null> {
     const userId = this.emailIndex.get(email);
     return userId ? this.users.get(userId) || null : null;
@@ -138,6 +142,7 @@ describe('UserRepositoryPort Interface', () => {
       expect(result).toEqual(testUser);
       expect(result.id).toBe('user-123');
       expect(result.email).toBe('john.doe@example.com');
+      expect(await repository.findAll()).toEqual([testUser]);
     });
 
     it('should allow creating multiple users', async () => {
@@ -268,6 +273,13 @@ describe('UserRepositoryPort Interface', () => {
 
       expect(result).toEqual([]);
     });
+  });
+
+  it('should list all users', async () => {
+    await repository.create(testUser);
+    const user2 = new User('user-2', 'Jane', 'Smith', 'jane@example.com', [], 'active', department, site);
+    await repository.create(user2);
+    expect(await repository.findAll()).toEqual([testUser, user2]);
   });
 
   describe('update', () => {

--- a/backend/tests/usecases/GetSiteUseCase.test.ts
+++ b/backend/tests/usecases/GetSiteUseCase.test.ts
@@ -1,0 +1,25 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetSiteUseCase } from '../../usecases/site/GetSiteUseCase';
+import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../domain/entities/Site';
+
+describe('GetSiteUseCase', () => {
+  let repository: DeepMockProxy<SiteRepositoryPort>;
+  let useCase: GetSiteUseCase;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<SiteRepositoryPort>();
+    useCase = new GetSiteUseCase(repository);
+    site = new Site('s', 'Site');
+  });
+
+  it('should return site by id', async () => {
+    repository.findById.mockResolvedValue(site);
+
+    const result = await useCase.execute('s');
+
+    expect(result).toBe(site);
+    expect(repository.findById).toHaveBeenCalledWith('s');
+  });
+});

--- a/backend/tests/usecases/GetSitesUseCase.test.ts
+++ b/backend/tests/usecases/GetSitesUseCase.test.ts
@@ -1,0 +1,25 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetSitesUseCase } from '../../usecases/site/GetSitesUseCase';
+import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../domain/entities/Site';
+
+describe('GetSitesUseCase', () => {
+  let repository: DeepMockProxy<SiteRepositoryPort>;
+  let useCase: GetSitesUseCase;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<SiteRepositoryPort>();
+    useCase = new GetSitesUseCase(repository);
+    site = new Site('s', 'Site');
+  });
+
+  it('should return sites from repository', async () => {
+    repository.findAll.mockResolvedValue([site]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([site]);
+    expect(repository.findAll).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/department/GetDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentUseCase.test.ts
@@ -1,0 +1,28 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetDepartmentUseCase } from '../../../usecases/department/GetDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('GetDepartmentUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: GetDepartmentUseCase;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new GetDepartmentUseCase(repository);
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+  });
+
+  it('should return a department by id', async () => {
+    repository.findById.mockResolvedValue(department);
+
+    const result = await useCase.execute('d');
+
+    expect(result).toBe(department);
+    expect(repository.findById).toHaveBeenCalledWith('d');
+  });
+});

--- a/backend/tests/usecases/department/GetDepartmentsUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentsUseCase.test.ts
@@ -1,0 +1,28 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetDepartmentsUseCase } from '../../../usecases/department/GetDepartmentsUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('GetDepartmentsUseCase', () => {
+  let repository: DeepMockProxy<DepartmentRepositoryPort>;
+  let useCase: GetDepartmentsUseCase;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<DepartmentRepositoryPort>();
+    useCase = new GetDepartmentsUseCase(repository);
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+  });
+
+  it('should return departments from repository', async () => {
+    repository.findAll.mockResolvedValue([department]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([department]);
+    expect(repository.findAll).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/permission/GetPermissionUseCase.test.ts
+++ b/backend/tests/usecases/permission/GetPermissionUseCase.test.ts
@@ -1,0 +1,25 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetPermissionUseCase } from '../../../usecases/permission/GetPermissionUseCase';
+import { PermissionRepositoryPort } from '../../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../../domain/entities/Permission';
+
+describe('GetPermissionUseCase', () => {
+  let repository: DeepMockProxy<PermissionRepositoryPort>;
+  let useCase: GetPermissionUseCase;
+  let perm: Permission;
+
+  beforeEach(() => {
+    repository = mockDeep<PermissionRepositoryPort>();
+    useCase = new GetPermissionUseCase(repository);
+    perm = new Permission('p', 'READ', 'desc');
+  });
+
+  it('should return permission by id', async () => {
+    repository.findById.mockResolvedValue(perm);
+
+    const result = await useCase.execute('p');
+
+    expect(result).toBe(perm);
+    expect(repository.findById).toHaveBeenCalledWith('p');
+  });
+});

--- a/backend/tests/usecases/permission/GetPermissionsUseCase.test.ts
+++ b/backend/tests/usecases/permission/GetPermissionsUseCase.test.ts
@@ -1,0 +1,25 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetPermissionsUseCase } from '../../../usecases/permission/GetPermissionsUseCase';
+import { PermissionRepositoryPort } from '../../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../../domain/entities/Permission';
+
+describe('GetPermissionsUseCase', () => {
+  let repository: DeepMockProxy<PermissionRepositoryPort>;
+  let useCase: GetPermissionsUseCase;
+  let perm: Permission;
+
+  beforeEach(() => {
+    repository = mockDeep<PermissionRepositoryPort>();
+    useCase = new GetPermissionsUseCase(repository);
+    perm = new Permission('p', 'READ', 'desc');
+  });
+
+  it('should return permissions from repository', async () => {
+    repository.findAll.mockResolvedValue([perm]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([perm]);
+    expect(repository.findAll).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/role/GetRoleUseCase.test.ts
+++ b/backend/tests/usecases/role/GetRoleUseCase.test.ts
@@ -1,0 +1,25 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetRoleUseCase } from '../../../usecases/role/GetRoleUseCase';
+import { RoleRepositoryPort } from '../../../domain/ports/RoleRepositoryPort';
+import { Role } from '../../../domain/entities/Role';
+
+describe('GetRoleUseCase', () => {
+  let repository: DeepMockProxy<RoleRepositoryPort>;
+  let useCase: GetRoleUseCase;
+  let role: Role;
+
+  beforeEach(() => {
+    repository = mockDeep<RoleRepositoryPort>();
+    useCase = new GetRoleUseCase(repository);
+    role = new Role('r', 'Role');
+  });
+
+  it('should return role by id', async () => {
+    repository.findById.mockResolvedValue(role);
+
+    const result = await useCase.execute('r');
+
+    expect(result).toBe(role);
+    expect(repository.findById).toHaveBeenCalledWith('r');
+  });
+});

--- a/backend/tests/usecases/role/GetRolesUseCase.test.ts
+++ b/backend/tests/usecases/role/GetRolesUseCase.test.ts
@@ -1,0 +1,25 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetRolesUseCase } from '../../../usecases/role/GetRolesUseCase';
+import { RoleRepositoryPort } from '../../../domain/ports/RoleRepositoryPort';
+import { Role } from '../../../domain/entities/Role';
+
+describe('GetRolesUseCase', () => {
+  let repository: DeepMockProxy<RoleRepositoryPort>;
+  let useCase: GetRolesUseCase;
+  let role: Role;
+
+  beforeEach(() => {
+    repository = mockDeep<RoleRepositoryPort>();
+    useCase = new GetRolesUseCase(repository);
+    role = new Role('r', 'Role');
+  });
+
+  it('should return roles from repository', async () => {
+    repository.findAll.mockResolvedValue([role]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([role]);
+    expect(repository.findAll).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/user/GetUserUseCase.test.ts
+++ b/backend/tests/usecases/user/GetUserUseCase.test.ts
@@ -1,0 +1,34 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetUserUseCase } from '../../../usecases/user/GetUserUseCase';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('GetUserUseCase', () => {
+  let repository: DeepMockProxy<UserRepositoryPort>;
+  let useCase: GetUserUseCase;
+  let user: User;
+  let role: Role;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<UserRepositoryPort>();
+    useCase = new GetUserUseCase(repository);
+    role = new Role('r', 'Role');
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'John', 'Doe', 'j@example.com', [role], 'active', department, site);
+  });
+
+  it('should return user by id', async () => {
+    repository.findById.mockResolvedValue(user);
+
+    const result = await useCase.execute('u');
+
+    expect(result).toBe(user);
+    expect(repository.findById).toHaveBeenCalledWith('u');
+  });
+});

--- a/backend/tests/usecases/user/GetUsersUseCase.test.ts
+++ b/backend/tests/usecases/user/GetUsersUseCase.test.ts
@@ -1,0 +1,34 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetUsersUseCase } from '../../../usecases/user/GetUsersUseCase';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('GetUsersUseCase', () => {
+  let repository: DeepMockProxy<UserRepositoryPort>;
+  let useCase: GetUsersUseCase;
+  let user: User;
+  let role: Role;
+  let department: Department;
+  let site: Site;
+
+  beforeEach(() => {
+    repository = mockDeep<UserRepositoryPort>();
+    useCase = new GetUsersUseCase(repository);
+    role = new Role('r', 'Role');
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'John', 'Doe', 'j@example.com', [role], 'active', department, site);
+  });
+
+  it('should return users from repository', async () => {
+    repository.findAll.mockResolvedValue([user]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([user]);
+    expect(repository.findAll).toHaveBeenCalled();
+  });
+});

--- a/backend/usecases/department/GetDepartmentUseCase.ts
+++ b/backend/usecases/department/GetDepartmentUseCase.ts
@@ -1,0 +1,19 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for retrieving a single department by id.
+ */
+export class GetDepartmentUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param id - Identifier of the department to fetch.
+   * @returns The corresponding {@link Department} or `null` if not found.
+   */
+  async execute(id: string): Promise<Department | null> {
+    return this.departmentRepository.findById(id);
+  }
+}

--- a/backend/usecases/department/GetDepartmentsUseCase.ts
+++ b/backend/usecases/department/GetDepartmentsUseCase.ts
@@ -1,0 +1,18 @@
+import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../domain/entities/Department';
+
+/**
+ * Use case for retrieving all departments.
+ */
+export class GetDepartmentsUseCase {
+  constructor(private readonly departmentRepository: DepartmentRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @returns Array of {@link Department} instances.
+   */
+  async execute(): Promise<Department[]> {
+    return this.departmentRepository.findAll();
+  }
+}

--- a/backend/usecases/permission/GetPermissionUseCase.ts
+++ b/backend/usecases/permission/GetPermissionUseCase.ts
@@ -1,0 +1,19 @@
+import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../domain/entities/Permission';
+
+/**
+ * Use case for retrieving a permission by id.
+ */
+export class GetPermissionUseCase {
+  constructor(private readonly permissionRepository: PermissionRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param id - Identifier of the permission to fetch.
+   * @returns The corresponding {@link Permission} or `null` if not found.
+   */
+  async execute(id: string): Promise<Permission | null> {
+    return this.permissionRepository.findById(id);
+  }
+}

--- a/backend/usecases/permission/GetPermissionsUseCase.ts
+++ b/backend/usecases/permission/GetPermissionsUseCase.ts
@@ -1,0 +1,18 @@
+import { PermissionRepositoryPort } from '../../domain/ports/PermissionRepositoryPort';
+import { Permission } from '../../domain/entities/Permission';
+
+/**
+ * Use case for listing all permissions.
+ */
+export class GetPermissionsUseCase {
+  constructor(private readonly permissionRepository: PermissionRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @returns Array of {@link Permission} instances.
+   */
+  async execute(): Promise<Permission[]> {
+    return this.permissionRepository.findAll();
+  }
+}

--- a/backend/usecases/role/GetRoleUseCase.ts
+++ b/backend/usecases/role/GetRoleUseCase.ts
@@ -1,0 +1,19 @@
+import { RoleRepositoryPort } from '../../domain/ports/RoleRepositoryPort';
+import { Role } from '../../domain/entities/Role';
+
+/**
+ * Use case for retrieving a role by id.
+ */
+export class GetRoleUseCase {
+  constructor(private readonly roleRepository: RoleRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param id - Identifier of the role to fetch.
+   * @returns The corresponding {@link Role} or `null` if not found.
+   */
+  async execute(id: string): Promise<Role | null> {
+    return this.roleRepository.findById(id);
+  }
+}

--- a/backend/usecases/role/GetRolesUseCase.ts
+++ b/backend/usecases/role/GetRolesUseCase.ts
@@ -1,0 +1,18 @@
+import { RoleRepositoryPort } from '../../domain/ports/RoleRepositoryPort';
+import { Role } from '../../domain/entities/Role';
+
+/**
+ * Use case for retrieving all roles.
+ */
+export class GetRolesUseCase {
+  constructor(private readonly roleRepository: RoleRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @returns Array of {@link Role} instances.
+   */
+  async execute(): Promise<Role[]> {
+    return this.roleRepository.findAll();
+  }
+}

--- a/backend/usecases/site/GetSiteUseCase.ts
+++ b/backend/usecases/site/GetSiteUseCase.ts
@@ -1,0 +1,19 @@
+import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../domain/entities/Site';
+
+/**
+ * Use case for retrieving a site by id.
+ */
+export class GetSiteUseCase {
+  constructor(private readonly siteRepository: SiteRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param id - Identifier of the site.
+   * @returns The corresponding {@link Site} or `null` if not found.
+   */
+  async execute(id: string): Promise<Site | null> {
+    return this.siteRepository.findById(id);
+  }
+}

--- a/backend/usecases/site/GetSitesUseCase.ts
+++ b/backend/usecases/site/GetSitesUseCase.ts
@@ -1,0 +1,18 @@
+import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../domain/entities/Site';
+
+/**
+ * Use case for listing all sites.
+ */
+export class GetSitesUseCase {
+  constructor(private readonly siteRepository: SiteRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @returns Array of {@link Site} instances.
+   */
+  async execute(): Promise<Site[]> {
+    return this.siteRepository.findAll();
+  }
+}

--- a/backend/usecases/user/GetUserUseCase.ts
+++ b/backend/usecases/user/GetUserUseCase.ts
@@ -1,0 +1,19 @@
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { User } from '../../domain/entities/User';
+
+/**
+ * Use case for retrieving a user by id.
+ */
+export class GetUserUseCase {
+  constructor(private readonly userRepository: UserRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param id - Identifier of the user to fetch.
+   * @returns The corresponding {@link User} or `null` if not found.
+   */
+  async execute(id: string): Promise<User | null> {
+    return this.userRepository.findById(id);
+  }
+}

--- a/backend/usecases/user/GetUsersUseCase.ts
+++ b/backend/usecases/user/GetUsersUseCase.ts
@@ -1,0 +1,18 @@
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { User } from '../../domain/entities/User';
+
+/**
+ * Use case for retrieving all users.
+ */
+export class GetUsersUseCase {
+  constructor(private readonly userRepository: UserRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @returns Array of {@link User} instances.
+   */
+  async execute(): Promise<User[]> {
+    return this.userRepository.findAll();
+  }
+}


### PR DESCRIPTION
## Summary
- add `findAll` to repository ports and Prisma implementations
- implement get/list usecases
- add GET collection and item routes for departments, permissions, roles, sites and users
- document routes with OpenAPI JSDoc
- test new usecases, ports and controllers

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882662ec84083238c491868ea8e8e5c