### PR TITLE
Block suspended or archived users from logging in

### DIFF
--- a/backend/adapters/auth/JWTAuthServiceAdapter.ts
+++ b/backend/adapters/auth/JWTAuthServiceAdapter.ts
@@ -28,6 +28,9 @@ export class JWTAuthServiceAdapter implements AuthServicePort {
     if (!user) {
       throw new Error('Invalid credentials');
     }
+    if (user.status === 'archived' || user.status === 'suspended') {
+      throw new Error('User account is suspended or archived');
+    }
     return user;
   }
 
@@ -55,6 +58,9 @@ export class JWTAuthServiceAdapter implements AuthServicePort {
     const user = await this.userRepository.findById(userId);
     if (!user) {
       throw new Error('Invalid token');
+    }
+    if (user.status === 'archived' || user.status === 'suspended') {
+      throw new Error('User account is suspended or archived');
     }
     return user;
   }

--- a/backend/adapters/auth/OIDCAuthServiceAdapter.ts
+++ b/backend/adapters/auth/OIDCAuthServiceAdapter.ts
@@ -59,6 +59,9 @@ export class OIDCAuthServiceAdapter implements AuthServicePort {
     if (!user) {
       throw new Error('Invalid token');
     }
+    if (user.status === 'archived' || user.status === 'suspended') {
+      throw new Error('User account is suspended or archived');
+    }
     return user;
   }
 }

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -284,12 +284,14 @@ export function createUserRouter(
    *               - email
    *               - password
    *     responses:
- *       200:
- *         description: User successfully authenticated
+   *       200:
+   *         description: User successfully authenticated
    *         content:
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/User'
+   *       403:
+   *         description: User account is suspended or archived
    */
   router.post('/auth/login', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /auth/login', getContext());
@@ -301,7 +303,10 @@ export function createUserRouter(
       res.json(user);
     } catch (err) {
       logger.warn('Authentication failed', { ...getContext(), error: err });
-      res.status(401).json({ error: (err as Error).message });
+      const message = (err as Error).message;
+      const status =
+        message === 'User account is suspended or archived' ? 403 : 401;
+      res.status(status).json({ error: message });
     }
   });
 
@@ -331,12 +336,14 @@ export function createUserRouter(
    *               - provider
    *               - token
    *     responses:
- *       200:
- *         description: User successfully authenticated with the provider
+   *       200:
+   *         description: User successfully authenticated with the provider
    *         content:
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/User'
+   *       403:
+   *         description: User account is suspended or archived
    */
   router.post('/auth/provider', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /auth/provider', getContext());
@@ -348,7 +355,10 @@ export function createUserRouter(
       res.json(user);
     } catch (err) {
       logger.warn('Provider auth failed', { ...getContext(), error: err });
-      res.status(401).json({ error: (err as Error).message });
+      const message = (err as Error).message;
+      const status =
+        message === 'User account is suspended or archived' ? 403 : 401;
+      res.status(status).json({ error: message });
     }
   });
 

--- a/backend/tests/adapters/auth/OIDCAuthServiceAdapter.test.ts
+++ b/backend/tests/adapters/auth/OIDCAuthServiceAdapter.test.ts
@@ -50,6 +50,19 @@ describe('OIDCAuthServiceAdapter', () => {
     await expect(adapter.verifyToken(token)).rejects.toThrow('Invalid token');
   });
 
+  it('should reject suspended or archived users', async () => {
+    const token = jwt.sign({}, secret, { algorithm: 'HS256', issuer: 'issuer', subject: 'u' });
+    repo.findById.mockResolvedValue(user);
+    user.status = 'suspended';
+    await expect(adapter.verifyToken(token)).rejects.toThrow(
+      'User account is suspended or archived',
+    );
+    user.status = 'archived';
+    await expect(adapter.verifyToken(token)).rejects.toThrow(
+      'User account is suspended or archived',
+    );
+  });
+
   it('should delegate authenticateWithProvider', async () => {
     const token = jwt.sign({}, secret, { algorithm: 'HS256', issuer: 'issuer', subject: 'u' });
     repo.findById.mockResolvedValue(user);

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -124,6 +124,19 @@ describe('User REST controller', () => {
     expect(res.status).toBe(401);
   });
 
+  it('should return 403 when user account is suspended', async () => {
+    auth.authenticate.mockRejectedValue(
+      new Error('User account is suspended or archived'),
+    );
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'john@example.com', password: 'secret' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('User account is suspended or archived');
+  });
+
   it('should authenticate with provider', async () => {
     const res = await request(app)
       .post('/api/auth/provider')
@@ -141,6 +154,19 @@ describe('User REST controller', () => {
       .send({ provider: 'oidc', token: 'bad' });
 
     expect(res.status).toBe(401);
+  });
+
+  it('should return 403 when provider account is suspended', async () => {
+    auth.authenticateWithProvider.mockRejectedValue(
+      new Error('User account is suspended or archived'),
+    );
+
+    const res = await request(app)
+      .post('/api/auth/provider')
+      .send({ provider: 'oidc', token: 'bad' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('User account is suspended or archived');
   });
 
   it('should request password reset', async () => {


### PR DESCRIPTION
## Summary
- prevent suspended or archived users from authenticating
- handle suspended/archived errors in login routes and swagger docs
- document auth failure in REST controller
- test auth adapters and REST controller for blocked users

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882835e68d88323b1763c8479dca105