### PR TITLE
Implement multiple responsible users in groups

### DIFF
--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -29,7 +29,7 @@ model User {
   permissions        UserPermission[]
   managedDepartments Department[] @relation("DepartmentManager")
   groups            UserGroupMember[]
-  responsibleGroups UserGroup[] @relation("Responsible")
+  responsibleGroups UserGroupResponsible[]
 }
 
 model Role {
@@ -106,12 +106,11 @@ model Site {
 }
 
 model UserGroup {
-  id               String   @id @default(uuid())
-  name             String
-  description      String?
-  responsibleUser  User     @relation("Responsible", fields: [responsibleUserId], references: [id])
-  responsibleUserId String
-  members          UserGroupMember[]
+  id          String   @id @default(uuid())
+  name        String
+  description String?
+  responsibles UserGroupResponsible[]
+  members     UserGroupMember[]
 }
 
 model UserGroupMember {
@@ -119,6 +118,15 @@ model UserGroupMember {
   userId   String
   group    UserGroup @relation(fields: [groupId], references: [id])
   groupId  String
+
+  @@id([userId, groupId])
+}
+
+model UserGroupResponsible {
+  user    User      @relation(fields: [userId], references: [id])
+  userId  String
+  group   UserGroup @relation(fields: [groupId], references: [id])
+  groupId String
 
   @@id([userId, groupId])
 }

--- a/backend/domain/entities/UserGroup.ts
+++ b/backend/domain/entities/UserGroup.ts
@@ -9,14 +9,14 @@ export class UserGroup {
    *
    * @param id - Unique identifier for the group.
    * @param name - Group name.
-   * @param responsibleUser - User responsible for the group.
+   * @param responsibleUsers - Users responsible for managing the group.
    * @param members - Users belonging to the group.
    * @param description - Optional description of the group.
    */
   constructor(
     public readonly id: string,
     public name: string,
-    public responsibleUser: User,
+    public responsibleUsers: User[] = [],
     public members: User[] = [],
     public description?: string,
   ) {}

--- a/backend/domain/ports/UserGroupRepositoryPort.ts
+++ b/backend/domain/ports/UserGroupRepositoryPort.ts
@@ -1,5 +1,7 @@
 import { UserGroup } from '../entities/UserGroup';
+import { User } from '../entities/User';
 import { ListParams, PaginatedResult } from '../dtos/PaginatedResult';
+import { UserFilters } from './UserRepositoryPort';
 
 /**
  * Filters for listing user groups.
@@ -76,4 +78,46 @@ export interface UserGroupRepositoryPort {
    * @returns The updated {@link UserGroup} or `null` if not found.
    */
   removeUser(groupId: string, userId: string): Promise<UserGroup | null>;
+
+  /**
+   * Add a responsible user to the group.
+   *
+   * @param groupId - Identifier of the group.
+   * @param userId - Identifier of the user to add as responsible.
+   * @returns The updated {@link UserGroup} or `null` if not found.
+   */
+  addResponsible(groupId: string, userId: string): Promise<UserGroup | null>;
+
+  /**
+   * Remove a responsible user from the group.
+   *
+   * @param groupId - Identifier of the group.
+   * @param userId - Identifier of the user to remove from responsibles.
+   * @returns The updated {@link UserGroup} or `null` if not found.
+   */
+  removeResponsible(groupId: string, userId: string): Promise<UserGroup | null>;
+
+  /**
+   * Retrieve members of the group with optional filters.
+   *
+   * @param groupId - Identifier of the group.
+   * @param params - Pagination and user filters.
+   * @returns Paginated list of {@link User}.
+   */
+  listMembers(
+    groupId: string,
+    params: ListParams & { filters?: UserFilters },
+  ): Promise<PaginatedResult<User>>;
+
+  /**
+   * Retrieve responsible users of the group with optional filters.
+   *
+   * @param groupId - Identifier of the group.
+   * @param params - Pagination and user filters.
+   * @returns Paginated list of responsible {@link User}.
+   */
+  listResponsibles(
+    groupId: string,
+    params: ListParams & { filters?: UserFilters },
+  ): Promise<PaginatedResult<User>>;
 }

--- a/backend/tests/adapters/controllers/rest/groupController.test.ts
+++ b/backend/tests/adapters/controllers/rest/groupController.test.ts
@@ -30,7 +30,7 @@ describe('Group REST controller', () => {
     dept = new Department('d', 'Dept', null, null, site);
     role = new Role('r', 'Role');
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
-    group = new UserGroup('g', 'Group', user, [user]);
+    group = new UserGroup('g', 'Group', [user], [user]);
     groupRepo.create.mockResolvedValue(group);
     groupRepo.findAll.mockResolvedValue([group]);
     groupRepo.findById.mockResolvedValue(group);
@@ -45,7 +45,7 @@ describe('Group REST controller', () => {
     const res = await request(app)
       .post('/api/groups')
       .set('Authorization', 'Bearer u')
-      .send({ id: 'g', name: 'Group' });
+      .send({ id: 'g', name: 'Group', responsibleIds: ['u'] });
     expect(res.status).toBe(201);
     expect(groupRepo.create).toHaveBeenCalled();
   });

--- a/backend/tests/domain/entities/UserGroup.test.ts
+++ b/backend/tests/domain/entities/UserGroup.test.ts
@@ -16,14 +16,14 @@ describe('UserGroup Entity', () => {
     department = new Department('d', 'Dept', null, null, site);
     role = new Role('r', 'Role');
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
-    group = new UserGroup('g', 'Group', user, [user], 'desc');
+    group = new UserGroup('g', 'Group', [user], [user], 'desc');
   });
 
   it('should construct a group with all properties', () => {
     expect(group.id).toBe('g');
     expect(group.name).toBe('Group');
     expect(group.description).toBe('desc');
-    expect(group.responsibleUser).toBe(user);
+    expect(group.responsibleUsers).toEqual([user]);
     expect(group.members).toEqual([user]);
   });
 
@@ -38,8 +38,9 @@ describe('UserGroup Entity', () => {
   });
 
   it('should use defaults when optional params omitted', () => {
-    const g = new UserGroup('id', 'label', user);
+    const g = new UserGroup('id', 'label');
     expect(g.members).toEqual([]);
+    expect(g.responsibleUsers).toEqual([]);
     expect(g.description).toBeUndefined();
   });
 });

--- a/backend/tests/usecases/CreateUserGroupUseCase.test.ts
+++ b/backend/tests/usecases/CreateUserGroupUseCase.test.ts
@@ -20,7 +20,7 @@ describe('CreateUserGroupUseCase', () => {
     const dept = new Department('d', 'Dept', null, null, site);
     const role = new Role('r', 'Role');
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
-    group = new UserGroup('g', 'Group', user, [user]);
+    group = new UserGroup('g', 'Group', [user], [user]);
   });
 
   it('should create group via repository', async () => {

--- a/backend/tests/usecases/userGroup/AddGroupResponsibleUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/AddGroupResponsibleUseCase.test.ts
@@ -1,5 +1,5 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { RemoveGroupUserUseCase } from '../../../usecases/userGroup/RemoveGroupUserUseCase';
+import { AddGroupResponsibleUseCase } from '../../../usecases/userGroup/AddGroupResponsibleUseCase';
 import { UserGroupRepositoryPort } from '../../../domain/ports/UserGroupRepositoryPort';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { UserGroup } from '../../../domain/entities/UserGroup';
@@ -8,10 +8,10 @@ import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
 
-describe('RemoveGroupUserUseCase', () => {
+describe('AddGroupResponsibleUseCase', () => {
   let groupRepo: DeepMockProxy<UserGroupRepositoryPort>;
   let userRepo: DeepMockProxy<UserRepositoryPort>;
-  let useCase: RemoveGroupUserUseCase;
+  let useCase: AddGroupResponsibleUseCase;
   let site: Site;
   let dept: Department;
   let role: Role;
@@ -21,7 +21,7 @@ describe('RemoveGroupUserUseCase', () => {
   beforeEach(() => {
     groupRepo = mockDeep<UserGroupRepositoryPort>();
     userRepo = mockDeep<UserRepositoryPort>();
-    useCase = new RemoveGroupUserUseCase(groupRepo, userRepo);
+    useCase = new AddGroupResponsibleUseCase(groupRepo, userRepo);
     site = new Site('s', 'Site');
     dept = new Department('d', 'Dept', null, null, site);
     role = new Role('r', 'Role');
@@ -29,15 +29,16 @@ describe('RemoveGroupUserUseCase', () => {
     group = new UserGroup('g', 'Group', [user], [user]);
   });
 
-  it('should remove user from group', async () => {
+  it('should add responsible to group', async () => {
+    const other = new User('u2', 'Jane', 'Doe', 'jane@example.com', [role], 'active', dept, site);
     groupRepo.findById.mockResolvedValue(group);
-    userRepo.findById.mockResolvedValue(user);
-    groupRepo.removeUser.mockResolvedValue(group);
+    userRepo.findById.mockResolvedValue(other);
+    groupRepo.addResponsible.mockResolvedValue(group);
 
-    const result = await useCase.execute('g', 'u');
+    const result = await useCase.execute('g', 'u2');
 
     expect(result).toBe(group);
-    expect(groupRepo.removeUser).toHaveBeenCalledWith('g', 'u');
+    expect(groupRepo.addResponsible).toHaveBeenCalledWith('g', 'u2');
   });
 
   it('should return null when group or user missing', async () => {
@@ -47,6 +48,6 @@ describe('RemoveGroupUserUseCase', () => {
     const result = await useCase.execute('g', 'u');
 
     expect(result).toBeNull();
-    expect(groupRepo.removeUser).not.toHaveBeenCalled();
+    expect(groupRepo.addResponsible).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/usecases/userGroup/AddGroupUserUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/AddGroupUserUseCase.test.ts
@@ -26,7 +26,7 @@ describe('AddGroupUserUseCase', () => {
     dept = new Department('d', 'Dept', null, null, site);
     role = new Role('r', 'Role');
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
-    group = new UserGroup('g', 'Group', user, [user]);
+    group = new UserGroup('g', 'Group', [user], [user]);
   });
 
   it('should add user to group', async () => {

--- a/backend/tests/usecases/userGroup/GetGroupMembersUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/GetGroupMembersUseCase.test.ts
@@ -1,0 +1,37 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetGroupMembersUseCase } from '../../../usecases/userGroup/GetGroupMembersUseCase';
+import { UserGroupRepositoryPort } from '../../../domain/ports/UserGroupRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+import { UserGroup } from '../../../domain/entities/UserGroup';
+
+describe('GetGroupMembersUseCase', () => {
+  let repository: DeepMockProxy<UserGroupRepositoryPort>;
+  let useCase: GetGroupMembersUseCase;
+  let site: Site;
+  let dept: Department;
+  let role: Role;
+  let user: User;
+  let group: UserGroup;
+
+  beforeEach(() => {
+    repository = mockDeep<UserGroupRepositoryPort>();
+    useCase = new GetGroupMembersUseCase(repository);
+    role = new Role('r', 'Role');
+    site = new Site('s', 'Site');
+    dept = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
+    group = new UserGroup('g', 'Group', [user], [user]);
+  });
+
+  it('should return members from repository', async () => {
+    repository.listMembers.mockResolvedValue({ items: [user], page: 1, limit: 20, total: 1 });
+
+    const result = await useCase.execute('g', { page: 1, limit: 20 });
+
+    expect(result.items).toEqual([user]);
+    expect(repository.listMembers).toHaveBeenCalledWith('g', { page: 1, limit: 20 });
+  });
+});

--- a/backend/tests/usecases/userGroup/GetGroupResponsiblesUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/GetGroupResponsiblesUseCase.test.ts
@@ -1,0 +1,37 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetGroupResponsiblesUseCase } from '../../../usecases/userGroup/GetGroupResponsiblesUseCase';
+import { UserGroupRepositoryPort } from '../../../domain/ports/UserGroupRepositoryPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+import { UserGroup } from '../../../domain/entities/UserGroup';
+
+describe('GetGroupResponsiblesUseCase', () => {
+  let repository: DeepMockProxy<UserGroupRepositoryPort>;
+  let useCase: GetGroupResponsiblesUseCase;
+  let site: Site;
+  let dept: Department;
+  let role: Role;
+  let user: User;
+  let group: UserGroup;
+
+  beforeEach(() => {
+    repository = mockDeep<UserGroupRepositoryPort>();
+    useCase = new GetGroupResponsiblesUseCase(repository);
+    role = new Role('r', 'Role');
+    site = new Site('s', 'Site');
+    dept = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
+    group = new UserGroup('g', 'Group', [user], [user]);
+  });
+
+  it('should return responsibles from repository', async () => {
+    repository.listResponsibles.mockResolvedValue({ items: [user], page: 1, limit: 20, total: 1 });
+
+    const result = await useCase.execute('g', { page: 1, limit: 20 });
+
+    expect(result.items).toEqual([user]);
+    expect(repository.listResponsibles).toHaveBeenCalledWith('g', { page: 1, limit: 20 });
+  });
+});

--- a/backend/tests/usecases/userGroup/GetUserGroupsUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/GetUserGroupsUseCase.test.ts
@@ -23,7 +23,7 @@ describe('GetUserGroupsUseCase', () => {
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
-    group = new UserGroup('g', 'Group', user, [user]);
+    group = new UserGroup('g', 'Group', [user], [user]);
   });
 
   it('should return groups from repository', async () => {

--- a/backend/tests/usecases/userGroup/RemoveGroupResponsibleUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/RemoveGroupResponsibleUseCase.test.ts
@@ -1,5 +1,5 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { RemoveGroupUserUseCase } from '../../../usecases/userGroup/RemoveGroupUserUseCase';
+import { RemoveGroupResponsibleUseCase } from '../../../usecases/userGroup/RemoveGroupResponsibleUseCase';
 import { UserGroupRepositoryPort } from '../../../domain/ports/UserGroupRepositoryPort';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { UserGroup } from '../../../domain/entities/UserGroup';
@@ -8,10 +8,10 @@ import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
 
-describe('RemoveGroupUserUseCase', () => {
+describe('RemoveGroupResponsibleUseCase', () => {
   let groupRepo: DeepMockProxy<UserGroupRepositoryPort>;
   let userRepo: DeepMockProxy<UserRepositoryPort>;
-  let useCase: RemoveGroupUserUseCase;
+  let useCase: RemoveGroupResponsibleUseCase;
   let site: Site;
   let dept: Department;
   let role: Role;
@@ -21,7 +21,7 @@ describe('RemoveGroupUserUseCase', () => {
   beforeEach(() => {
     groupRepo = mockDeep<UserGroupRepositoryPort>();
     userRepo = mockDeep<UserRepositoryPort>();
-    useCase = new RemoveGroupUserUseCase(groupRepo, userRepo);
+    useCase = new RemoveGroupResponsibleUseCase(groupRepo, userRepo);
     site = new Site('s', 'Site');
     dept = new Department('d', 'Dept', null, null, site);
     role = new Role('r', 'Role');
@@ -29,15 +29,15 @@ describe('RemoveGroupUserUseCase', () => {
     group = new UserGroup('g', 'Group', [user], [user]);
   });
 
-  it('should remove user from group', async () => {
+  it('should remove responsible from group', async () => {
     groupRepo.findById.mockResolvedValue(group);
     userRepo.findById.mockResolvedValue(user);
-    groupRepo.removeUser.mockResolvedValue(group);
+    groupRepo.removeResponsible.mockResolvedValue(group);
 
     const result = await useCase.execute('g', 'u');
 
     expect(result).toBe(group);
-    expect(groupRepo.removeUser).toHaveBeenCalledWith('g', 'u');
+    expect(groupRepo.removeResponsible).toHaveBeenCalledWith('g', 'u');
   });
 
   it('should return null when group or user missing', async () => {
@@ -47,6 +47,6 @@ describe('RemoveGroupUserUseCase', () => {
     const result = await useCase.execute('g', 'u');
 
     expect(result).toBeNull();
-    expect(groupRepo.removeUser).not.toHaveBeenCalled();
+    expect(groupRepo.removeResponsible).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/usecases/userGroup/UpdateUserGroupUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/UpdateUserGroupUseCase.test.ts
@@ -20,7 +20,7 @@ describe('UpdateUserGroupUseCase', () => {
     const dept = new Department('d', 'Dept', null, null, site);
     const role = new Role('r', 'Role');
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
-    group = new UserGroup('g', 'Group', user, [user]);
+    group = new UserGroup('g', 'Group', [user], [user]);
   });
 
   it('should update group via repository', async () => {

--- a/backend/usecases/userGroup/AddGroupResponsibleUseCase.ts
+++ b/backend/usecases/userGroup/AddGroupResponsibleUseCase.ts
@@ -1,0 +1,30 @@
+/* istanbul ignore file */
+import { UserGroupRepositoryPort } from '../../domain/ports/UserGroupRepositoryPort';
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import type { UserGroup } from '../../domain/entities/UserGroup';
+
+/**
+ * Use case for adding a responsible user to a group.
+ */
+export class AddGroupResponsibleUseCase {
+  constructor(
+    private readonly groupRepository: UserGroupRepositoryPort,
+    private readonly userRepository: UserRepositoryPort,
+  ) {}
+
+  /**
+   * Execute the association.
+   *
+   * @param groupId - Identifier of the group.
+   * @param userId - Identifier of the user to add as responsible.
+   * @returns The updated {@link UserGroup} or `null` when group or user is missing.
+   */
+  async execute(groupId: string, userId: string): Promise<UserGroup | null> {
+    const group = await this.groupRepository.findById(groupId);
+    const user = await this.userRepository.findById(userId);
+    if (!group || !user) {
+      return null;
+    }
+    return this.groupRepository.addResponsible(groupId, userId);
+  }
+}

--- a/backend/usecases/userGroup/GetGroupMembersUseCase.ts
+++ b/backend/usecases/userGroup/GetGroupMembersUseCase.ts
@@ -1,0 +1,25 @@
+import { User } from '../../domain/entities/User';
+import { UserGroupRepositoryPort } from '../../domain/ports/UserGroupRepositoryPort';
+import { UserFilters } from '../../domain/ports/UserRepositoryPort';
+import { ListParams, PaginatedResult } from '../../domain/dtos/PaginatedResult';
+
+/**
+ * Use case for retrieving members of a user group.
+ */
+export class GetGroupMembersUseCase {
+  constructor(private readonly groupRepository: UserGroupRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param groupId - Identifier of the group.
+   * @param params - Pagination and filter parameters.
+   * @returns Paginated list of {@link User}.
+   */
+  async execute(
+    groupId: string,
+    params: ListParams & { filters?: UserFilters },
+  ): Promise<PaginatedResult<User>> {
+    return this.groupRepository.listMembers(groupId, params);
+  }
+}

--- a/backend/usecases/userGroup/GetGroupResponsiblesUseCase.ts
+++ b/backend/usecases/userGroup/GetGroupResponsiblesUseCase.ts
@@ -1,0 +1,25 @@
+import { User } from '../../domain/entities/User';
+import { UserGroupRepositoryPort } from '../../domain/ports/UserGroupRepositoryPort';
+import { UserFilters } from '../../domain/ports/UserRepositoryPort';
+import { ListParams, PaginatedResult } from '../../domain/dtos/PaginatedResult';
+
+/**
+ * Use case for retrieving responsible users of a group.
+ */
+export class GetGroupResponsiblesUseCase {
+  constructor(private readonly groupRepository: UserGroupRepositoryPort) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param groupId - Identifier of the group.
+   * @param params - Pagination and filter parameters.
+   * @returns Paginated list of {@link User} responsibles.
+   */
+  async execute(
+    groupId: string,
+    params: ListParams & { filters?: UserFilters },
+  ): Promise<PaginatedResult<User>> {
+    return this.groupRepository.listResponsibles(groupId, params);
+  }
+}

--- a/backend/usecases/userGroup/RemoveGroupResponsibleUseCase.ts
+++ b/backend/usecases/userGroup/RemoveGroupResponsibleUseCase.ts
@@ -1,0 +1,30 @@
+/* istanbul ignore file */
+import { UserGroupRepositoryPort } from '../../domain/ports/UserGroupRepositoryPort';
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import type { UserGroup } from '../../domain/entities/UserGroup';
+
+/**
+ * Use case for removing a responsible user from a group.
+ */
+export class RemoveGroupResponsibleUseCase {
+  constructor(
+    private readonly groupRepository: UserGroupRepositoryPort,
+    private readonly userRepository: UserRepositoryPort,
+  ) {}
+
+  /**
+   * Execute the removal.
+   *
+   * @param groupId - Identifier of the group.
+   * @param userId - Identifier of the responsible user to remove.
+   * @returns The updated {@link UserGroup} or `null` when group or user is missing.
+   */
+  async execute(groupId: string, userId: string): Promise<UserGroup | null> {
+    const group = await this.groupRepository.findById(groupId);
+    const user = await this.userRepository.findById(userId);
+    if (!group || !user) {
+      return null;
+    }
+    return this.groupRepository.removeResponsible(groupId, userId);
+  }
+}


### PR DESCRIPTION
## Summary
- support multiple responsible users in `UserGroup`
- extend `UserGroupRepositoryPort` with responsible management and listing
- update Prisma schema and repository implementation
- add use cases and REST endpoints for members and responsibles
- adjust domain entity and controller logic
- expand unit tests for new behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68828f7251d48323a8e09da9aacd1162