### PR TITLE
Implement invitation REST controller

### DIFF
--- a/backend/adapters/controllers/rest/invitationController.ts
+++ b/backend/adapters/controllers/rest/invitationController.ts
@@ -1,0 +1,171 @@
+/* istanbul ignore file */
+import express, { Request, Response, Router } from 'express';
+import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { InvitationRepositoryPort } from '../../../domain/ports/InvitationRepositoryPort';
+import { EmailServicePort } from '../../../domain/ports/EmailServicePort';
+import { CreateInvitationUseCase } from '../../../usecases/invitation/CreateInvitationUseCase';
+import { GetInvitationUseCase } from '../../../usecases/invitation/GetInvitationUseCase';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { getContext } from '../../../infrastructure/loggerContext';
+
+export function createInvitationRouter(
+  authService: AuthServicePort,
+  userRepository: UserRepositoryPort,
+  invitationRepository: InvitationRepositoryPort,
+  emailService: EmailServicePort,
+  logger: LoggerPort,
+): Router {
+  const router = express.Router();
+
+  /**
+   * @openapi
+   * /users/invite/{token}:
+   *   get:
+   *     summary: Get invitation information by token
+   *     description: >
+   *       Retrieves the invitation details linked to the provided token. Used to validate the invitation and pre-fill onboarding fields.
+   *     tags: [User]
+   *     parameters:
+   *       - in: path
+   *         name: token
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The invitation token from the activation link.
+   *     responses:
+   *       200:
+   *         description: Invitation details and onboarding info.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 email:
+   *                   type: string
+   *                 firstName:
+   *                   type: string
+   *                 lastName:
+   *                   type: string
+   *                 role:
+   *                   type: string
+   *               required: [email]
+   *       404:
+   *         description: Invalid or expired invitation token.
+   *       400:
+   *         description: Invalid token parameter.
+   */
+  router.get('/users/invite/:token', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /users/invite/:token', getContext());
+    const { token } = req.params;
+    if (!token) {
+      res.status(400).end();
+      return;
+    }
+    const useCase = new GetInvitationUseCase(invitationRepository);
+    const invitation = await useCase.execute(token);
+    if (!invitation) {
+      logger.warn('Invitation not found', getContext());
+      res.status(404).end();
+      return;
+    }
+    logger.debug('Invitation retrieved', getContext());
+    res.json({
+      email: invitation.email,
+      firstName: invitation.firstName,
+      lastName: invitation.lastName,
+      role: invitation.role,
+    });
+  });
+
+  const authMiddleware: express.RequestHandler = async (req, res, next) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith('Bearer ')) {
+      res.status(401).end();
+      return;
+    }
+    const token = header.slice(7);
+    try {
+      await authService.verifyToken(token);
+      next();
+    } catch {
+      res.status(401).end();
+    }
+  };
+
+  router.use(authMiddleware);
+
+  /**
+   * @openapi
+   * /users/invite:
+   *   post:
+   *     summary: Invite a new user by email
+   *     description: >
+   *       Sends an invitation email with an activation link to a new user. Only administrators can invite users.
+   *     tags: [User]
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       description: Email and optional details for the invited user.
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               email:
+   *                 type: string
+   *                 description: Email address of the invitee.
+   *               firstName:
+   *                 type: string
+   *                 description: First name (optional).
+   *               lastName:
+   *                 type: string
+   *                 description: Last name (optional).
+   *               role:
+   *                 type: string
+   *                 description: Role to assign after activation (optional).
+   *             required:
+   *               - email
+   *     responses:
+   *       201:
+   *         description: Invitation sent successfully.
+   *       409:
+   *         description: User already exists or invitation already sent.
+   *       400:
+   *         description: Invalid request.
+   */
+  router.post('/users/invite', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('POST /users/invite', getContext());
+    const { email, firstName, lastName, role } = req.body as {
+      email?: string;
+      firstName?: string;
+      lastName?: string;
+      role?: string;
+    };
+    if (!email) {
+      res.status(400).end();
+      return;
+    }
+    const useCase = new CreateInvitationUseCase(
+      userRepository,
+      invitationRepository,
+      emailService,
+    );
+    try {
+      const invitation = await useCase.execute({ email, firstName, lastName, role });
+      logger.debug('Invitation created', getContext());
+      res.status(201).json({ token: invitation.token });
+    } catch (err) {
+      logger.warn('Invitation creation failed', { ...getContext(), error: err });
+      const msg = (err as Error).message;
+      if (msg === 'User already exists' || msg === 'Invitation already exists') {
+        res.status(409).end();
+      } else {
+        res.status(400).end();
+      }
+    }
+  });
+
+  return router;
+}

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -2,8 +2,6 @@
 import express, { Request, Response, Router } from 'express';
 import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
-import { InvitationRepositoryPort } from '../../../domain/ports/InvitationRepositoryPort';
-import { EmailServicePort } from '../../../domain/ports/EmailServicePort';
 import { GetCurrentUserProfileUseCase } from '../../../usecases/user/GetCurrentUserProfileUseCase';
 import { RegisterUserUseCase } from '../../../usecases/user/RegisterUserUseCase';
 import { AuthenticateUserUseCase } from '../../../usecases/user/AuthenticateUserUseCase';
@@ -15,8 +13,6 @@ import { ChangeUserStatusUseCase } from '../../../usecases/user/ChangeUserStatus
 import { RemoveUserUseCase } from '../../../usecases/user/RemoveUserUseCase';
 import { GetUsersUseCase } from '../../../usecases/user/GetUsersUseCase';
 import { GetUserUseCase } from '../../../usecases/user/GetUserUseCase';
-import { CreateInvitationUseCase } from '../../../usecases/invitation/CreateInvitationUseCase';
-import { GetInvitationUseCase } from '../../../usecases/invitation/GetInvitationUseCase';
 import { LoggerPort } from '../../../domain/ports/LoggerPort';
 import { getContext } from '../../../infrastructure/loggerContext';
 import { User } from '../../../domain/entities/User';
@@ -163,8 +159,6 @@ interface AuthedRequest extends Request {
 export function createUserRouter(
   authService: AuthServicePort,
   userRepository: UserRepositoryPort,
-  invitationRepository: InvitationRepositoryPort,
-  emailService: EmailServicePort,
   logger: LoggerPort,
 ): Router {
   const router = express.Router();
@@ -439,119 +433,7 @@ export function createUserRouter(
     res.status(204).end();
   });
 
-  /**
-   * @openapi
-   * /users/invite/{token}:
-   *   get:
-   *     summary: Get invitation information by token
-   *     description: |
-   *       Retrieves the invitation details linked to the provided token. Used to validate the invitation and pre-fill onboarding fields.
-   *     tags:
-   *       - User
-   *     parameters:
-   *       - in: path
-   *         name: token
-   *         required: true
-   *         schema:
-   *           type: string
-   *         description: The invitation token from the activation link.
-   *     responses:
-   *       200:
-   *         description: Invitation details and onboarding info.
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 email:
-   *                   type: string
-   *                 firstName:
-   *                   type: string
-   *                 lastName:
-   *                   type: string
-   *                 role:
-   *                   type: string
-   *               required: [email]
-   *       404:
-   *         description: Invalid or expired invitation token.
-   */
-  router.get('/users/invite/:token', async (req: Request, res: Response): Promise<void> => {
-    logger.debug('GET /users/invite/:token', getContext());
-    const useCase = new GetInvitationUseCase(invitationRepository);
-    const invitation = await useCase.execute(req.params.token);
-    if (!invitation) {
-      logger.warn('Invitation not found', getContext());
-      res.status(404).end();
-      return;
-    }
-    logger.debug('Invitation retrieved', getContext());
-    res.json({
-      email: invitation.email,
-      firstName: invitation.firstName,
-      lastName: invitation.lastName,
-      role: invitation.role,
-    });
-  });
-
   router.use(authMiddleware);
-
-  /**
-   * @openapi
-   * /users/invite:
-   *   post:
-   *     summary: Invite a new user by email
-   *     description: |
-   *       Sends an invitation email with an activation link to a new user. Only administrators can invite users.
-   *     tags:
-   *       - User
-   *     security:
-   *       - bearerAuth: []
-   *     requestBody:
-   *       description: Email and optional details for the invited user.
-   *       required: true
-   *       content:
-   *         application/json:
-   *           schema:
-   *             type: object
-   *             properties:
-   *               email:
-   *                 type: string
-   *                 description: Email address of the invitee.
-   *               firstName:
-   *                 type: string
-   *                 description: First name (optional).
-   *               lastName:
-   *                 type: string
-   *                 description: Last name (optional).
-   *               role:
-   *                 type: string
-   *                 description: Role to assign after activation (optional).
-   *             required:
-   *               - email
-   *     responses:
-   *       201:
-   *         description: Invitation sent successfully.
-   *       409:
-   *         description: User already exists or invitation already sent.
-   *       400:
-   *         description: Invalid request.
-   */
-  router.post('/users/invite', async (req: Request, res: Response): Promise<void> => {
-    logger.debug('POST /users/invite', getContext());
-    const useCase = new CreateInvitationUseCase(
-      userRepository,
-      invitationRepository,
-      emailService,
-    );
-    try {
-      const invitation = await useCase.execute(req.body);
-      logger.debug('Invitation created', getContext());
-      res.status(201).json({ token: invitation.token });
-    } catch (err) {
-      logger.warn('Invitation creation failed', { ...getContext(), error: err });
-      res.status(409).end();
-    }
-  });
 
   /**
    * @openapi

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -4,6 +4,7 @@ import { Server as SocketIOServer } from 'socket.io';
 import { randomUUID } from 'crypto';
 
 import { createUserRouter } from '../adapters/controllers/rest/userController';
+import { createInvitationRouter } from '../adapters/controllers/rest/invitationController';
 import { registerUserGateway } from '../adapters/controllers/websocket/userGateway';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
@@ -38,7 +39,24 @@ async function bootstrap(): Promise<void> {
   });
 
   setupSwagger(app);
-  app.use('/api', createUserRouter(authService, userRepository, invitationRepository, emailService, logger));
+  app.use(
+    '/api',
+    createInvitationRouter(
+      authService,
+      userRepository,
+      invitationRepository,
+      emailService,
+      logger,
+    ),
+  );
+  app.use(
+    '/api',
+    createUserRouter(
+      authService,
+      userRepository,
+      logger,
+    ),
+  );
   
   const httpServer = http.createServer(app);
   const io = new SocketIOServer(httpServer);

--- a/backend/tests/adapters/controllers/rest/invitationController.test.ts
+++ b/backend/tests/adapters/controllers/rest/invitationController.test.ts
@@ -1,0 +1,82 @@
+import request from 'supertest';
+import express from 'express';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { createInvitationRouter } from '../../../../adapters/controllers/rest/invitationController';
+import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
+import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort';
+import { InvitationRepositoryPort } from '../../../../domain/ports/InvitationRepositoryPort';
+import { EmailServicePort } from '../../../../domain/ports/EmailServicePort';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { Invitation } from '../../../../domain/entities/Invitation';
+
+describe('Invitation REST controller', () => {
+  let app: express.Express;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let invitationRepo: DeepMockProxy<InvitationRepositoryPort>;
+  let email: DeepMockProxy<EmailServicePort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+
+  beforeEach(() => {
+    auth = mockDeep<AuthServicePort>();
+    userRepo = mockDeep<UserRepositoryPort>();
+    invitationRepo = mockDeep<InvitationRepositoryPort>();
+    email = mockDeep<EmailServicePort>();
+    logger = mockDeep<LoggerPort>();
+    auth.verifyToken.mockResolvedValue({} as any);
+
+    app = express();
+    app.use(express.json());
+    app.use(
+      '/api',
+      createInvitationRouter(auth, userRepo, invitationRepo, email, logger),
+    );
+  });
+
+  it('should create invitation', async () => {
+    invitationRepo.findByEmail.mockResolvedValue(null);
+    userRepo.findByEmail.mockResolvedValue(null as any);
+    invitationRepo.create.mockImplementation(async (i) => i);
+
+    const res = await request(app)
+      .post('/api/users/invite')
+      .set('Authorization', 'Bearer token')
+      .send({ email: 'new@test.com' });
+
+    expect(res.status).toBe(201);
+    expect(invitationRepo.create).toHaveBeenCalled();
+    expect(email.sendMail).toHaveBeenCalled();
+  });
+
+  it('should return 409 when invitation exists', async () => {
+    invitationRepo.findByEmail.mockResolvedValue(
+      new Invitation('a', 't', 'pending', new Date()),
+    );
+
+    const res = await request(app)
+      .post('/api/users/invite')
+      .set('Authorization', 'Bearer token')
+      .send({ email: 'a' });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('should get invitation info', async () => {
+    invitationRepo.findByToken.mockResolvedValue(
+      new Invitation('a', 't', 'pending', new Date(Date.now() + 1000)),
+    );
+
+    const res = await request(app).get('/api/users/invite/t');
+
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('a');
+  });
+
+  it('should return 404 when invitation not found', async () => {
+    invitationRepo.findByToken.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/users/invite/none');
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -4,21 +4,17 @@ import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { createUserRouter } from '../../../../adapters/controllers/rest/userController';
 import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
 import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort';
-import { InvitationRepositoryPort } from '../../../../domain/ports/InvitationRepositoryPort';
-import { EmailServicePort } from '../../../../domain/ports/EmailServicePort';
+
 import { User } from '../../../../domain/entities/User';
 import { Role } from '../../../../domain/entities/Role';
 import { Department } from '../../../../domain/entities/Department';
 import { Site } from '../../../../domain/entities/Site';
-import { Invitation } from '../../../../domain/entities/Invitation';
 import { LoggerPort } from '../../../../domain/ports/LoggerPort';
 
 describe('User REST controller', () => {
   let app: express.Express;
   let auth: DeepMockProxy<AuthServicePort>;
   let repo: DeepMockProxy<UserRepositoryPort>;
-  let invitationRepo: DeepMockProxy<InvitationRepositoryPort>;
-  let email: DeepMockProxy<EmailServicePort>;
   let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let user: User;
   let role: Role;
@@ -28,8 +24,6 @@ describe('User REST controller', () => {
   beforeEach(() => {
     auth = mockDeep<AuthServicePort>();
     repo = mockDeep<UserRepositoryPort>();
-    invitationRepo = mockDeep<InvitationRepositoryPort>();
-    email = mockDeep<EmailServicePort>();
     logger = mockDeep<LoggerPort>();
     role = new Role('r', 'Role');
     site = new Site('s', 'Site');
@@ -46,7 +40,7 @@ describe('User REST controller', () => {
     auth.resetPassword.mockResolvedValue();
     app = express();
     app.use(express.json());
-    app.use('/api', createUserRouter(auth, repo, invitationRepo, email, logger));
+    app.use('/api', createUserRouter(auth, repo, logger));
   });
 
   it('should return current user profile', async () => {
@@ -293,46 +287,4 @@ describe('User REST controller', () => {
     expect(res.status).toBe(404);
   });
 
-  it('should create invitation', async () => {
-    invitationRepo.findByEmail.mockResolvedValue(null);
-    repo.findByEmail.mockResolvedValue(null as any);
-    invitationRepo.create.mockImplementation(async i => i);
-
-    const res = await request(app)
-      .post('/api/users/invite')
-      .set('Authorization', 'Bearer token')
-      .send({ email: 'new@test.com' });
-
-    expect(res.status).toBe(201);
-    expect(invitationRepo.create).toHaveBeenCalled();
-    expect(email.sendMail).toHaveBeenCalled();
-  });
-
-  it('should return 409 when invitation exists', async () => {
-    invitationRepo.findByEmail.mockResolvedValue(new Invitation('a','t','pending', new Date()));
-
-    const res = await request(app)
-      .post('/api/users/invite')
-      .set('Authorization', 'Bearer token')
-      .send({ email: 'a' });
-
-    expect(res.status).toBe(409);
-  });
-
-  it('should get invitation info', async () => {
-    invitationRepo.findByToken.mockResolvedValue(new Invitation('a','t','pending', new Date(Date.now()+1000)));
-
-    const res = await request(app).get('/api/users/invite/t');
-
-    expect(res.status).toBe(200);
-    expect(res.body.email).toBe('a');
-  });
-
-  it('should return 404 when invitation not found', async () => {
-    invitationRepo.findByToken.mockResolvedValue(null);
-
-    const res = await request(app).get('/api/users/invite/none');
-
-    expect(res.status).toBe(404);
-  });
 });


### PR DESCRIPTION
## Summary
- add a dedicated REST controller for invitations
- wire the invitation controller into the server
- adapt user controller and tests
- cover invitation controller with new tests

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6882a65f6fd883239a74334f2fc5356f