### PR TITLE
Update HTTP methods in controllers

### DIFF
--- a/backend/adapters/controllers/rest/departmentController.ts
+++ b/backend/adapters/controllers/rest/departmentController.ts
@@ -555,7 +555,7 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}:
- *   put:
+ *   post:
  *     summary: Update a department.
  *     description: Modify a department's label, parent, manager or permissions.
  *     tags:
@@ -688,7 +688,7 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/manager:
- *   put:
+ *   post:
  *     summary: Set department manager.
  *     description: |
  *       Assigns a user as the manager of the department. Requires
@@ -780,7 +780,7 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/parent:
- *   put:
+ *   post:
  *     summary: Set parent department.
  *     description: |
  *       Defines the parent department for hierarchical organization. Requires
@@ -872,7 +872,7 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/permissions:
- *   put:
+ *   post:
  *     summary: Add permission to department.
  *     description: |
  *       Grants a specific permission to the department. Administrator
@@ -903,8 +903,8 @@ export function createDepartmentRouter(
    *             schema:
    *               $ref: '#/components/schemas/Department'
    */
-  router.put('/departments/:id/permissions', async (req: Request, res: Response): Promise<void> => {
-    logger.debug('PUT /departments/:id/permissions', getContext());
+  router.post('/departments/:id/permissions', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('POST /departments/:id/permissions', getContext());
     const useCase = new SetDepartmentPermissionUseCase(departmentRepository);
     const permission = new Permission(req.body.id, req.body.permissionKey, req.body.description);
     const updated = await useCase.execute(req.params.id, permission);
@@ -966,7 +966,7 @@ export function createDepartmentRouter(
   /**
    * @openapi
   * /departments/{id}/users/{userId}:
- *   put:
+ *   post:
  *     summary: Attach user to department.
  *     description: |
  *       Adds an existing user to the specified department. Requires
@@ -996,8 +996,8 @@ export function createDepartmentRouter(
    *             schema:
    *               $ref: '#/components/schemas/Department'
    */
-  router.put('/departments/:id/users/:userId', async (req: Request, res: Response): Promise<void> => {
-    logger.debug('PUT /departments/:id/users/:userId', getContext());
+  router.post('/departments/:id/users/:userId', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('POST /departments/:id/users/:userId', getContext());
     const useCase = new AddDepartmentUserUseCase(userRepository, departmentRepository);
     const updated = await useCase.execute(req.params.userId, req.params.id);
     if (!updated) {

--- a/backend/adapters/controllers/rest/groupController.ts
+++ b/backend/adapters/controllers/rest/groupController.ts
@@ -362,7 +362,7 @@ export function createGroupRouter(
   /**
    * @openapi
    * /groups/{id}:
-   *   patch:
+   *   put:
    *     summary: Update a group.
    *     description: Updates group information. Only the responsible user can modify it.
    *     tags: [UserGroup]
@@ -399,8 +399,8 @@ export function createGroupRouter(
    *       403:
    *         description: Forbidden.
    */
-  router.patch('/groups/:id', async (req, res): Promise<void> => {
-    logger.debug('PATCH /groups/:id', getContext());
+  router.put('/groups/:id', async (req, res): Promise<void> => {
+    logger.debug('PUT /groups/:id', getContext());
     const group = await groupRepository.findById(req.params.id);
     if (!group) {
       res.status(404).end();

--- a/backend/tests/adapters/controllers/rest/departmentController.test.ts
+++ b/backend/tests/adapters/controllers/rest/departmentController.test.ts
@@ -231,7 +231,7 @@ describe('Department REST controller', () => {
 
   it('should add permission', async () => {
     const res = await request(app)
-      .put('/api/departments/d/permissions')
+      .post('/api/departments/d/permissions')
       .send({ id: 'p', permissionKey: 'P', description: 'desc' });
 
     expect(res.status).toBe(200);
@@ -242,7 +242,7 @@ describe('Department REST controller', () => {
     deptRepo.findById.mockResolvedValueOnce(null);
 
     const res = await request(app)
-      .put('/api/departments/d/permissions')
+      .post('/api/departments/d/permissions')
       .send({ id: 'p', permissionKey: 'P', description: 'desc' });
 
     expect(res.status).toBe(404);
@@ -264,7 +264,7 @@ describe('Department REST controller', () => {
   });
 
   it('should add user to department', async () => {
-    const res = await request(app).put('/api/departments/d/users/u');
+    const res = await request(app).post('/api/departments/d/users/u');
 
     expect(res.status).toBe(200);
     expect(userRepo.update).toHaveBeenCalled();
@@ -273,7 +273,7 @@ describe('Department REST controller', () => {
   it('should return 404 when department missing for user add', async () => {
     deptRepo.findById.mockResolvedValueOnce(null);
 
-    const res = await request(app).put('/api/departments/d/users/u');
+    const res = await request(app).post('/api/departments/d/users/u');
 
     expect(res.status).toBe(404);
   });
@@ -281,7 +281,7 @@ describe('Department REST controller', () => {
   it('should return 404 when user missing for add', async () => {
     userRepo.findById.mockResolvedValueOnce(null);
 
-    const res = await request(app).put('/api/departments/d/users/u');
+    const res = await request(app).post('/api/departments/d/users/u');
 
     expect(res.status).toBe(404);
   });

--- a/backend/tests/adapters/controllers/rest/groupController.test.ts
+++ b/backend/tests/adapters/controllers/rest/groupController.test.ts
@@ -65,7 +65,7 @@ describe('Group REST controller', () => {
     const other = new User('x', 'Jane', 'Doe', 'jane@example.com', [role], 'active', dept, site);
     userRepo.findById.mockResolvedValueOnce(other);
     const res = await request(app)
-      .patch('/api/groups/g')
+      .put('/api/groups/g')
       .set('Authorization', 'Bearer x')
       .send({ name: 'New' });
     expect(res.status).toBe(403);


### PR DESCRIPTION
## Summary
- switch department permission route to POST
- switch department user assignment route to POST
- switch group update route to PUT
- adjust OpenAPI comments and associated tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882b6c27c1c8323a338b4783d57e407