### PR TITLE
Document 401 responses

### DIFF
--- a/backend/adapters/controllers/rest/departmentController.ts
+++ b/backend/adapters/controllers/rest/departmentController.ts
@@ -177,6 +177,8 @@ export function createDepartmentRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/departments', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /departments', getContext());
@@ -222,6 +224,8 @@ export function createDepartmentRouter(
    *               $ref: '#/components/schemas/Department'
    *       404:
    *         description: Department not found.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/departments/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /departments/:id', getContext());
@@ -294,6 +298,8 @@ export function createDepartmentRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/departments/:id/children', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /departments/:id/children', getContext());
@@ -342,6 +348,8 @@ export function createDepartmentRouter(
    *               $ref: '#/components/schemas/User'
    *       404:
    *         description: Manager not found.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/departments/:id/manager', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /departments/:id/manager', getContext());
@@ -382,6 +390,8 @@ export function createDepartmentRouter(
    *               $ref: '#/components/schemas/Department'
    *       404:
    *         description: Parent department not found.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/departments/:id/parent', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /departments/:id/parent', getContext());
@@ -448,6 +458,8 @@ export function createDepartmentRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/departments/:id/permissions', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /departments/:id/permissions', getContext());
@@ -532,6 +544,8 @@ export function createDepartmentRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/departments/:id/users', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /departments/:id/users', getContext());
@@ -582,6 +596,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/departments', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /departments', getContext());
@@ -622,6 +638,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.put('/departments/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('PUT /departments/:id', getContext());
@@ -664,6 +682,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/departments/:id/children/:childId', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /departments/:id/children/:childId', getContext());
@@ -710,6 +730,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/departments/:id/children/:childId', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /departments/:id/children/:childId', getContext());
@@ -762,6 +784,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.put('/departments/:id/manager', async (req: Request, res: Response): Promise<void> => {
     logger.debug('PUT /departments/:id/manager', getContext());
@@ -802,6 +826,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/departments/:id/manager', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /departments/:id/manager', getContext());
@@ -854,6 +880,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.put('/departments/:id/parent', async (req: Request, res: Response): Promise<void> => {
     logger.debug('PUT /departments/:id/parent', getContext());
@@ -894,6 +922,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/departments/:id/parent', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /departments/:id/parent', getContext());
@@ -941,6 +971,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/departments/:id/permissions', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /departments/:id/permissions', getContext());
@@ -988,6 +1020,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/departments/:id/permissions/:permissionId', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /departments/:id/permissions/:permissionId', getContext());
@@ -1034,6 +1068,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/departments/:id/users/:userId', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /departments/:id/users/:userId', getContext());
@@ -1080,6 +1116,8 @@ export function createDepartmentRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Department'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/departments/:id/users/:userId', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /departments/:id/users/:userId', getContext());
@@ -1118,6 +1156,8 @@ export function createDepartmentRouter(
  *         description: Department successfully deleted
  *       400:
  *         description: Operation failed
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/departments/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /departments/:id', getContext());

--- a/backend/adapters/controllers/rest/groupController.ts
+++ b/backend/adapters/controllers/rest/groupController.ts
@@ -125,6 +125,8 @@ export function createGroupRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/UserGroup'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/groups', async (req, res): Promise<void> => {
     logger.debug('POST /groups', getContext());
@@ -186,6 +188,8 @@ export function createGroupRouter(
    *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/groups', async (req, res): Promise<void> => {
     logger.debug('GET /groups', getContext());
@@ -229,6 +233,8 @@ export function createGroupRouter(
    *               $ref: '#/components/schemas/UserGroup'
    *       404:
    *         description: Group not found.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/groups/:id', async (req, res): Promise<void> => {
     logger.debug('GET /groups/:id', getContext());
@@ -293,6 +299,8 @@ export function createGroupRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/groups/:id/users', async (req, res): Promise<void> => {
     logger.debug('GET /groups/:id/users', getContext());
@@ -364,6 +372,8 @@ export function createGroupRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/groups/:id/responsibles', async (req, res): Promise<void> => {
     logger.debug('GET /groups/:id/responsibles', getContext());
@@ -421,6 +431,8 @@ export function createGroupRouter(
    *               $ref: '#/components/schemas/UserGroup'
    *       403:
    *         description: Forbidden.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.put('/groups/:id', async (req, res): Promise<void> => {
     logger.debug('PUT /groups/:id', getContext());
@@ -462,6 +474,8 @@ export function createGroupRouter(
    *         description: Group deleted.
    *       403:
    *         description: Forbidden.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/groups/:id', async (req, res): Promise<void> => {
     logger.debug('DELETE /groups/:id', getContext());
@@ -517,6 +531,8 @@ export function createGroupRouter(
    *               $ref: '#/components/schemas/UserGroup'
    *       403:
    *         description: Forbidden.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/groups/:id/users', async (req, res): Promise<void> => {
     logger.debug('POST /groups/:id/users', getContext());
@@ -576,6 +592,8 @@ export function createGroupRouter(
    *               $ref: '#/components/schemas/UserGroup'
    *       403:
    *         description: Forbidden.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/groups/:id/responsibles', async (req, res): Promise<void> => {
     logger.debug('POST /groups/:id/responsibles', getContext());
@@ -635,6 +653,8 @@ export function createGroupRouter(
    *               $ref: '#/components/schemas/UserGroup'
    *       403:
    *         description: Forbidden.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/groups/:id/users', async (req, res): Promise<void> => {
     logger.debug('DELETE /groups/:id/users', getContext());
@@ -694,6 +714,8 @@ export function createGroupRouter(
    *               $ref: '#/components/schemas/UserGroup'
    *       403:
    *         description: Forbidden.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/groups/:id/responsibles', async (req, res): Promise<void> => {
     logger.debug('DELETE /groups/:id/responsibles', getContext());

--- a/backend/adapters/controllers/rest/invitationController.ts
+++ b/backend/adapters/controllers/rest/invitationController.ts
@@ -144,6 +144,8 @@ export function createInvitationRouter(
    *         description: User already exists or invitation already sent.
    *       400:
    *         description: Invalid request.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/invitations/invite', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /invitations/invite', getContext());

--- a/backend/adapters/controllers/rest/permissionController.ts
+++ b/backend/adapters/controllers/rest/permissionController.ts
@@ -103,6 +103,8 @@ export function createPermissionRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/permissions', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /permissions', getContext());
@@ -148,6 +150,8 @@ export function createPermissionRouter(
    *               $ref: '#/components/schemas/Permission'
    *       404:
    *         description: Permission not found.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/permissions/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /permissions/:id', getContext());
@@ -188,6 +192,8 @@ export function createPermissionRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Permission'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/permissions', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /permissions', getContext());
@@ -228,6 +234,8 @@ export function createPermissionRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Permission'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.put('/permissions/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('PUT /permissions/:id', getContext());
@@ -259,6 +267,8 @@ export function createPermissionRouter(
  *     responses:
  *       204:
  *         description: Permission successfully removed
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/permissions/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /permissions/:id', getContext());

--- a/backend/adapters/controllers/rest/roleController.ts
+++ b/backend/adapters/controllers/rest/roleController.ts
@@ -130,6 +130,8 @@ export function createRoleRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/roles', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /roles', getContext());
@@ -175,6 +177,8 @@ export function createRoleRouter(
    *               $ref: '#/components/schemas/Role'
    *       404:
    *         description: Role not found.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/roles/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /roles/:id', getContext());
@@ -215,6 +219,8 @@ export function createRoleRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Role'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/roles', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /roles', getContext());
@@ -255,6 +261,8 @@ export function createRoleRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Role'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.put('/roles/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('PUT /roles/:id', getContext());
@@ -289,6 +297,8 @@ export function createRoleRouter(
  *         description: Role successfully deleted
  *       400:
  *         description: Deletion failed because the role is still in use
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/roles/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /roles/:id', getContext());

--- a/backend/adapters/controllers/rest/siteController.ts
+++ b/backend/adapters/controllers/rest/siteController.ts
@@ -99,6 +99,8 @@ export function createSiteRouter(
   *                   type: integer
    *       204:
    *         description: No content.
+ *       401:
+ *         description: Invalid or expired authentication token.
   */
   router.get('/sites', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /sites', getContext());
@@ -144,6 +146,8 @@ export function createSiteRouter(
    *               $ref: '#/components/schemas/Site'
    *       404:
    *         description: Site not found.
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.get('/sites/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('GET /sites/:id', getContext());
@@ -184,6 +188,8 @@ export function createSiteRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Site'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.post('/sites', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /sites', getContext());
@@ -226,6 +232,8 @@ export function createSiteRouter(
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Site'
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.put('/sites/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('PUT /sites/:id', getContext());
@@ -261,6 +269,8 @@ export function createSiteRouter(
  *         description: Site successfully deleted
  *       400:
  *         description: Operation failed due to existing attachments
+ *       401:
+ *         description: Invalid or expired authentication token.
    */
   router.delete('/sites/:id', async (req: Request, res: Response): Promise<void> => {
     logger.debug('DELETE /sites/:id', getContext());


### PR DESCRIPTION
## Summary
- update REST controller openapi docs with 401 Unauthorized info

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68835157197083239400104ea2363033