### PR TITLE
Fix backend tests for permission checker

### DIFF
--- a/backend/tests/usecases/department/AddChildDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/AddChildDepartmentUseCase.test.ts
@@ -24,7 +24,13 @@ describe('AddChildDepartmentUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.UPDATE_DEPARTMENT, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/AddDepartmentUserUseCase.test.ts
+++ b/backend/tests/usecases/department/AddDepartmentUserUseCase.test.ts
@@ -30,7 +30,13 @@ describe('AddDepartmentUserUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.UPDATE_USER, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/GetDepartmentChildrenUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentChildrenUseCase.test.ts
@@ -3,6 +3,11 @@ import { GetDepartmentChildrenUseCase } from '../../../usecases/department/GetDe
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('GetDepartmentChildrenUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -11,10 +16,23 @@ describe('GetDepartmentChildrenUseCase', () => {
   let child1: Department;
   let child2: Department;
   let other: Department;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new GetDepartmentChildrenUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.READ_DEPARTMENTS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new GetDepartmentChildrenUseCase(repository, checker);
     site = new Site('s', 'Site');
     child1 = new Department('c1', 'Child1', 'p', null, site);
     child2 = new Department('c2', 'Child2', 'p', null, site);

--- a/backend/tests/usecases/department/GetDepartmentParentUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentParentUseCase.test.ts
@@ -3,6 +3,11 @@ import { GetDepartmentParentUseCase } from '../../../usecases/department/GetDepa
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 
 describe('GetDepartmentParentUseCase', () => {
@@ -11,10 +16,23 @@ describe('GetDepartmentParentUseCase', () => {
   let site: Site;
   let parent: Department;
   let child: Department;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repo = mockDeep<DepartmentRepositoryPort>();
-    useCase = new GetDepartmentParentUseCase(repo);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.READ_DEPARTMENT, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new GetDepartmentParentUseCase(repo, checker);
     site = new Site('s', 'Site');
     parent = new Department('p','Parent',null,null,site);
     child = new Department('c','Child','p',null,site);

--- a/backend/tests/usecases/department/GetDepartmentPermissionsUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentPermissionsUseCase.test.ts
@@ -4,6 +4,10 @@ import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentReposi
 import { Department } from '../../../domain/entities/Department';
 import { Permission } from '../../../domain/entities/Permission';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('GetDepartmentPermissionsUseCase', () => {
   let repo: DeepMockProxy<DepartmentRepositoryPort>;
@@ -12,10 +16,23 @@ describe('GetDepartmentPermissionsUseCase', () => {
   let permission: Permission;
   let other: Permission;
   let dept: Department;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repo = mockDeep<DepartmentRepositoryPort>();
-    useCase = new GetDepartmentPermissionsUseCase(repo);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_PERMISSIONS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new GetDepartmentPermissionsUseCase(repo, checker);
     site = new Site('s', 'Site');
     permission = new Permission('p1','perm1','desc');
     other = new Permission('p2','perm2','other');

--- a/backend/tests/usecases/department/GetDepartmentUsersUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentUsersUseCase.test.ts
@@ -5,6 +5,9 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('GetDepartmentUsersUseCase', () => {
   let repo: DeepMockProxy<UserRepositoryPort>;
@@ -13,10 +16,23 @@ describe('GetDepartmentUsersUseCase', () => {
   let dept: Department;
   let role: Role;
   let user: User;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repo = mockDeep<UserRepositoryPort>();
-    useCase = new GetDepartmentUsersUseCase(repo);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.READ_USERS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new GetDepartmentUsersUseCase(repo, checker);
     site = new Site('s','Site');
     dept = new Department('d','Dept',null,null,site);
     role = new Role('r','Role');

--- a/backend/tests/usecases/department/RemoveChildDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveChildDepartmentUseCase.test.ts
@@ -3,16 +3,34 @@ import { RemoveChildDepartmentUseCase } from '../../../usecases/department/Remov
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('RemoveChildDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
   let useCase: RemoveChildDepartmentUseCase;
   let child: Department;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new RemoveChildDepartmentUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new RemoveChildDepartmentUseCase(repository, checker);
     site = new Site('site-1', 'HQ');
     child = new Department('child', 'IT', 'parent', null, site);
   });

--- a/backend/tests/usecases/department/RemoveDepartmentManagerUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentManagerUseCase.test.ts
@@ -3,16 +3,34 @@ import { RemoveDepartmentManagerUseCase } from '../../../usecases/department/Rem
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('RemoveDepartmentManagerUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
   let useCase: RemoveDepartmentManagerUseCase;
   let department: Department;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new RemoveDepartmentManagerUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new RemoveDepartmentManagerUseCase(repository, checker);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, 'manager', site);
   });

--- a/backend/tests/usecases/department/RemoveDepartmentParentDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentParentDepartmentUseCase.test.ts
@@ -3,16 +3,34 @@ import { RemoveDepartmentParentDepartmentUseCase } from '../../../usecases/depar
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('RemoveDepartmentParentDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
   let useCase: RemoveDepartmentParentDepartmentUseCase;
   let department: Department;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new RemoveDepartmentParentDepartmentUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new RemoveDepartmentParentDepartmentUseCase(repository, checker);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', 'parent', null, site);
   });

--- a/backend/tests/usecases/department/RemoveDepartmentPermissionUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentPermissionUseCase.test.ts
@@ -4,6 +4,10 @@ import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentReposi
 import { Department } from '../../../domain/entities/Department';
 import { Permission } from '../../../domain/entities/Permission';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('RemoveDepartmentPermissionUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -11,10 +15,23 @@ describe('RemoveDepartmentPermissionUseCase', () => {
   let department: Department;
   let permission: Permission;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new RemoveDepartmentPermissionUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_PERMISSIONS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new RemoveDepartmentPermissionUseCase(repository, checker);
     site = new Site('site-1', 'HQ');
     permission = new Permission('perm-1', 'READ', 'read');
     department = new Department('dept-1', 'IT', null, null, site, [permission]);

--- a/backend/tests/usecases/department/RemoveDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentUseCase.test.ts
@@ -6,6 +6,9 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('RemoveDepartmentUseCase', () => {
   let deptRepo: DeepMockProxy<DepartmentRepositoryPort>;
@@ -15,11 +18,24 @@ describe('RemoveDepartmentUseCase', () => {
   let site: Site;
   let user: User;
   let role: Role;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     deptRepo = mockDeep<DepartmentRepositoryPort>();
     userRepo = mockDeep<UserRepositoryPort>();
-    useCase = new RemoveDepartmentUseCase(deptRepo, userRepo);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.DELETE_DEPARTMENT, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new RemoveDepartmentUseCase(deptRepo, userRepo, checker);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
     role = new Role('role-1', 'Admin');

--- a/backend/tests/usecases/department/RemoveDepartmentUserUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentUserUseCase.test.ts
@@ -5,6 +5,9 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('RemoveDepartmentUserUseCase', () => {
   let userRepo: DeepMockProxy<UserRepositoryPort>;
@@ -13,10 +16,23 @@ describe('RemoveDepartmentUserUseCase', () => {
   let role: Role;
   let department: Department;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     userRepo = mockDeep<UserRepositoryPort>();
-    useCase = new RemoveDepartmentUserUseCase(userRepo);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new RemoveDepartmentUserUseCase(userRepo, checker);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
     role = new Role('role-1', 'Admin');

--- a/backend/tests/usecases/department/SetDepartmentManagerUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentManagerUseCase.test.ts
@@ -3,16 +3,34 @@ import { SetDepartmentManagerUseCase } from '../../../usecases/department/SetDep
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('SetDepartmentManagerUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
   let useCase: SetDepartmentManagerUseCase;
   let department: Department;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new SetDepartmentManagerUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new SetDepartmentManagerUseCase(repository, checker);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
   });

--- a/backend/tests/usecases/department/SetDepartmentParentDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentParentDepartmentUseCase.test.ts
@@ -3,16 +3,34 @@ import { SetDepartmentParentDepartmentUseCase } from '../../../usecases/departme
 import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('SetDepartmentParentDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
   let useCase: SetDepartmentParentDepartmentUseCase;
   let department: Department;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new SetDepartmentParentDepartmentUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new SetDepartmentParentDepartmentUseCase(repository, checker);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
   });

--- a/backend/tests/usecases/department/SetDepartmentPermissionUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentPermissionUseCase.test.ts
@@ -4,6 +4,10 @@ import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentReposi
 import { Department } from '../../../domain/entities/Department';
 import { Permission } from '../../../domain/entities/Permission';
 import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('SetDepartmentPermissionUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -11,10 +15,23 @@ describe('SetDepartmentPermissionUseCase', () => {
   let department: Department;
   let permission: Permission;
   let site: Site;
+  let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<DepartmentRepositoryPort>();
-    useCase = new SetDepartmentPermissionUseCase(repository);
+    checker = new PermissionChecker(
+      new User(
+        'actor',
+        'A',
+        'B',
+        'a@b.c',
+        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_PERMISSIONS, '')])],
+        'active',
+        new Department('d', 'Dept', null, null, new Site('s', 'Site')),
+        new Site('s', 'Site'),
+      ),
+    );
+    useCase = new SetDepartmentPermissionUseCase(repository, checker);
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
     permission = new Permission('perm-1', 'READ', 'read');


### PR DESCRIPTION
## Summary
- fix department-related tests by providing `PermissionChecker`
- ensure tests cover missing department scenarios

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883e2f723448323b6a327e065140dac