### PR TITLE
Fix misplaced usecase tests

### DIFF
--- a/backend/tests/usecases/department/CreateDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/CreateDepartmentUseCase.test.ts
@@ -1,13 +1,13 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { CreateDepartmentUseCase } from '../../usecases/department/CreateDepartmentUseCase';
-import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
-import { Department } from '../../domain/entities/Department';
-import { Site } from '../../domain/entities/Site';
-import { PermissionChecker } from '../../domain/services/PermissionChecker';
-import { User } from '../../domain/entities/User';
-import { Role } from '../../domain/entities/Role';
-import { Permission } from '../../domain/entities/Permission';
-import { PermissionKeys } from '../../domain/entities/PermissionKeys';
+import { CreateDepartmentUseCase } from '../../../usecases/department/CreateDepartmentUseCase';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('CreateDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;

--- a/backend/tests/usecases/role/CreateRoleUseCase.test.ts
+++ b/backend/tests/usecases/role/CreateRoleUseCase.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { CreateRoleUseCase } from '../../usecases/role/CreateRoleUseCase';
-import { RoleRepositoryPort } from '../../domain/ports/RoleRepositoryPort';
-import { Role } from '../../domain/entities/Role';
+import { CreateRoleUseCase } from '../../../usecases/role/CreateRoleUseCase';
+import { RoleRepositoryPort } from '../../../domain/ports/RoleRepositoryPort';
+import { Role } from '../../../domain/entities/Role';
 
 describe('CreateRoleUseCase', () => {
   let repository: DeepMockProxy<RoleRepositoryPort>;

--- a/backend/tests/usecases/site/CreateSiteUseCase.test.ts
+++ b/backend/tests/usecases/site/CreateSiteUseCase.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { CreateSiteUseCase } from '../../usecases/site/CreateSiteUseCase';
-import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
-import { Site } from '../../domain/entities/Site';
+import { CreateSiteUseCase } from '../../../usecases/site/CreateSiteUseCase';
+import { SiteRepositoryPort } from '../../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../../domain/entities/Site';
 
 describe('CreateSiteUseCase', () => {
   let repository: DeepMockProxy<SiteRepositoryPort>;

--- a/backend/tests/usecases/site/GetSiteUseCase.test.ts
+++ b/backend/tests/usecases/site/GetSiteUseCase.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { GetSiteUseCase } from '../../usecases/site/GetSiteUseCase';
-import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
-import { Site } from '../../domain/entities/Site';
+import { GetSiteUseCase } from '../../../usecases/site/GetSiteUseCase';
+import { SiteRepositoryPort } from '../../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../../domain/entities/Site';
 
 describe('GetSiteUseCase', () => {
   let repository: DeepMockProxy<SiteRepositoryPort>;

--- a/backend/tests/usecases/site/GetSitesUseCase.test.ts
+++ b/backend/tests/usecases/site/GetSitesUseCase.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { GetSitesUseCase } from '../../usecases/site/GetSitesUseCase';
-import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
-import { Site } from '../../domain/entities/Site';
+import { GetSitesUseCase } from '../../../usecases/site/GetSitesUseCase';
+import { SiteRepositoryPort } from '../../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../../domain/entities/Site';
 
 describe('GetSitesUseCase', () => {
   let repository: DeepMockProxy<SiteRepositoryPort>;

--- a/backend/tests/usecases/site/RemoveSiteUseCase.test.ts
+++ b/backend/tests/usecases/site/RemoveSiteUseCase.test.ts
@@ -1,12 +1,12 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { RemoveSiteUseCase } from '../../usecases/site/RemoveSiteUseCase';
-import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
-import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
-import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositoryPort';
-import { Site } from '../../domain/entities/Site';
-import { User } from '../../domain/entities/User';
-import { Department } from '../../domain/entities/Department';
-import { Role } from '../../domain/entities/Role';
+import { RemoveSiteUseCase } from '../../../usecases/site/RemoveSiteUseCase';
+import { SiteRepositoryPort } from '../../../domain/ports/SiteRepositoryPort';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { Site } from '../../../domain/entities/Site';
+import { User } from '../../../domain/entities/User';
+import { Department } from '../../../domain/entities/Department';
+import { Role } from '../../../domain/entities/Role';
 
 describe('RemoveSiteUseCase', () => {
   let siteRepo: DeepMockProxy<SiteRepositoryPort>;

--- a/backend/tests/usecases/site/UpdateSiteUseCase.test.ts
+++ b/backend/tests/usecases/site/UpdateSiteUseCase.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { UpdateSiteUseCase } from '../../usecases/site/UpdateSiteUseCase';
-import { SiteRepositoryPort } from '../../domain/ports/SiteRepositoryPort';
-import { Site } from '../../domain/entities/Site';
+import { UpdateSiteUseCase } from '../../../usecases/site/UpdateSiteUseCase';
+import { SiteRepositoryPort } from '../../../domain/ports/SiteRepositoryPort';
+import { Site } from '../../../domain/entities/Site';
 
 describe('UpdateSiteUseCase', () => {
   let repository: DeepMockProxy<SiteRepositoryPort>;

--- a/backend/tests/usecases/userGroup/CreateUserGroupUseCase.test.ts
+++ b/backend/tests/usecases/userGroup/CreateUserGroupUseCase.test.ts
@@ -1,11 +1,11 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { CreateUserGroupUseCase } from '../../usecases/userGroup/CreateUserGroupUseCase';
-import { UserGroupRepositoryPort } from '../../domain/ports/UserGroupRepositoryPort';
-import { UserGroup } from '../../domain/entities/UserGroup';
-import { User } from '../../domain/entities/User';
-import { Role } from '../../domain/entities/Role';
-import { Department } from '../../domain/entities/Department';
-import { Site } from '../../domain/entities/Site';
+import { CreateUserGroupUseCase } from '../../../usecases/userGroup/CreateUserGroupUseCase';
+import { UserGroupRepositoryPort } from '../../../domain/ports/UserGroupRepositoryPort';
+import { UserGroup } from '../../../domain/entities/UserGroup';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
 
 describe('CreateUserGroupUseCase', () => {
   let repo: DeepMockProxy<UserGroupRepositoryPort>;


### PR DESCRIPTION
## Summary
- move misplaced tests in tests/usecases to their proper subfolders
- adjust import paths to new locations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883e5ea231c832384215be422feb1a0