### PR TITLE
Remove unused imports

### DIFF
--- a/backend/usecases/invitation/GetInvitationUseCase.ts
+++ b/backend/usecases/invitation/GetInvitationUseCase.ts
@@ -1,7 +1,5 @@
 import { InvitationRepositoryPort } from '../../domain/ports/InvitationRepositoryPort';
 import { Invitation } from '../../domain/entities/Invitation';
-import { PermissionChecker } from '../../domain/services/PermissionChecker';
-import { PermissionKeys } from '../../domain/entities/PermissionKeys';
 
 /**
  * Use case for retrieving an invitation by its token.


### PR DESCRIPTION
## Summary
- drop unused PermissionChecker and PermissionKeys imports from `GetInvitationUseCase`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883fa54f4bc8323bd2d7244c2d4213a