### PR TITLE
Add initialization script for admin account

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "dev": "ts-node infrastructure/server.ts",
-    "permissions:sync": "ts-node scripts/syncPermissions.ts"
+    "permissions:sync": "ts-node scripts/syncPermissions.ts",
+    "initialize": "node scripts/init-application.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.850.0",

--- a/backend/scripts/init-application.js
+++ b/backend/scripts/init-application.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-undef */
+/* eslint-env node */
+// Initialize application with default administrator
+const { PrismaClient } = require('@prisma/client');
+const { randomUUID } = require('crypto');
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://sovrane:sovrane@localhost:5432/sovrane';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+async function main() {
+  const prisma = new PrismaClient();
+  const existing = await prisma.role.findFirst({ where: { label: 'Administrators' } });
+  if (existing) {
+    console.log('Administrators role already exists. Initialization aborted.');
+    await prisma.$disconnect();
+    return;
+  }
+
+  const siteName = process.env.MAIN_SITE_NAME || 'Main Site';
+  let site = await prisma.site.findFirst({ where: { label: siteName } });
+  if (!site) {
+    site = await prisma.site.create({ data: { id: randomUUID(), label: siteName } });
+  }
+
+  const departmentName = process.env.MAIN_DEPARTMENT_NAME || 'Main Department';
+  let department = await prisma.department.findFirst({ where: { label: departmentName } });
+  if (!department) {
+    department = await prisma.department.create({ data: { id: randomUUID(), label: departmentName, siteId: site.id } });
+  }
+
+  let group = await prisma.userGroup.findFirst({ where: { name: 'Administrators' } });
+  if (!group) {
+    group = await prisma.userGroup.create({ data: { id: randomUUID(), name: 'Administrators' } });
+  }
+
+  let rootPermission = await prisma.permission.findFirst({ where: { permissionKey: 'root' } });
+  if (!rootPermission) {
+    rootPermission = await prisma.permission.create({ data: { id: randomUUID(), permissionKey: 'root', description: 'All permissions' } });
+  }
+
+  const role = await prisma.role.create({
+    data: {
+      id: randomUUID(),
+      label: 'Administrators',
+      permissions: { create: { permissionId: rootPermission.id } }
+    }
+  });
+
+  const adminEmail = process.env.ADMIN_EMAIL || 'admin@admin.com';
+  const adminPassword = process.env.ADMIN_PASSWORD || 'admin';
+
+  await prisma.user.create({
+    data: {
+      id: randomUUID(),
+      firstname: 'Admin',
+      lastname: 'Admin',
+      email: adminEmail,
+      password: adminPassword,
+      status: 'active',
+      departmentId: department.id,
+      siteId: site.id,
+      roles: { create: { roleId: role.id } },
+      groups: { create: { groupId: group.id } }
+    }
+  });
+
+  console.log(`Administrator account created with email ${adminEmail}`);
+  await prisma.$disconnect();
+}
+
+main().catch(async err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a script to populate a default admin role, department, site and user
- include defaults for missing environment variables so the initialization can run standalone
- expose the script via `npm run initialize`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885161b8f108323a68dc13ba87e8b71