### PR TITLE
Implement secure password hashing

### DIFF
--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -33,6 +33,7 @@ async function bootstrap(): Promise<void> {
   const authService = new JWTAuthServiceAdapter(
     process.env.JWT_SECRET ?? 'secret',
     userRepository,
+    prisma,
     logger,
   );
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.850.0",
         "@prisma/client": "^6.12.0",
+        "argon2": "^0.43.1",
         "email-templates": "^12.0.3",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
@@ -2679,6 +2680,15 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4651,6 +4661,21 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argon2": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.43.1.tgz",
+      "integrity": "sha512-TfOzvDWUaQPurCT1hOwIeFNkgrAJDpbBGBGWDgzDsm11nNhImc13WhdGdCU6K7brkp8VpeY07oGtSex0Wmhg8w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.4.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -9159,6 +9184,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -9177,6 +9211,17 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.850.0",
     "@prisma/client": "^6.12.0",
+    "argon2": "^0.43.1",
     "email-templates": "^12.0.3",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",

--- a/backend/scripts/init-application.js
+++ b/backend/scripts/init-application.js
@@ -3,6 +3,7 @@
 // Initialize application with default administrator
 const { PrismaClient } = require('@prisma/client');
 const { randomUUID } = require('crypto');
+const argon2 = require('argon2');
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://sovrane:sovrane@localhost:5432/sovrane';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'secret';
@@ -48,6 +49,7 @@ async function main() {
 
   const adminEmail = process.env.ADMIN_EMAIL || 'admin@admin.com';
   const adminPassword = process.env.ADMIN_PASSWORD || 'admin';
+  const passwordHash = await argon2.hash(adminPassword);
 
   await prisma.user.create({
     data: {
@@ -55,7 +57,7 @@ async function main() {
       firstname: 'Admin',
       lastname: 'Admin',
       email: adminEmail,
-      password: adminPassword,
+      password: passwordHash,
       status: 'active',
       departmentId: department.id,
       siteId: site.id,


### PR DESCRIPTION
## Summary
- add argon2 dependency
- hash admin password on initialization
- verify hashed passwords in JWT auth adapter
- adapt server to pass prisma instance
- update tests for new auth logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885293492708323b87d2baf85796121