### PR TITLE
Fix login missing params

### DIFF
--- a/backend/adapters/controllers/rest/requestValidator.ts
+++ b/backend/adapters/controllers/rest/requestValidator.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Creates middleware validating that required parameters are present
+ * in the request body. If any parameter is missing, the request is
+ * rejected with status 400 and an error message listing the missing keys.
+ *
+ * @param fields - Required body field names.
+ * @returns Express middleware performing the validation.
+ */
+export function requireBodyParams(fields: string[]): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const missing = fields.filter((f) => req.body?.[f] === undefined);
+    if (missing.length > 0) {
+      res.status(400).json({ error: `Missing required parameters: ${missing.join(', ')}` });
+      return;
+    }
+    next();
+  };
+}

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -24,6 +24,7 @@ import {Department} from '../../../domain/entities/Department';
 import {Site} from '../../../domain/entities/Site';
 import {Permission} from '../../../domain/entities/Permission';
 import {PermissionChecker} from '../../../domain/services/PermissionChecker';
+import {requireBodyParams} from './requestValidator';
 
 /**
  * @openapi
@@ -306,23 +307,26 @@ export function createUserRouter(
      *       403:
      *         description: User account is suspended or archived
      */
-    router.post('/auth/login', async (req: Request, res: Response): Promise<void> => {
-      console.log('debug');
-      logger.debug('POST /auth/login', getContext());
-      const {email, password} = req.body;
-      const useCase = new AuthenticateUserUseCase(authService);
-      try {
-        const user = await useCase.execute(email, password);
-        logger.debug('User authenticated', getContext());
-        res.json(user);
-      } catch (err) {
-        logger.warn('Authentication failed', {...getContext(), error: err});
-        const message = (err as Error).message;
-        const status =
-                message === 'User account is suspended or archived' ? 403 : 401;
-        res.status(status).json({error: message});
-      }
-    });
+    router.post(
+      '/auth/login',
+      requireBodyParams(['email', 'password']),
+      async (req: Request, res: Response): Promise<void> => {
+        logger.debug('POST /auth/login', getContext());
+        const {email, password} = req.body;
+        const useCase = new AuthenticateUserUseCase(authService);
+        try {
+          const user = await useCase.execute(email, password);
+          logger.debug('User authenticated', getContext());
+          res.json(user);
+        } catch (err) {
+          logger.warn('Authentication failed', {...getContext(), error: err});
+          const message = (err as Error).message;
+          const status =
+            message === 'User account is suspended or archived' ? 403 : 401;
+          res.status(status).json({error: message});
+        }
+      },
+    );
 
     /**
      * @openapi

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2818,6 +2818,9 @@
           },
           "403": {
             "description": "User account is suspended or archived"
+          },
+          "400": {
+            "description": "Missing required parameters"
           }
         }
       }

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -143,6 +143,13 @@ describe('User REST controller', () => {
     expect(res.body.error).toBe('User account is suspended or archived');
   });
 
+  it('should return 400 when parameters are missing', async () => {
+    const res = await request(app).post('/api/auth/login').send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Missing required parameters: email, password');
+  });
+
   it('should authenticate with provider', async () => {
     const res = await request(app)
       .post('/api/auth/provider')


### PR DESCRIPTION
## Summary
- add a generic `requireBodyParams` middleware
- validate email and password on the login route
- document 400 response for `/auth/login` in the API spec
- test missing parameter handling

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68855d436c28832385b8416993499350