### PR TITLE
Add flexible request body validation

### DIFF
--- a/backend/adapters/controllers/rest/requestValidator.ts
+++ b/backend/adapters/controllers/rest/requestValidator.ts
@@ -1,20 +1,84 @@
-import { Request, Response, NextFunction, RequestHandler } from 'express';
+import {Request, Response, NextFunction, RequestHandler} from 'express';
+
+/** Validation rules allowed for each body parameter. */
+export interface BodyParamRules {
+  /** Validator type to apply on the value. */
+  validator?: 'string' | 'email' | 'int' | 'float' | 'bool';
+  /** Minimum string length or numeric value. */
+  minLength?: number;
+  /** Maximum string length or numeric value. */
+  maxLength?: number;
+  /** Minimum numeric value. */
+  min?: number;
+  /** Maximum numeric value. */
+  max?: number;
+}
+
+export type BodyParamsSchema = string[] | Record<string, BodyParamRules>;
 
 /**
- * Creates middleware validating that required parameters are present
- * in the request body. If any parameter is missing, the request is
- * rejected with status 400 and an error message listing the missing keys.
+ * Validate request body parameters according to a schema. When called with an
+ * array, only presence of the listed fields is checked (legacy behaviour).
+ * When called with an object, values are also validated using the specified
+ * {@link BodyParamRules}.
  *
- * @param fields - Required body field names.
+ * @param schema - Required fields or a mapping of field names to rules.
  * @returns Express middleware performing the validation.
  */
-export function requireBodyParams(fields: string[]): RequestHandler {
+export function requireBodyParams(schema: BodyParamsSchema): RequestHandler {
   return (req: Request, res: Response, next: NextFunction): void => {
+    const fields = Array.isArray(schema) ? schema : Object.keys(schema);
     const missing = fields.filter((f) => req.body?.[f] === undefined);
     if (missing.length > 0) {
-      res.status(400).json({ error: `Missing required parameters: ${missing.join(', ')}` });
+      res
+        .status(400)
+        .json({error: `Missing required parameters: ${missing.join(', ')}`});
       return;
     }
+
+    if (!Array.isArray(schema)) {
+      const invalid = Object.entries(schema).reduce<string[]>((acc, [key, rules]) => {
+        const value = req.body[key];
+        if (!validate(value, rules)) {
+          acc.push(key);
+        }
+        return acc;
+      }, []);
+      if (invalid.length > 0) {
+        res
+          .status(422)
+          .json({error: `Invalid parameters value : ${invalid.join(', ')}`});
+        return;
+      }
+    }
+
     next();
   };
+}
+
+function validate(value: unknown, rules: BodyParamRules): boolean {
+  switch (rules.validator) {
+  case 'email':
+    if (typeof value !== 'string') return false;
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  case 'string':
+    if (typeof value !== 'string') return false;
+    if (rules.minLength !== undefined && value.length < rules.minLength) return false;
+    if (rules.maxLength !== undefined && value.length > rules.maxLength) return false;
+    return true;
+  case 'int':
+    if (typeof value !== 'number' || !Number.isInteger(value)) return false;
+    if (rules.min !== undefined && value < rules.min) return false;
+    if (rules.max !== undefined && value > rules.max) return false;
+    return true;
+  case 'float':
+    if (typeof value !== 'number') return false;
+    if (rules.min !== undefined && value < rules.min) return false;
+    if (rules.max !== undefined && value > rules.max) return false;
+    return true;
+  case 'bool':
+    return typeof value === 'boolean';
+  default:
+    return true;
+  }
 }

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -309,7 +309,10 @@ export function createUserRouter(
      */
     router.post(
       '/auth/login',
-      requireBodyParams(['email', 'password']),
+      requireBodyParams({
+        email: {validator: 'email'},
+        password: {validator: 'string', minLength: 8, maxLength: 49},
+      }),
       async (req: Request, res: Response): Promise<void> => {
         logger.debug('POST /auth/login', getContext());
         const {email, password} = req.body;

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -103,7 +103,7 @@ describe('User REST controller', () => {
   it('should authenticate a user', async () => {
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'john@example.com', password: 'secret' });
+      .send({ email: 'john@example.com', password: 'secret123' });
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -125,7 +125,7 @@ describe('User REST controller', () => {
 
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'john@example.com', password: 'bad' });
+      .send({ email: 'john@example.com', password: 'badpass1' });
 
     expect(res.status).toBe(401);
   });
@@ -137,7 +137,7 @@ describe('User REST controller', () => {
 
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'john@example.com', password: 'secret' });
+      .send({ email: 'john@example.com', password: 'secret123' });
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('User account is suspended or archived');
@@ -148,6 +148,15 @@ describe('User REST controller', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Missing required parameters: email, password');
+  });
+
+  it('should return 422 when parameters are invalid', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'bad', password: 'short' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Invalid parameters value : email, password');
   });
 
   it('should authenticate with provider', async () => {


### PR DESCRIPTION
## Summary
- extend request body validator to support field validation
- use new validator in user controller login route
- test validation rules for login

## Testing
- `npm run lint`
- `npm test` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_688561c070808323a4392b8e785ec638