### PR TITLE
Add JWT and refresh tokens on auth

### DIFF
--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -142,3 +142,12 @@ model Invitation {
   expiresAt DateTime
   createdAt DateTime @default(now())
 }
+
+model RefreshToken {
+  id        String   @id @default(uuid())
+  token     String   @unique
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+}

--- a/backend/adapters/repositories/PrismaRefreshTokenRepository.ts
+++ b/backend/adapters/repositories/PrismaRefreshTokenRepository.ts
@@ -1,0 +1,37 @@
+/* istanbul ignore file */
+import { PrismaClient } from '@prisma/client';
+import { RefreshTokenRepositoryPort } from '../../domain/ports/RefreshTokenRepositoryPort';
+import { RefreshToken } from '../../domain/entities/RefreshToken';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
+
+/**
+ * Prisma based implementation of {@link RefreshTokenRepositoryPort}.
+ */
+export class PrismaRefreshTokenRepository implements RefreshTokenRepositoryPort {
+  constructor(private prisma: PrismaClient, private readonly logger: LoggerPort) {}
+
+  async create(token: RefreshToken): Promise<RefreshToken> {
+    this.logger.info('Creating refresh token', getContext());
+    await this.prisma.refreshToken.create({
+      data: {
+        token: token.token,
+        userId: token.userId,
+        expiresAt: token.expiresAt,
+      },
+    });
+    return token;
+  }
+
+  async findByToken(token: string): Promise<RefreshToken | null> {
+    this.logger.debug('RefreshToken findByToken', getContext());
+    const record = await this.prisma.refreshToken.findUnique({ where: { token } });
+    if (!record) return null;
+    return new RefreshToken(record.token, record.userId, record.expiresAt);
+  }
+
+  async delete(token: string): Promise<void> {
+    this.logger.debug('RefreshToken delete', getContext());
+    await this.prisma.refreshToken.deleteMany({ where: { token } });
+  }
+}

--- a/backend/adapters/token/JWTTokenServiceAdapter.ts
+++ b/backend/adapters/token/JWTTokenServiceAdapter.ts
@@ -1,0 +1,62 @@
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
+import { TokenServicePort } from '../../domain/ports/TokenServicePort';
+import { User } from '../../domain/entities/User';
+import { RefreshTokenRepositoryPort } from '../../domain/ports/RefreshTokenRepositoryPort';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { RefreshToken } from '../../domain/entities/RefreshToken';
+import { getContext } from '../../infrastructure/loggerContext';
+
+/**
+ * Token service issuing JWT access tokens and persistent refresh tokens.
+ */
+export class JWTTokenServiceAdapter implements TokenServicePort {
+  /**
+   * Create a new service instance.
+   *
+   * @param secret - Secret used to sign access tokens.
+   * @param refreshRepo - Repository storing refresh tokens.
+   * @param logger - Logger instance.
+   * @param accessDuration - JWT expiration duration string.
+   * @param refreshDuration - Refresh token validity duration string.
+   */
+  constructor(
+    private readonly secret: string,
+    private readonly refreshRepo: RefreshTokenRepositoryPort,
+    private readonly logger: LoggerPort,
+    private readonly accessDuration: string = process.env.JWT_ACCESS_TOKEN_DURATION || '15m',
+    private readonly refreshDuration: string = process.env.JWT_REFRESH_TOKEN_DURATION || '7d',
+  ) {}
+
+  generateAccessToken(user: User): string {
+    this.logger.debug('Generating access token', getContext());
+    return jwt.sign(
+      { email: user.email },
+      this.secret,
+      { subject: user.id, expiresIn: this.accessDuration } as jwt.SignOptions,
+    );
+  }
+
+  async generateRefreshToken(user: User): Promise<string> {
+    this.logger.debug('Generating refresh token', getContext());
+    const token = randomUUID();
+    const expires = new Date(Date.now() + this.parseDuration(this.refreshDuration));
+    await this.refreshRepo.create(new RefreshToken(token, user.id, expires));
+    return token;
+  }
+
+  private parseDuration(text: string): number {
+    const match = text.match(/^(\d+)([smhdw])$/);
+    if (!match) return parseInt(text, 10) * 1000;
+    const value = parseInt(match[1], 10);
+    const unit = match[2];
+    switch (unit) {
+    case 's': return value * 1000;
+    case 'm': return value * 60 * 1000;
+    case 'h': return value * 60 * 60 * 1000;
+    case 'd': return value * 24 * 60 * 60 * 1000;
+    case 'w': return value * 7 * 24 * 60 * 60 * 1000;
+    default: return value;
+    }
+  }
+}

--- a/backend/domain/entities/RefreshToken.ts
+++ b/backend/domain/entities/RefreshToken.ts
@@ -1,0 +1,17 @@
+/**
+ * Represents a refresh token associated with a user account.
+ */
+export class RefreshToken {
+  /**
+   * Create a new refresh token instance.
+   *
+   * @param token - The token string value.
+   * @param userId - Identifier of the user owning the token.
+   * @param expiresAt - Expiration date of the token.
+   */
+  constructor(
+    public readonly token: string,
+    public readonly userId: string,
+    public readonly expiresAt: Date,
+  ) {}
+}

--- a/backend/domain/ports/RefreshTokenRepositoryPort.ts
+++ b/backend/domain/ports/RefreshTokenRepositoryPort.ts
@@ -1,0 +1,29 @@
+import { RefreshToken } from '../entities/RefreshToken';
+
+/**
+ * Defines the contract for persisting refresh tokens.
+ */
+export interface RefreshTokenRepositoryPort {
+  /**
+   * Store a refresh token.
+   *
+   * @param token - Token to persist.
+   * @returns The stored {@link RefreshToken}.
+   */
+  create(token: RefreshToken): Promise<RefreshToken>;
+
+  /**
+   * Find a refresh token by its value.
+   *
+   * @param token - Token string to search for.
+   * @returns The matching {@link RefreshToken} or `null` if not found.
+   */
+  findByToken(token: string): Promise<RefreshToken | null>;
+
+  /**
+   * Delete a refresh token by value.
+   *
+   * @param token - Token string to remove.
+   */
+  delete(token: string): Promise<void>;
+}

--- a/backend/domain/ports/TokenServicePort.ts
+++ b/backend/domain/ports/TokenServicePort.ts
@@ -1,0 +1,22 @@
+import { User } from '../entities/User';
+
+/**
+ * Service responsible for issuing authentication tokens.
+ */
+export interface TokenServicePort {
+  /**
+   * Generate a short lived access token for the given user.
+   *
+   * @param user - User to encode in the token.
+   * @returns Signed JWT string.
+   */
+  generateAccessToken(user: User): string;
+
+  /**
+   * Generate and persist a refresh token for the user.
+   *
+   * @param user - User owning the token.
+   * @returns The created refresh token string.
+   */
+  generateRefreshToken(user: User): Promise<string>;
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -9,10 +9,12 @@ import { registerUserGateway } from '../adapters/controllers/websocket/userGatew
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
 import { JWTAuthServiceAdapter } from '../adapters/auth/JWTAuthServiceAdapter';
+import { JWTTokenServiceAdapter } from '../adapters/token/JWTTokenServiceAdapter';
 import { ConsoleLoggerAdapter } from '../adapters/logger/ConsoleLoggerAdapter';
 import { ConsoleEmailServiceAdapter } from '../adapters/email/ConsoleEmailServiceAdapter';
 import { LocalFileStorageAdapter } from '../adapters/storage/LocalFileStorageAdapter';
 import { AvatarService } from '../domain/services/AvatarService';
+import { PrismaRefreshTokenRepository } from '../adapters/repositories/PrismaRefreshTokenRepository';
 import { createPrisma } from './createPrisma';
 import { withContext, getContext } from './loggerContext';
 
@@ -29,6 +31,13 @@ async function bootstrap(): Promise<void> {
   const emailService = new ConsoleEmailServiceAdapter(logger);
   const storage = new LocalFileStorageAdapter(process.env.STORAGE_PATH ?? './uploads', logger);
   const avatarService = new AvatarService(storage, userRepository, logger);
+
+  const refreshRepo = new PrismaRefreshTokenRepository(prisma, logger);
+  const tokenService = new JWTTokenServiceAdapter(
+    process.env.JWT_SECRET ?? 'secret',
+    refreshRepo,
+    logger,
+  );
 
   const authService = new JWTAuthServiceAdapter(
     process.env.JWT_SECRET ?? 'secret',
@@ -60,6 +69,7 @@ async function bootstrap(): Promise<void> {
       authService,
       userRepository,
       avatarService,
+      tokenService,
       logger,
     ),
   );

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2647,11 +2647,16 @@
         },
         "responses": {
           "201": {
-            "description": "Newly created user profile.",
+            "description": "Newly created user profile with authentication tokens.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "type": "object",
+                  "properties": {
+                    "user": { "$ref": "#/components/schemas/User" },
+                    "token": { "type": "string" },
+                    "refreshToken": { "type": "string" }
+                  }
                 }
               }
             }
@@ -2808,7 +2813,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "type": "object",
+                  "properties": {
+                    "user": { "$ref": "#/components/schemas/User" },
+                    "token": { "type": "string" },
+                    "refreshToken": { "type": "string" }
+                  }
                 }
               }
             }

--- a/backend/tests/adapters/token/JWTTokenServiceAdapter.test.ts
+++ b/backend/tests/adapters/token/JWTTokenServiceAdapter.test.ts
@@ -1,0 +1,42 @@
+import jwt from 'jsonwebtoken';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { JWTTokenServiceAdapter } from '../../../adapters/token/JWTTokenServiceAdapter';
+import { RefreshTokenRepositoryPort } from '../../../domain/ports/RefreshTokenRepositoryPort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('JWTTokenServiceAdapter', () => {
+  const secret = 'secret';
+  let repo: DeepMockProxy<RefreshTokenRepositoryPort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let service: JWTTokenServiceAdapter;
+  let user: User;
+
+  beforeEach(() => {
+    repo = mockDeep<RefreshTokenRepositoryPort>();
+    logger = mockDeep<LoggerPort>();
+    const role = new Role('r', 'Role');
+    const site = new Site('s', 'Site');
+    const dept = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
+    service = new JWTTokenServiceAdapter(secret, repo, logger, '15m', '7d');
+  });
+
+  it('should generate access token', () => {
+    const token = service.generateAccessToken(user);
+    const payload = jwt.verify(token, secret) as jwt.JwtPayload;
+    expect(payload.sub).toBe('u');
+    expect(payload.email).toBe('john@example.com');
+  });
+
+  it('should generate refresh token and store it', async () => {
+    const token = await service.generateRefreshToken(user);
+    expect(repo.create).toHaveBeenCalled();
+    const saved = repo.create.mock.calls[0][0];
+    expect(saved.token).toBe(token);
+    expect(saved.userId).toBe('u');
+  });
+});

--- a/backend/tests/domain/ports/RefreshTokenRepositoryPort.test.ts
+++ b/backend/tests/domain/ports/RefreshTokenRepositoryPort.test.ts
@@ -1,0 +1,40 @@
+import { RefreshTokenRepositoryPort } from '../../../domain/ports/RefreshTokenRepositoryPort';
+import { RefreshToken } from '../../../domain/entities/RefreshToken';
+
+class MockRefreshTokenRepository implements RefreshTokenRepositoryPort {
+  private tokens: Map<string, RefreshToken> = new Map();
+
+  async create(token: RefreshToken): Promise<RefreshToken> {
+    this.tokens.set(token.token, token);
+    return token;
+  }
+
+  async findByToken(token: string): Promise<RefreshToken | null> {
+    return this.tokens.get(token) || null;
+  }
+
+  async delete(token: string): Promise<void> {
+    this.tokens.delete(token);
+  }
+}
+
+describe('RefreshTokenRepositoryPort Interface', () => {
+  let repo: MockRefreshTokenRepository;
+  let token: RefreshToken;
+
+  beforeEach(() => {
+    repo = new MockRefreshTokenRepository();
+    token = new RefreshToken('t', 'u', new Date());
+  });
+
+  it('should create and retrieve a token', async () => {
+    await repo.create(token);
+    expect(await repo.findByToken('t')).toEqual(token);
+  });
+
+  it('should delete a token', async () => {
+    await repo.create(token);
+    await repo.delete('t');
+    expect(await repo.findByToken('t')).toBeNull();
+  });
+});

--- a/backend/tests/usecases/user/AuthenticateUserUseCase.test.ts
+++ b/backend/tests/usecases/user/AuthenticateUserUseCase.test.ts
@@ -1,6 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { AuthenticateUserUseCase } from '../../../usecases/user/AuthenticateUserUseCase';
 import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { TokenServicePort } from '../../../domain/ports/TokenServicePort';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
@@ -8,6 +9,7 @@ import { Site } from '../../../domain/entities/Site';
 
 describe('AuthenticateUserUseCase', () => {
   let service: DeepMockProxy<AuthServicePort>;
+  let tokenService: DeepMockProxy<TokenServicePort>;
   let useCase: AuthenticateUserUseCase;
   let user: User;
   let role: Role;
@@ -16,7 +18,8 @@ describe('AuthenticateUserUseCase', () => {
 
   beforeEach(() => {
     service = mockDeep<AuthServicePort>();
-    useCase = new AuthenticateUserUseCase(service);
+    tokenService = mockDeep<TokenServicePort>();
+    useCase = new AuthenticateUserUseCase(service, tokenService);
     role = new Role('role-1', 'Admin');
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
@@ -25,10 +28,14 @@ describe('AuthenticateUserUseCase', () => {
 
   it('should authenticate via service', async () => {
     service.authenticate.mockResolvedValue(user);
+    tokenService.generateAccessToken.mockReturnValue('t');
+    tokenService.generateRefreshToken.mockResolvedValue('r');
 
     const result = await useCase.execute('john@example.com', 'secret');
 
-    expect(result).toBe(user);
+    expect(result).toEqual({ user, token: 't', refreshToken: 'r' });
     expect(service.authenticate).toHaveBeenCalledWith('john@example.com', 'secret');
+    expect(tokenService.generateAccessToken).toHaveBeenCalledWith(user);
+    expect(tokenService.generateRefreshToken).toHaveBeenCalledWith(user);
   });
 });

--- a/backend/tests/usecases/user/RegisterUserUseCase.test.ts
+++ b/backend/tests/usecases/user/RegisterUserUseCase.test.ts
@@ -1,6 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { RegisterUserUseCase } from '../../../usecases/user/RegisterUserUseCase';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { TokenServicePort } from '../../../domain/ports/TokenServicePort';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
@@ -8,6 +9,7 @@ import { Site } from '../../../domain/entities/Site';
 
 describe('RegisterUserUseCase', () => {
   let repository: DeepMockProxy<UserRepositoryPort>;
+  let tokenService: DeepMockProxy<TokenServicePort>;
   let useCase: RegisterUserUseCase;
   let user: User;
   let role: Role;
@@ -16,7 +18,8 @@ describe('RegisterUserUseCase', () => {
 
   beforeEach(() => {
     repository = mockDeep<UserRepositoryPort>();
-    useCase = new RegisterUserUseCase(repository);
+    tokenService = mockDeep<TokenServicePort>();
+    useCase = new RegisterUserUseCase(repository, tokenService);
     role = new Role('role-1', 'Admin');
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
@@ -25,10 +28,14 @@ describe('RegisterUserUseCase', () => {
 
   it('should create a user via repository', async () => {
     repository.create.mockResolvedValue(user);
+    tokenService.generateAccessToken.mockReturnValue('t');
+    tokenService.generateRefreshToken.mockResolvedValue('r');
 
     const result = await useCase.execute(user);
 
-    expect(result).toBe(user);
+    expect(result).toEqual({ user, token: 't', refreshToken: 'r' });
     expect(repository.create).toHaveBeenCalledWith(user);
+    expect(tokenService.generateAccessToken).toHaveBeenCalledWith(user);
+    expect(tokenService.generateRefreshToken).toHaveBeenCalledWith(user);
   });
 });

--- a/backend/usecases/user/AuthenticateUserUseCase.ts
+++ b/backend/usecases/user/AuthenticateUserUseCase.ts
@@ -1,20 +1,31 @@
 import { AuthServicePort } from '../../domain/ports/AuthServicePort';
+import { TokenServicePort } from '../../domain/ports/TokenServicePort';
 import { User } from '../../domain/entities/User';
 
 /**
- * Use case for authenticating a user using login and password.
+ * Use case for authenticating a user using login and password
+ * and issuing authentication tokens.
  */
 export class AuthenticateUserUseCase {
-  constructor(private readonly authService: AuthServicePort) {}
+  constructor(
+    private readonly authService: AuthServicePort,
+    private readonly tokenService: TokenServicePort,
+  ) {}
 
   /**
    * Execute the authentication.
    *
    * @param email - User email used for login.
    * @param password - User password.
-   * @returns The authenticated {@link User}.
+   * @returns Authenticated user profile and tokens.
    */
-  async execute(email: string, password: string): Promise<User> {
-    return this.authService.authenticate(email, password);
+  async execute(
+    email: string,
+    password: string,
+  ): Promise<{ user: User; token: string; refreshToken: string }> {
+    const user = await this.authService.authenticate(email, password);
+    const token = this.tokenService.generateAccessToken(user);
+    const refreshToken = await this.tokenService.generateRefreshToken(user);
+    return { user, token, refreshToken };
   }
 }

--- a/backend/usecases/user/RegisterUserUseCase.ts
+++ b/backend/usecases/user/RegisterUserUseCase.ts
@@ -1,19 +1,27 @@
 import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { TokenServicePort } from '../../domain/ports/TokenServicePort';
 import { User } from '../../domain/entities/User';
 
 /**
- * Use case responsible for registering a new {@link User}.
+ * Use case responsible for registering a new {@link User}
+ * and issuing authentication tokens.
  */
 export class RegisterUserUseCase {
-  constructor(private readonly userRepository: UserRepositoryPort) {}
+  constructor(
+    private readonly userRepository: UserRepositoryPort,
+    private readonly tokenService: TokenServicePort,
+  ) {}
 
   /**
    * Execute the use case.
    *
    * @param user - The user to persist.
-   * @returns The registered {@link User}.
+   * @returns The registered user profile and tokens.
    */
-  async execute(user: User): Promise<User> {
-    return this.userRepository.create(user);
+  async execute(user: User): Promise<{ user: User; token: string; refreshToken: string }> {
+    const created = await this.userRepository.create(user);
+    const token = this.tokenService.generateAccessToken(created);
+    const refreshToken = await this.tokenService.generateRefreshToken(created);
+    return { user: created, token, refreshToken };
   }
 }


### PR DESCRIPTION
## Summary
- generate JWT and refresh tokens on login and registration
- store refresh tokens via new repository and service
- document new response schema in Swagger docs
- update REST controller and use cases to return tokens
- add unit tests for new service and repository

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688618e034688323b921e652cd1fda93