### PR TITLE
Add audit info handling in user use cases

### DIFF
--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -223,6 +223,16 @@ export function createUserRouter(
       );
     }
 
+    function serializeUser(u: User): Record<string, unknown> {
+      return {
+        ...u,
+        createdAt: u.createdAt.toISOString(),
+        updatedAt: u.updatedAt.toISOString(),
+        createdBy: null,
+        updatedBy: null,
+      };
+    }
+
     const authMiddleware: express.RequestHandler = async (req, res, next) => {
       logger.debug('REST auth middleware', getContext());
       const header = req.headers.authorization;
@@ -795,7 +805,7 @@ export function createUserRouter(
       try {
         const updated = await useCase.execute(user);
         logger.debug('User profile updated', getContext());
-        res.json(updated);
+        res.json(serializeUser(updated));
       } catch (err) {
         if ((err as Error).message === 'Forbidden') {
           logger.warn('Permission denied updating user', { ...getContext(), error: err });
@@ -863,7 +873,7 @@ export function createUserRouter(
           return;
         }
         logger.debug('User status changed', getContext());
-        res.json(updated);
+        res.json(serializeUser(updated));
       } catch (err) {
         if ((err as Error).message === 'Forbidden') {
           logger.warn('Permission denied changing status', { ...getContext(), error: err });

--- a/backend/adapters/orm/prisma/migrations/20250727163015_add_user_audit_fields/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250727163015_add_user_audit_fields/migration.sql
@@ -1,0 +1,7 @@
+-- Add audit columns to User
+ALTER TABLE "User" ADD COLUMN "createdById" TEXT;
+ALTER TABLE "User" ADD COLUMN "updatedById" TEXT;
+
+-- Add foreign key constraints
+ALTER TABLE "User" ADD CONSTRAINT "User_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "User" ADD CONSTRAINT "User_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -19,6 +19,10 @@ model User {
   emailVerified      Boolean?               @default(false)
   externalId         String?
   externalProvider   String?
+  createdBy          User?                  @relation("UserCreatedBy", fields: [createdById], references: [id])
+  createdById        String?
+  updatedBy          User?                  @relation("UserUpdatedBy", fields: [updatedById], references: [id])
+  updatedById        String?
   createdAt          DateTime               @default(now())
   updatedAt          DateTime               @updatedAt
   department         Department             @relation(fields: [departmentId], references: [id])
@@ -30,6 +34,8 @@ model User {
   managedDepartments Department[]           @relation("DepartmentManager")
   groups             UserGroupMember[]
   responsibleGroups  UserGroupResponsible[]
+  createdUsers       User[]                 @relation("UserCreatedBy")
+  updatedUsers       User[]                 @relation("UserUpdatedBy")
   RefreshToken       RefreshToken[]
 }
 

--- a/backend/adapters/repositories/PrismaUserRepository.ts
+++ b/backend/adapters/repositories/PrismaUserRepository.ts
@@ -68,6 +68,10 @@ export class PrismaUserRepository implements UserRepositoryPort {
       record.permissions.map((up) =>
         new Permission(up.permission.id, up.permission.permissionKey, up.permission.description),
       ),
+      record.createdAt,
+      record.updatedAt,
+      null,
+      null,
     );
   }
 
@@ -80,6 +84,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return record ? this.mapRecord(record) : null;
@@ -93,6 +99,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return records.map(r => this.mapRecord(r));
@@ -132,6 +140,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     const total = await this.prisma.user.count({ where });
@@ -152,6 +162,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return record ? this.mapRecord(record) : null;
@@ -169,6 +181,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return record ? this.mapRecord(record) : null;
@@ -183,6 +197,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return records.map(r => this.mapRecord(r));
@@ -197,6 +213,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return records.map(r => this.mapRecord(r));
@@ -211,6 +229,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return records.map(r => this.mapRecord(r));
@@ -229,6 +249,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         departmentId: user.department.id,
         siteId: user.site.id,
         picture: user.picture,
+        createdById: user.createdBy?.id,
+        updatedById: user.updatedBy?.id,
         permissions: {
           create: user.permissions.map((p) => ({ permission: { connect: { id: p.id } } })),
         },
@@ -241,6 +263,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return this.mapRecord(record);
@@ -258,6 +282,7 @@ export class PrismaUserRepository implements UserRepositoryPort {
         departmentId: user.department.id,
         siteId: user.site.id,
         picture: user.picture,
+        updatedById: user.updatedBy?.id,
         permissions: {
           deleteMany: {},
           create: user.permissions.map((p) => ({ permission: { connect: { id: p.id } } })),
@@ -272,6 +297,8 @@ export class PrismaUserRepository implements UserRepositoryPort {
         department: { include: { site: true } },
         site: true,
         permissions: { include: { permission: true } },
+        createdBy: true,
+        updatedBy: true,
       },
     });
     return this.mapRecord(record);

--- a/backend/domain/entities/User.ts
+++ b/backend/domain/entities/User.ts
@@ -20,7 +20,11 @@ export class User {
    * @param site - {@link Site} where the user is located.
    * @param picture - Optional profile picture URL.
    * @param permissions - Collection of {@link Permission} granted directly to the user.
-  */
+   * @param createdAt - Date when the user was created.
+   * @param updatedAt - Date when the user was last updated. Defaults to {@link createdAt}.
+   * @param createdBy - User who created this record or `null` when created automatically.
+   * @param updatedBy - User who last updated this record or `null` when updated automatically.
+   */
   constructor(
     public readonly id: string,
     public firstName: string,
@@ -32,6 +36,14 @@ export class User {
     public site: Site,
     public picture?: string,
     public permissions: Permission[] = [],
+    /** Date when the user record was created. */
+    public createdAt: Date = new Date(),
+    /** Date when the user record was last updated. Defaults to {@link createdAt}. */
+    public updatedAt: Date = createdAt,
+    /** User that created this record or `null` when created automatically. */
+    public createdBy: User | null = null,
+    /** User that last updated this record or `null` when updated automatically. */
+    public updatedBy: User | null = createdBy,
   ) {}
 }
 

--- a/backend/domain/services/PermissionChecker.ts
+++ b/backend/domain/services/PermissionChecker.ts
@@ -13,6 +13,15 @@ export class PermissionChecker {
   constructor(private readonly user: User) {}
 
   /**
+   * Retrieve the user associated with this checker.
+   *
+   * @returns The current authenticated {@link User}.
+   */
+  get currentUser(): User {
+    return this.user;
+  }
+
+  /**
    * Determine whether the user has the requested permission key or the root permission.
    *
    * @param key - Permission key to verify.

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -71,6 +71,10 @@ describe('User REST controller', () => {
       department,
       site,
       permissions: [],
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+      createdBy: null,
+      updatedBy: null,
     });
     expect(auth.verifyToken).toHaveBeenCalledWith('token');
   });
@@ -106,7 +110,17 @@ describe('User REST controller', () => {
       .send({ id: 'u', firstName: 'John', lastName: 'Doe', email: 'john@example.com', roles: [{ id: 'r', label: 'Role' }], status: 'active', permissions: [{ id: 'p', permissionKey: 'k', description: 'd' }], department: { id: 'd', label: 'Dept', site: { id: 's', label: 'Site' } }, site: { id: 's', label: 'Site' } });
 
     expect(res.status).toBe(201);
-    expect(res.body).toEqual({ user, token: 't', refreshToken: 'r' });
+    expect(res.body).toEqual({
+      user: {
+        ...user,
+        createdAt: user.createdAt.toISOString(),
+        updatedAt: user.updatedAt.toISOString(),
+        createdBy: null,
+        updatedBy: null,
+      },
+      token: 't',
+      refreshToken: 'r',
+    });
     expect(repo.create).toHaveBeenCalled();
   });
 
@@ -119,7 +133,17 @@ describe('User REST controller', () => {
       .send({ email: 'john@example.com', password: 'secret123' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ user, token: 't', refreshToken: 'r' });
+    expect(res.body).toEqual({
+      user: {
+        ...user,
+        createdAt: user.createdAt.toISOString(),
+        updatedAt: user.updatedAt.toISOString(),
+        createdBy: null,
+        updatedBy: null,
+      },
+      token: 't',
+      refreshToken: 'r',
+    });
     expect(auth.authenticate).toHaveBeenCalled();
   });
 

--- a/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
@@ -21,6 +21,8 @@ describe('PrismaUserRepository', () => {
     department: { include: { site: true } },
     site: true,
     permissions: { include: { permission: true } },
+    createdBy: true,
+    updatedBy: true,
   };
 
   beforeEach(() => {
@@ -321,6 +323,8 @@ describe('PrismaUserRepository', () => {
           departmentId: 'dept-1',
           siteId: 'site-1',
           picture: undefined,
+          createdById: undefined,
+          updatedById: undefined,
           permissions: { create: [] },
           status: 'active',
           roles: {
@@ -368,6 +372,8 @@ describe('PrismaUserRepository', () => {
           departmentId: 'dept-1',
           siteId: 'site-1',
           picture: undefined,
+          createdById: undefined,
+          updatedById: undefined,
           permissions: { create: [{ permission: { connect: { id: 'perm-1' } } }] },
           status: 'active',
           roles: {
@@ -423,6 +429,8 @@ describe('PrismaUserRepository', () => {
           departmentId: 'dept-1',
           siteId: 'site-1',
           picture: undefined,
+          createdById: undefined,
+          updatedById: undefined,
           permissions: { create: [] },
           status: 'active',
           roles: {
@@ -496,6 +504,7 @@ describe('PrismaUserRepository', () => {
           departmentId: 'dept-1',
           siteId: 'site-1',
           picture: undefined,
+          updatedById: undefined,
           permissions: { deleteMany: {}, create: [] },
           roles: {
             deleteMany: {},
@@ -565,6 +574,7 @@ describe('PrismaUserRepository', () => {
           departmentId: 'dept-1',
           siteId: 'site-1',
           picture: undefined,
+          updatedById: undefined,
           permissions: { deleteMany: {}, create: [] },
           roles: {
             deleteMany: {},
@@ -623,6 +633,7 @@ describe('PrismaUserRepository', () => {
           departmentId: 'dept-1',
           siteId: 'site-1',
           picture: undefined,
+          updatedById: undefined,
           permissions: { deleteMany: {}, create: [{ permission: { connect: { id: 'perm-2' } } }] },
           roles: {
             deleteMany: {},
@@ -679,6 +690,7 @@ describe('PrismaUserRepository', () => {
           departmentId: 'dept-1',
           siteId: 'site-1',
           picture: undefined,
+          updatedById: undefined,
           permissions: { deleteMany: {}, create: [] },
           roles: {
             deleteMany: {},

--- a/backend/tests/domain/entities/User.test.ts
+++ b/backend/tests/domain/entities/User.test.ts
@@ -141,4 +141,27 @@ describe('User Entity', () => {
       expect(multiRoleUser.roles).toContain(userRole);
     });
   });
+
+  describe('Timestamps and Audit Fields', () => {
+    it('should set default createdAt and updatedAt values', () => {
+      const newUser = new User('u1', 'A', 'B', 'a@b.c', [], 'active', department, site);
+
+      expect(newUser.createdAt).toBeInstanceOf(Date);
+      expect(newUser.updatedAt).toEqual(newUser.createdAt);
+      expect(newUser.createdBy).toBeNull();
+      expect(newUser.updatedBy).toBeNull();
+    });
+
+    it('should accept custom audit information', () => {
+      const creator = new User('c1', 'C', 'D', 'c@d.e', [], 'active', department, site);
+      const updater = new User('u2', 'U', 'D', 'u@d.e', [], 'active', department, site);
+      const date = new Date('2020-01-01T00:00:00Z');
+      const auditedUser = new User('u3', 'F', 'L', 'f@l.c', [], 'active', department, site, undefined, [], date, date, creator, updater);
+
+      expect(auditedUser.createdAt).toBe(date);
+      expect(auditedUser.updatedAt).toBe(date);
+      expect(auditedUser.createdBy).toBe(creator);
+      expect(auditedUser.updatedBy).toBe(updater);
+    });
+  });
 });

--- a/backend/tests/domain/services/PermissionChecker.test.ts
+++ b/backend/tests/domain/services/PermissionChecker.test.ts
@@ -58,4 +58,10 @@ describe('PermissionChecker', () => {
     const checker = new PermissionChecker(user);
     expect(checker.has(PermissionKeys.READ_USERS)).toBe(false);
   });
+
+  it('exposes the current user', () => {
+    const user = new User('u', 'John', 'Doe', 'j@e.c', [], 'active', dept, site);
+    const checker = new PermissionChecker(user);
+    expect(checker.currentUser).toBe(user);
+  });
 });

--- a/backend/tests/usecases/user/ChangeUserStatusUseCase.test.ts
+++ b/backend/tests/usecases/user/ChangeUserStatusUseCase.test.ts
@@ -47,6 +47,8 @@ describe('ChangeUserStatusUseCase', () => {
 
     expect(result).toBe(user);
     expect(user.status).toBe('suspended');
+    expect(user.updatedBy).toBe(checker.currentUser);
+    expect(user.updatedAt).toBeInstanceOf(Date);
     expect(repository.findById).toHaveBeenCalledWith('user-1');
     expect(repository.update).toHaveBeenCalledWith(user);
   });

--- a/backend/tests/usecases/user/RegisterUserUseCase.test.ts
+++ b/backend/tests/usecases/user/RegisterUserUseCase.test.ts
@@ -34,6 +34,10 @@ describe('RegisterUserUseCase', () => {
     const result = await useCase.execute(user);
 
     expect(result).toEqual({ user, token: 't', refreshToken: 'r' });
+    expect(user.createdAt).toBeInstanceOf(Date);
+    expect(user.updatedAt).toBeInstanceOf(Date);
+    expect(user.createdBy).toBeNull();
+    expect(user.updatedBy).toBeNull();
     expect(repository.create).toHaveBeenCalledWith(user);
     expect(tokenService.generateAccessToken).toHaveBeenCalledWith(user);
     expect(tokenService.generateRefreshToken).toHaveBeenCalledWith(user);

--- a/backend/tests/usecases/user/UpdateUserProfileUseCase.test.ts
+++ b/backend/tests/usecases/user/UpdateUserProfileUseCase.test.ts
@@ -45,6 +45,8 @@ describe('UpdateUserProfileUseCase', () => {
     const result = await useCase.execute(user);
 
     expect(result).toBe(user);
+    expect(user.updatedBy).toBe(checker.currentUser);
+    expect(user.updatedAt).toBeInstanceOf(Date);
     expect(repository.update).toHaveBeenCalledWith(user);
   });
 

--- a/backend/usecases/user/ChangeUserStatusUseCase.ts
+++ b/backend/usecases/user/ChangeUserStatusUseCase.ts
@@ -26,6 +26,8 @@ export class ChangeUserStatusUseCase {
       return null;
     }
     user.status = status;
+    user.updatedAt = new Date();
+    user.updatedBy = this.checker.currentUser;
     return this.userRepository.update(user);
   }
 }

--- a/backend/usecases/user/RegisterUserUseCase.ts
+++ b/backend/usecases/user/RegisterUserUseCase.ts
@@ -19,6 +19,10 @@ export class RegisterUserUseCase {
    * @returns The registered user profile and tokens.
    */
   async execute(user: User): Promise<{ user: User; token: string; refreshToken: string }> {
+    user.createdAt = new Date();
+    user.updatedAt = user.createdAt;
+    user.createdBy = null;
+    user.updatedBy = null;
     const created = await this.userRepository.create(user);
     const token = this.tokenService.generateAccessToken(created);
     const refreshToken = await this.tokenService.generateRefreshToken(created);

--- a/backend/usecases/user/UpdateUserProfileUseCase.ts
+++ b/backend/usecases/user/UpdateUserProfileUseCase.ts
@@ -20,6 +20,8 @@ export class UpdateUserProfileUseCase {
    */
   async execute(user: User): Promise<User> {
     this.checker.check(PermissionKeys.UPDATE_USER);
+    user.updatedAt = new Date();
+    user.updatedBy = this.checker.currentUser;
     return this.userRepository.update(user);
   }
 }


### PR DESCRIPTION
## Summary
- expose current user from `PermissionChecker`
- update user creation and update use cases to set audit fields
- serialize user responses to avoid circular references
- adjust unit tests for audit metadata

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68864f99819483239ef656de381cb901