### PR TITLE
Add audit fields to user groups

### DIFF
--- a/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
@@ -94,6 +94,10 @@ CREATE TABLE "UserGroup" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "UserGroup_pkey" PRIMARY KEY ("id")
 );
@@ -208,6 +212,12 @@ ALTER TABLE "UserGroupResponsible" ADD CONSTRAINT "UserGroupResponsible_userId_f
 
 -- AddForeignKey
 ALTER TABLE "UserGroupResponsible" ADD CONSTRAINT "UserGroupResponsible_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "UserGroup"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserGroup" ADD CONSTRAINT "UserGroup_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserGroup" ADD CONSTRAINT "UserGroup_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -34,6 +34,8 @@ model User {
   managedDepartments Department[]           @relation("DepartmentManager")
   groups             UserGroupMember[]
   responsibleGroups  UserGroupResponsible[]
+  createdGroups      UserGroup[]           @relation("UserGroupCreatedBy")
+  updatedGroups      UserGroup[]           @relation("UserGroupUpdatedBy")
   createdUsers       User[]                 @relation("UserCreatedBy")
   updatedUsers       User[]                 @relation("UserUpdatedBy")
   RefreshToken       RefreshToken[]
@@ -116,6 +118,12 @@ model UserGroup {
   id           String                 @id @default(uuid())
   name         String
   description  String?
+  createdBy    User?                  @relation("UserGroupCreatedBy", fields: [createdById], references: [id])
+  createdById  String?
+  updatedBy    User?                  @relation("UserGroupUpdatedBy", fields: [updatedById], references: [id])
+  updatedById  String?
+  createdAt    DateTime               @default(now())
+  updatedAt    DateTime               @updatedAt
   responsibles UserGroupResponsible[]
   members      UserGroupMember[]
 }

--- a/backend/adapters/repositories/PrismaUserGroupRepository.ts
+++ b/backend/adapters/repositories/PrismaUserGroupRepository.ts
@@ -63,6 +63,20 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
       site: PrismaSite;
       permissions: Array<{ permission: PrismaPermission }>;
     } }>;
+    createdBy?: PrismaUser & {
+      roles: Array<{ role: PrismaRole }>;
+      department: PrismaDepartment & { site: PrismaSite };
+      site: PrismaSite;
+      permissions: Array<{ permission: PrismaPermission }>;
+    } | null;
+    updatedBy?: PrismaUser & {
+      roles: Array<{ role: PrismaRole }>;
+      department: PrismaDepartment & { site: PrismaSite };
+      site: PrismaSite;
+      permissions: Array<{ permission: PrismaPermission }>;
+    } | null;
+    createdAt: Date;
+    updatedAt: Date;
   }): UserGroup {
     return new UserGroup(
       record.id,
@@ -72,6 +86,10 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       record.members.map((m: any) => this.mapUser(m.user)),
       record.description ?? undefined,
+      record.createdAt,
+      record.updatedAt,
+      record.createdBy ? this.mapUser(record.createdBy) : null,
+      record.updatedBy ? this.mapUser(record.updatedBy) : null,
     );
   }
 
@@ -81,6 +99,8 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
     const record = await (this.prisma as any).userGroup.findUnique({
       where: { id },
       include: {
+        createdBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
+        updatedBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
         responsibles: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
         members: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
       },
@@ -93,6 +113,8 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const records = await (this.prisma as any).userGroup.findMany({
       include: {
+        createdBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
+        updatedBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
         responsibles: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
         members: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
       },
@@ -116,6 +138,8 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
       take: params.limit,
       where,
       include: {
+        createdBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
+        updatedBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
         responsibles: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
         members: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
       },
@@ -139,6 +163,8 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
         id: group.id,
         name: group.name,
         description: group.description,
+        createdById: group.createdBy?.id,
+        updatedById: group.updatedBy?.id,
         responsibles: {
           create: group.responsibleUsers.map(u => ({ user: { connect: { id: u.id } } })),
         },
@@ -147,6 +173,8 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
         },
       },
       include: {
+        createdBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
+        updatedBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
         responsibles: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
         members: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
       },
@@ -162,8 +190,11 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
       data: {
         name: group.name,
         description: group.description,
+        updatedById: group.updatedBy?.id,
       },
       include: {
+        createdBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
+        updatedBy: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } },
         responsibles: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
         members: { include: { user: { include: { roles: { include: { role: true } }, department: { include: { site: true } }, site: true, permissions: { include: { permission: true } } } } } },
       },

--- a/backend/domain/entities/UserGroup.ts
+++ b/backend/domain/entities/UserGroup.ts
@@ -12,6 +12,10 @@ export class UserGroup {
    * @param responsibleUsers - Users responsible for managing the group.
    * @param members - Users belonging to the group.
    * @param description - Optional description of the group.
+   * @param createdAt - Date of creation.
+   * @param updatedAt - Date of last modification. Defaults to {@link createdAt}.
+   * @param createdBy - User who created this record or `null` if created automatically.
+   * @param updatedBy - User who last updated this record or `null` if updated automatically.
    */
   constructor(
     public readonly id: string,
@@ -19,5 +23,13 @@ export class UserGroup {
     public responsibleUsers: User[] = [],
     public members: User[] = [],
     public description?: string,
+    /** Date when the group was created. */
+    public createdAt: Date = new Date(),
+    /** Date when the group was last updated. Defaults to {@link createdAt}. */
+    public updatedAt: Date = createdAt,
+    /** User that created the group or `null` when created automatically. */
+    public createdBy: User | null = null,
+    /** User that last updated the group or `null` when updated automatically. */
+    public updatedBy: User | null = createdBy,
   ) {}
 }

--- a/backend/tests/adapters/repositories/PrismaUserGroupRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserGroupRepository.test.ts
@@ -34,6 +34,10 @@ describe('PrismaUserGroupRepository', () => {
       id: 'g',
       name: 'Group',
       description: null,
+      createdAt: new Date('2020-01-01T00:00:00Z'),
+      updatedAt: new Date('2020-01-01T00:00:00Z'),
+      createdBy: null,
+      updatedBy: null,
       responsibles: [{ user: {
         id: 'u',
         firstname: 'John',
@@ -58,6 +62,10 @@ describe('PrismaUserGroupRepository', () => {
         id: 'g',
         name: 'Group',
         description: null,
+        createdAt: new Date('2020-01-01T00:00:00Z'),
+        updatedAt: new Date('2020-01-01T00:00:00Z'),
+        createdBy: null,
+        updatedBy: null,
         responsibles: [{ user: {
           id: 'u',
           firstname: 'John',
@@ -81,6 +89,30 @@ describe('PrismaUserGroupRepository', () => {
       id: 'g',
       name: 'Group',
       description: null,
+      createdAt: new Date('2020-01-01T00:00:00Z'),
+      updatedAt: new Date('2020-01-01T00:00:00Z'),
+      createdBy: {
+        id: 'c',
+        firstname: 'Creator',
+        lastname: 'User',
+        email: 'c@u.com',
+        roles: [],
+        status: 'active',
+        department: { id: 'd', label: 'Dept', parentDepartmentId: null, managerUserId: null, site: { id: 's', label: 'Site' } },
+        site: { id: 's', label: 'Site' },
+        permissions: []
+      },
+      updatedBy: {
+        id: 'u2',
+        firstname: 'Updater',
+        lastname: 'User',
+        email: 'u@u.com',
+        roles: [],
+        status: 'active',
+        department: { id: 'd', label: 'Dept', parentDepartmentId: null, managerUserId: null, site: { id: 's', label: 'Site' } },
+        site: { id: 's', label: 'Site' },
+        permissions: []
+      },
       responsibles: [{ user: {
         id: 'u',
         firstname: 'John',
@@ -114,6 +146,10 @@ describe('PrismaUserGroupRepository', () => {
       id: 'g',
       name: 'New',
       description: null,
+      createdAt: new Date('2020-01-01T00:00:00Z'),
+      updatedAt: new Date('2020-01-01T00:00:00Z'),
+      createdBy: null,
+      updatedBy: null,
       responsibles: [{ user: {
         id: 'u',
         firstname: 'John',

--- a/backend/tests/domain/entities/UserGroup.test.ts
+++ b/backend/tests/domain/entities/UserGroup.test.ts
@@ -42,5 +42,20 @@ describe('UserGroup Entity', () => {
     expect(g.members).toEqual([]);
     expect(g.responsibleUsers).toEqual([]);
     expect(g.description).toBeUndefined();
+    expect(g.createdAt).toBeInstanceOf(Date);
+    expect(g.updatedAt).toEqual(g.createdAt);
+    expect(g.createdBy).toBeNull();
+    expect(g.updatedBy).toBeNull();
+  });
+
+  it('should accept custom audit information', () => {
+    const creator = new User('c', 'C', 'R', 'c@r.io', [role], 'active', department, site);
+    const updater = new User('u2', 'U', 'P', 'u@p.io', [role], 'active', department, site);
+    const date = new Date('2020-01-01T00:00:00Z');
+    const audited = new UserGroup('id2', 'name', [], [], undefined, date, date, creator, updater);
+    expect(audited.createdAt).toBe(date);
+    expect(audited.updatedAt).toBe(date);
+    expect(audited.createdBy).toBe(creator);
+    expect(audited.updatedBy).toBe(updater);
   });
 });

--- a/backend/usecases/group/AddGroupResponsibleUseCase.ts
+++ b/backend/usecases/group/AddGroupResponsibleUseCase.ts
@@ -29,6 +29,8 @@ export class AddGroupResponsibleUseCase {
     if (!group || !user) {
       return null;
     }
+    group.updatedAt = new Date();
+    group.updatedBy = this.checker.currentUser;
     return this.groupRepository.addResponsible(groupId, userId);
   }
 }

--- a/backend/usecases/group/AddGroupUserUseCase.ts
+++ b/backend/usecases/group/AddGroupUserUseCase.ts
@@ -30,6 +30,8 @@ export class AddGroupUserUseCase {
       return null;
     }
     group.members.push(user);
+    group.updatedAt = new Date();
+    group.updatedBy = this.checker.currentUser;
     return this.groupRepository.addUser(groupId, userId);
   }
 }

--- a/backend/usecases/group/CreateUserGroupUseCase.ts
+++ b/backend/usecases/group/CreateUserGroupUseCase.ts
@@ -21,6 +21,11 @@ export class CreateUserGroupUseCase {
    */
   async execute(group: UserGroup): Promise<UserGroup> {
     this.checker.check(PermissionKeys.CREATE_GROUP);
+    const now = new Date();
+    group.createdAt = now;
+    group.updatedAt = now;
+    group.createdBy = this.checker.currentUser;
+    group.updatedBy = this.checker.currentUser;
     return this.repository.create(group);
   }
 }

--- a/backend/usecases/group/RemoveGroupResponsibleUseCase.ts
+++ b/backend/usecases/group/RemoveGroupResponsibleUseCase.ts
@@ -29,6 +29,8 @@ export class RemoveGroupResponsibleUseCase {
     if (!group || !user) {
       return null;
     }
+    group.updatedAt = new Date();
+    group.updatedBy = this.checker.currentUser;
     return this.groupRepository.removeResponsible(groupId, userId);
   }
 }

--- a/backend/usecases/group/RemoveGroupUserUseCase.ts
+++ b/backend/usecases/group/RemoveGroupUserUseCase.ts
@@ -29,6 +29,8 @@ export class RemoveGroupUserUseCase {
     if (!group || !user) {
       return null;
     }
+    group.updatedAt = new Date();
+    group.updatedBy = this.checker.currentUser;
     return this.groupRepository.removeUser(groupId, userId);
   }
 }

--- a/backend/usecases/group/UpdateUserGroupUseCase.ts
+++ b/backend/usecases/group/UpdateUserGroupUseCase.ts
@@ -21,6 +21,8 @@ export class UpdateUserGroupUseCase {
    */
   async execute(group: UserGroup): Promise<UserGroup> {
     this.checker.check(PermissionKeys.UPDATE_GROUP);
+    group.updatedAt = new Date();
+    group.updatedBy = this.checker.currentUser;
     return this.repository.update(group);
   }
 }


### PR DESCRIPTION
## Summary
- add createdAt, updatedAt, createdBy and updatedBy to UserGroup entity
- support the new audit fields in Prisma schema and migration
- map audit fields in PrismaUserGroupRepository
- update group use cases to set audit information
- extend tests for updated behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68866344c04c8323b1b2ebcc65113a54