### PR TITLE
Add auditing to permissions

### DIFF
--- a/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
@@ -57,6 +57,10 @@ CREATE TABLE "Permission" (
     "id" TEXT NOT NULL,
     "permissionKey" TEXT NOT NULL,
     "description" TEXT NOT NULL,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Permission_pkey" PRIMARY KEY ("id")
 );
@@ -196,6 +200,12 @@ ALTER TABLE "Role" ADD CONSTRAINT "Role_createdById_fkey" FOREIGN KEY ("createdB
 
 -- AddForeignKey
 ALTER TABLE "Role" ADD CONSTRAINT "Role_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Permission" ADD CONSTRAINT "Permission_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Permission" ADD CONSTRAINT "Permission_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "UserRole" ADD CONSTRAINT "UserRole_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -42,6 +42,8 @@ model User {
   updatedSites       Site[]                 @relation("SiteUpdatedBy")
   createdRoles       Role[]                 @relation("RoleCreatedBy")
   updatedRoles       Role[]                 @relation("RoleUpdatedBy")
+  createdPermissions Permission[]           @relation("PermissionCreatedBy")
+  updatedPermissions Permission[]           @relation("PermissionUpdatedBy")
   RefreshToken       RefreshToken[]
 }
 
@@ -85,6 +87,12 @@ model Permission {
   id                    String                 @id @default(uuid())
   permissionKey         String                 @unique
   description           String
+  createdBy             User?                  @relation("PermissionCreatedBy", fields: [createdById], references: [id])
+  createdById           String?
+  updatedBy             User?                  @relation("PermissionUpdatedBy", fields: [updatedById], references: [id])
+  updatedById           String?
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @updatedAt
   userPermissions       UserPermission[]
   rolePermissions       RolePermission[]
   departmentPermissions DepartmentPermission[]

--- a/backend/adapters/repositories/PrismaPermissionRepository.ts
+++ b/backend/adapters/repositories/PrismaPermissionRepository.ts
@@ -19,7 +19,15 @@ export class PrismaPermissionRepository implements PermissionRepositoryPort {
   ) {}
 
   private mapRecord(record: PrismaPermission): Permission {
-    return new Permission(record.id, record.permissionKey, record.description);
+    return new Permission(
+      record.id,
+      record.permissionKey,
+      record.description,
+      record.createdAt,
+      record.updatedAt,
+      null,
+      null,
+    );
   }
 
   async findById(id: string): Promise<Permission | null> {
@@ -69,7 +77,13 @@ export class PrismaPermissionRepository implements PermissionRepositoryPort {
   async create(permission: Permission): Promise<Permission> {
     this.logger.info('Creating permission', getContext());
     const record = await this.prisma.permission.create({
-      data: { id: permission.id, permissionKey: permission.permissionKey, description: permission.description },
+      data: {
+        id: permission.id,
+        permissionKey: permission.permissionKey,
+        description: permission.description,
+        createdById: permission.createdBy?.id,
+        updatedById: permission.updatedBy?.id,
+      },
     });
     return this.mapRecord(record);
   }
@@ -78,7 +92,11 @@ export class PrismaPermissionRepository implements PermissionRepositoryPort {
     this.logger.info('Updating permission', getContext());
     const record = await this.prisma.permission.update({
       where: { id: permission.id },
-      data: { permissionKey: permission.permissionKey, description: permission.description },
+      data: {
+        permissionKey: permission.permissionKey,
+        description: permission.description,
+        updatedById: permission.updatedBy?.id,
+      },
     });
     return this.mapRecord(record);
   }

--- a/backend/domain/entities/Permission.ts
+++ b/backend/domain/entities/Permission.ts
@@ -1,3 +1,5 @@
+import { User } from './User';
+
 /**
  * Represents a permission available in the system.
  */
@@ -12,6 +14,14 @@ export class Permission {
   constructor(
     public readonly id: string,
     public permissionKey: string,
-    public description: string
+    public description: string,
+    /** Date when the permission was created. */
+    public createdAt: Date = new Date(),
+    /** Date when the permission was last updated. Defaults to {@link createdAt}. */
+    public updatedAt: Date = createdAt,
+    /** User that created the permission or `null` when created automatically. */
+    public createdBy: User | null = null,
+    /** User that last updated the permission or `null` when updated automatically. */
+    public updatedBy: User | null = createdBy,
   ) {}
 }

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -55,6 +55,27 @@ describe('User REST controller', () => {
     app.use('/api', createUserRouter(auth, repo, avatar, tokenService, refreshRepo, logger));
   });
 
+  function serializePermission(p: Permission) {
+    return {
+      ...p,
+      createdAt: p.createdAt.toISOString(),
+      updatedAt: p.updatedAt.toISOString(),
+      createdBy: null,
+      updatedBy: null,
+    };
+  }
+
+  function serializeRole(r: Role) {
+    return {
+      ...r,
+      permissions: r.permissions.map(serializePermission),
+      createdAt: r.createdAt.toISOString(),
+      updatedAt: r.updatedAt.toISOString(),
+      createdBy: null,
+      updatedBy: null,
+    };
+  }
+
   it('should return current user profile', async () => {
     const res = await request(app)
       .get('/api/users/me')
@@ -66,15 +87,7 @@ describe('User REST controller', () => {
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
-      roles: [
-        {
-          ...role,
-          createdAt: role.createdAt.toISOString(),
-          updatedAt: role.updatedAt.toISOString(),
-          createdBy: null,
-          updatedBy: null,
-        },
-      ],
+      roles: [serializeRole(role)],
       status: 'active',
       department: {
         ...department,
@@ -136,15 +149,7 @@ describe('User REST controller', () => {
     expect(res.body).toEqual({
       user: {
         ...user,
-        roles: [
-          {
-            ...role,
-            createdAt: role.createdAt.toISOString(),
-            updatedAt: role.updatedAt.toISOString(),
-            createdBy: null,
-            updatedBy: null,
-          },
-        ],
+        roles: [serializeRole(role)],
         department: {
           ...department,
           site: {
@@ -185,15 +190,7 @@ describe('User REST controller', () => {
     expect(res.body).toEqual({
       user: {
         ...user,
-        roles: [
-          {
-            ...role,
-            createdAt: role.createdAt.toISOString(),
-            updatedAt: role.updatedAt.toISOString(),
-            createdBy: null,
-            updatedBy: null,
-          },
-        ],
+        roles: [serializeRole(role)],
         department: {
           ...department,
           site: {

--- a/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
@@ -10,13 +10,15 @@ describe('PrismaPermissionRepository', () => {
   let prismaAny: any;
   let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let perm: Permission;
+  let now: Date;
 
   beforeEach(() => {
     prisma = mockDeep<PrismaClient>();
     prismaAny = prisma as any;
     logger = mockDeep<LoggerPort>();
     repository = new PrismaPermissionRepository(prisma, logger);
-    perm = new Permission('perm-1', 'READ', 'Read access');
+    now = new Date();
+    perm = new Permission('perm-1', 'READ', 'Read access', now, now);
   });
 
   afterEach(() => {
@@ -25,7 +27,7 @@ describe('PrismaPermissionRepository', () => {
 
   describe('findById', () => {
     it('should return a permission when found', async () => {
-      prismaAny.permission.findUnique.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access' } as any);
+      prismaAny.permission.findUnique.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access', createdAt: now, updatedAt: now } as any);
 
       const result = await repository.findById('perm-1');
 
@@ -45,7 +47,7 @@ describe('PrismaPermissionRepository', () => {
 
   describe('findByKey', () => {
     it('should return a permission by key', async () => {
-      prismaAny.permission.findFirst.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access' } as any);
+      prismaAny.permission.findFirst.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access', createdAt: now, updatedAt: now } as any);
 
       const result = await repository.findByKey('READ');
 
@@ -65,25 +67,36 @@ describe('PrismaPermissionRepository', () => {
 
   describe('create', () => {
     it('should create a permission', async () => {
-      prismaAny.permission.create.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access' } as any);
+      prismaAny.permission.create.mockResolvedValue({ id: 'perm-1', permissionKey: 'READ', description: 'Read access', createdAt: now, updatedAt: now } as any);
 
       const result = await repository.create(perm);
 
       expect(result).toEqual(perm);
-      expect(prismaAny.permission.create).toHaveBeenCalledWith({ data: { id: 'perm-1', permissionKey: 'READ', description: 'Read access' } });
+      expect(prismaAny.permission.create).toHaveBeenCalledWith({
+        data: {
+          id: 'perm-1',
+          permissionKey: 'READ',
+          description: 'Read access',
+          createdById: undefined,
+          updatedById: undefined,
+        },
+      });
     });
   });
 
   describe('update', () => {
     it('should update a permission', async () => {
-      prismaAny.permission.update.mockResolvedValue({ id: 'perm-1', permissionKey: 'WRITE', description: 'Write access' } as any);
+      prismaAny.permission.update.mockResolvedValue({ id: 'perm-1', permissionKey: 'WRITE', description: 'Write access', createdAt: now, updatedAt: now } as any);
 
       perm.permissionKey = 'WRITE';
       perm.description = 'Write access';
       const result = await repository.update(perm);
 
-      expect(result).toEqual(new Permission('perm-1', 'WRITE', 'Write access'));
-      expect(prismaAny.permission.update).toHaveBeenCalledWith({ where: { id: 'perm-1' }, data: { permissionKey: 'WRITE', description: 'Write access' } });
+      expect(result).toEqual(new Permission('perm-1', 'WRITE', 'Write access', now, now));
+      expect(prismaAny.permission.update).toHaveBeenCalledWith({
+        where: { id: 'perm-1' },
+        data: { permissionKey: 'WRITE', description: 'Write access', updatedById: undefined },
+      });
     });
   });
 

--- a/backend/usecases/permission/CreatePermissionUseCase.ts
+++ b/backend/usecases/permission/CreatePermissionUseCase.ts
@@ -14,6 +14,11 @@ export class CreatePermissionUseCase {
    * @returns The created {@link Permission}.
    */
   async execute(permission: Permission): Promise<Permission> {
+    const now = new Date();
+    permission.createdAt = now;
+    permission.updatedAt = now;
+    permission.createdBy = null;
+    permission.updatedBy = null;
     return this.permissionRepository.create(permission);
   }
 }

--- a/backend/usecases/permission/UpdatePermissionUseCase.ts
+++ b/backend/usecases/permission/UpdatePermissionUseCase.ts
@@ -14,6 +14,8 @@ export class UpdatePermissionUseCase {
    * @returns The persisted {@link Permission} after update.
    */
   async execute(permission: Permission): Promise<Permission> {
+    permission.updatedAt = new Date();
+    permission.updatedBy = null;
     return this.permissionRepository.update(permission);
   }
 }


### PR DESCRIPTION
## Summary
- add created/updated fields to Permission entity
- track audit info when creating/updating permissions
- support new columns in Prisma schema and migration
- handle audit columns in PrismaPermissionRepository
- adjust tests for new Permission fields

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68866f91c9948323b2271c7c8d11eae3