### PR TITLE
Add audit fields to invitations

### DIFF
--- a/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
@@ -140,7 +140,10 @@ CREATE TABLE "Invitation" (
     "role" TEXT,
     "status" TEXT NOT NULL,
     "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdById" TEXT,
+    "updatedById" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Invitation_pkey" PRIMARY KEY ("id")
 );
@@ -251,3 +254,9 @@ ALTER TABLE "UserGroup" ADD CONSTRAINT "UserGroup_updatedById_fkey" FOREIGN KEY 
 
 -- AddForeignKey
 ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -44,6 +44,8 @@ model User {
   updatedRoles       Role[]                 @relation("RoleUpdatedBy")
   createdPermissions Permission[]           @relation("PermissionCreatedBy")
   updatedPermissions Permission[]           @relation("PermissionUpdatedBy")
+  createdInvitations Invitation[]          @relation("InvitationCreatedBy")
+  updatedInvitations Invitation[]          @relation("InvitationUpdatedBy")
   RefreshToken       RefreshToken[]
 }
 
@@ -179,7 +181,12 @@ model Invitation {
   role      String?
   status    String
   expiresAt DateTime
-  createdAt DateTime @default(now())
+  createdBy   User?    @relation("InvitationCreatedBy", fields: [createdById], references: [id])
+  createdById String?
+  updatedBy   User?    @relation("InvitationUpdatedBy", fields: [updatedById], references: [id])
+  updatedById String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model RefreshToken {

--- a/backend/adapters/repositories/PrismaInvitationRepository.ts
+++ b/backend/adapters/repositories/PrismaInvitationRepository.ts
@@ -23,6 +23,10 @@ export class PrismaInvitationRepository implements InvitationRepositoryPort {
       record.firstName ?? undefined,
       record.lastName ?? undefined,
       record.role ?? undefined,
+      record.createdAt,
+      record.updatedAt,
+      null,
+      null,
     );
   }
 
@@ -37,6 +41,8 @@ export class PrismaInvitationRepository implements InvitationRepositoryPort {
         firstName: invitation.firstName,
         lastName: invitation.lastName,
         role: invitation.role,
+        createdById: invitation.createdBy?.id,
+        updatedById: invitation.updatedBy?.id,
       },
     });
     return this.mapRecord(record);

--- a/backend/domain/entities/Invitation.ts
+++ b/backend/domain/entities/Invitation.ts
@@ -1,3 +1,5 @@
+import { User } from './User';
+
 export class Invitation {
   /**
    * Create a new invitation instance.
@@ -18,5 +20,13 @@ export class Invitation {
     public firstName?: string,
     public lastName?: string,
     public role?: string,
+    /** Date when the invitation was created. */
+    public createdAt: Date = new Date(),
+    /** Date when the invitation was last updated. Defaults to {@link createdAt}. */
+    public updatedAt: Date = createdAt,
+    /** User that created the invitation or `null` when created automatically. */
+    public createdBy: User | null = null,
+    /** User that last updated the invitation or `null` when updated automatically. */
+    public updatedBy: User | null = createdBy,
   ) {}
 }

--- a/backend/tests/adapters/repositories/PrismaInvitationRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaInvitationRepository.test.ts
@@ -26,6 +26,7 @@ describe('PrismaInvitationRepository', () => {
       role: null,
       id: '1',
       createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-02'),
     } as any);
 
     const inv = await repo.create(new Invitation('a', 't', 'pending', new Date('2024-01-01')));
@@ -45,6 +46,7 @@ describe('PrismaInvitationRepository', () => {
       role: null,
       id: '1',
       createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-02'),
     } as any);
 
     const inv = await repo.findByToken('t');
@@ -70,6 +72,7 @@ describe('PrismaInvitationRepository', () => {
       role: null,
       id: '2',
       createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-02'),
     } as any);
 
     const inv = await repo.findByEmail('b');

--- a/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaPermissionRepository.test.ts
@@ -119,7 +119,15 @@ describe('PrismaPermissionRepository', () => {
     expect(prismaAny.permission.count).toHaveBeenCalled();
   });
   it('should return all permissions', async () => {
-    prismaAny.permission.findMany.mockResolvedValue([{ id: 'perm-1', permissionKey: 'READ', description: 'Read access' }] as any);
+    prismaAny.permission.findMany.mockResolvedValue([
+      {
+        id: 'perm-1',
+        permissionKey: 'READ',
+        description: 'Read access',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ] as any);
     const result = await repository.findAll();
     expect(result).toEqual([perm]);
     expect(prismaAny.permission.findMany).toHaveBeenCalledWith();

--- a/backend/usecases/invitation/CreateInvitationUseCase.ts
+++ b/backend/usecases/invitation/CreateInvitationUseCase.ts
@@ -40,6 +40,7 @@ export class CreateInvitationUseCase {
     }
 
     const token = randomBytes(32).toString('hex');
+    const now = new Date();
     const invitation = new Invitation(
       data.email,
       token,
@@ -48,6 +49,10 @@ export class CreateInvitationUseCase {
       data.firstName,
       data.lastName,
       data.role,
+      now,
+      now,
+      this.checker.currentUser,
+      this.checker.currentUser,
     );
 
     await this.invitationRepository.create(invitation);


### PR DESCRIPTION
## Summary
- add created/updated fields to `Invitation` entity
- support new fields in Prisma invitation repository and schema
- set audit info when creating invitations
- update tests for repository

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886742fba78832380c746926cb51428