### PR TITLE
Add audit fields to Department entity

### DIFF
--- a/backend/adapters/controllers/rest/departmentController.ts
+++ b/backend/adapters/controllers/rest/departmentController.ts
@@ -126,6 +126,40 @@ function parseDepartment(body: DepartmentPayload): Department {
   );
 }
 
+function serializeDepartment(d: Department): Record<string, unknown> {
+  return {
+    ...d,
+    site: {
+      ...d.site,
+      createdAt: d.site.createdAt.toISOString(),
+      updatedAt: d.site.updatedAt.toISOString(),
+      createdBy: null,
+      updatedBy: null,
+    },
+    permissions: d.permissions.map((p) => ({
+      ...p,
+      createdAt: p.createdAt.toISOString(),
+      updatedAt: p.updatedAt.toISOString(),
+      createdBy: null,
+      updatedBy: null,
+    })),
+    createdAt: d.createdAt.toISOString(),
+    updatedAt: d.updatedAt.toISOString(),
+    createdBy: null,
+    updatedBy: null,
+  };
+}
+
+function serializeUser(u: User): Record<string, unknown> {
+  return {
+    ...u,
+    createdAt: u.createdAt.toISOString(),
+    updatedAt: u.updatedAt.toISOString(),
+    createdBy: null,
+    updatedBy: null,
+  };
+}
+
 interface AuthedRequest extends Request {
   user: User;
 }
@@ -204,7 +238,7 @@ export function createDepartmentRouter(
       res.status(204).end();
       return;
     }
-    res.json(result);
+    res.json({ ...result, items: result.items.map(serializeDepartment) });
   });
 
   /**
@@ -247,7 +281,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department retrieved', getContext());
-    res.json(department);
+    res.json(serializeDepartment(department));
   });
 
   /**
@@ -330,7 +364,7 @@ export function createDepartmentRouter(
       res.status(204).end();
       return;
     }
-    res.json(result);
+    res.json({ ...result, items: result.items.map(serializeDepartment) });
   });
 
   /**
@@ -664,7 +698,7 @@ export function createDepartmentRouter(
     const useCase = new UpdateDepartmentUseCase(departmentRepository, checker);
     const updated = await useCase.execute(department);
     logger.debug('Department updated', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -714,7 +748,7 @@ export function createDepartmentRouter(
         return;
       }
       logger.debug('Child department added', getContext());
-      res.json(updated);
+      res.json(serializeDepartment(updated));
     } catch (err) {
       if ((err as Error).message === 'Forbidden') {
         logger.warn('Permission denied adding child department', {...getContext(), error: err});
@@ -771,7 +805,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Child department removed', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -826,7 +860,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department manager set', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -869,7 +903,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department manager removed', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -924,7 +958,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department parent set', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -967,7 +1001,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department parent removed', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -1018,7 +1052,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department permission added', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -1067,7 +1101,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department permission removed', getContext());
-    res.json(updated);
+    res.json(serializeDepartment(updated));
   });
 
   /**
@@ -1116,7 +1150,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department user added', getContext());
-    res.json(updated);
+    res.json(serializeUser(updated));
   });
 
   /**
@@ -1165,7 +1199,7 @@ export function createDepartmentRouter(
       return;
     }
     logger.debug('Department user removed', getContext());
-    res.json(updated);
+    res.json(serializeUser(updated));
   });
 
   /**

--- a/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250727171621_init/migration.sql
@@ -40,6 +40,10 @@ CREATE TABLE "Department" (
     "parentDepartmentId" TEXT,
     "managerUserId" TEXT,
     "siteId" TEXT NOT NULL,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Department_pkey" PRIMARY KEY ("id")
 );
@@ -191,6 +195,12 @@ ALTER TABLE "Department" ADD CONSTRAINT "Department_managerUserId_fkey" FOREIGN 
 
 -- AddForeignKey
 ALTER TABLE "Department" ADD CONSTRAINT "Department_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Department" ADD CONSTRAINT "Department_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Department" ADD CONSTRAINT "Department_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "Site" ADD CONSTRAINT "Site_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -34,8 +34,8 @@ model User {
   managedDepartments Department[]           @relation("DepartmentManager")
   groups             UserGroupMember[]
   responsibleGroups  UserGroupResponsible[]
-  createdGroups      UserGroup[]           @relation("UserGroupCreatedBy")
-  updatedGroups      UserGroup[]           @relation("UserGroupUpdatedBy")
+  createdGroups      UserGroup[]            @relation("UserGroupCreatedBy")
+  updatedGroups      UserGroup[]            @relation("UserGroupUpdatedBy")
   createdUsers       User[]                 @relation("UserCreatedBy")
   updatedUsers       User[]                 @relation("UserUpdatedBy")
   createdSites       Site[]                 @relation("SiteCreatedBy")
@@ -44,8 +44,10 @@ model User {
   updatedRoles       Role[]                 @relation("RoleUpdatedBy")
   createdPermissions Permission[]           @relation("PermissionCreatedBy")
   updatedPermissions Permission[]           @relation("PermissionUpdatedBy")
-  createdInvitations Invitation[]          @relation("InvitationCreatedBy")
-  updatedInvitations Invitation[]          @relation("InvitationUpdatedBy")
+  createdInvitations Invitation[]           @relation("InvitationCreatedBy")
+  updatedInvitations Invitation[]           @relation("InvitationUpdatedBy")
+  createdDepartments Department[]           @relation("DepartmentCreatedBy")
+  updatedDepartments Department[]           @relation("DepartmentUpdatedBy")
   RefreshToken       RefreshToken[]
 }
 
@@ -74,6 +76,12 @@ model Department {
   permissions        DepartmentPermission[]
   site               Site                   @relation(fields: [siteId], references: [id])
   siteId             String
+  createdBy          User?                  @relation("DepartmentCreatedBy", fields: [createdById], references: [id])
+  createdById        String?
+  updatedBy          User?                  @relation("DepartmentUpdatedBy", fields: [updatedById], references: [id])
+  updatedById        String?
+  createdAt          DateTime               @default(now())
+  updatedAt          DateTime               @updatedAt
 }
 
 model UserRole {
@@ -173,14 +181,14 @@ model UserGroupResponsible {
 }
 
 model Invitation {
-  id        String   @id @default(uuid())
-  email     String
-  token     String   @unique
-  firstName String?
-  lastName  String?
-  role      String?
-  status    String
-  expiresAt DateTime
+  id          String   @id @default(uuid())
+  email       String
+  token       String   @unique
+  firstName   String?
+  lastName    String?
+  role        String?
+  status      String
+  expiresAt   DateTime
   createdBy   User?    @relation("InvitationCreatedBy", fields: [createdById], references: [id])
   createdById String?
   updatedBy   User?    @relation("InvitationUpdatedBy", fields: [updatedById], references: [id])

--- a/backend/adapters/repositories/PrismaDepartmentRepository.ts
+++ b/backend/adapters/repositories/PrismaDepartmentRepository.ts
@@ -31,6 +31,11 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
       record.parentDepartmentId,
       record.managerUserId,
       new Site(record.site.id, record.site.label),
+      [],
+      record.createdAt,
+      record.updatedAt,
+      null,
+      null,
     );
   }
 
@@ -88,6 +93,8 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
         parentDepartmentId: department.parentDepartmentId,
         managerUserId: department.managerUserId,
         siteId: department.site.id,
+        createdById: department.createdBy?.id,
+        updatedById: department.updatedBy?.id,
       },
       include: { site: true },
     });
@@ -103,6 +110,7 @@ export class PrismaDepartmentRepository implements DepartmentRepositoryPort {
         parentDepartmentId: department.parentDepartmentId,
         managerUserId: department.managerUserId,
         siteId: department.site.id,
+        updatedById: department.updatedBy?.id,
       },
       include: { site: true },
     });

--- a/backend/domain/entities/Department.ts
+++ b/backend/domain/entities/Department.ts
@@ -3,6 +3,7 @@
  */
 import { Permission } from './Permission';
 import { Site } from './Site';
+import { User } from './User';
 
 export class Department {
   /**
@@ -14,6 +15,10 @@ export class Department {
    * @param managerUserId - Identifier of the user managing the department, if any.
    * @param site - {@link Site} where the department is located.
    * @param permissions - Collection of {@link Permission} associated with the department.
+   * @param createdAt - Date when the department was created.
+   * @param updatedAt - Date when the department was last updated. Defaults to {@link createdAt}.
+   * @param createdBy - User who created the department or `null` if created automatically.
+   * @param updatedBy - User who last updated the department or `null` if updated automatically.
    */
   constructor(
     public readonly id: string,
@@ -22,5 +27,13 @@ export class Department {
     public managerUserId: string | null = null,
     public site: Site,
     public permissions: Permission[] = [],
+    /** Date when the department was created. */
+    public createdAt: Date = new Date(),
+    /** Date when the department was last updated. Defaults to {@link createdAt}. */
+    public updatedAt: Date = createdAt,
+    /** User that created the department or `null` when created automatically. */
+    public createdBy: User | null = null,
+    /** User that last updated the department or `null` when updated automatically. */
+    public updatedBy: User | null = createdBy,
   ) {}
 }

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -98,6 +98,10 @@ describe('User REST controller', () => {
           createdBy: null,
           updatedBy: null,
         },
+        createdAt: department.createdAt.toISOString(),
+        updatedAt: department.updatedAt.toISOString(),
+        createdBy: null,
+        updatedBy: null,
       },
       site: {
         ...site,
@@ -159,6 +163,10 @@ describe('User REST controller', () => {
             createdBy: null,
             updatedBy: null,
           },
+          createdAt: department.createdAt.toISOString(),
+          updatedAt: department.updatedAt.toISOString(),
+          createdBy: null,
+          updatedBy: null,
         },
         site: {
           ...site,
@@ -200,6 +208,10 @@ describe('User REST controller', () => {
             createdBy: null,
             updatedBy: null,
           },
+          createdAt: department.createdAt.toISOString(),
+          updatedAt: department.updatedAt.toISOString(),
+          createdBy: null,
+          updatedBy: null,
         },
         site: {
           ...site,

--- a/backend/tests/adapters/repositories/PrismaDepartmentRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaDepartmentRepository.test.ts
@@ -37,6 +37,8 @@ describe('PrismaDepartmentRepository', () => {
     const result = await repo.findById('dept-1');
     dept.site.createdAt = result!.site.createdAt;
     dept.site.updatedAt = result!.site.updatedAt;
+    dept.createdAt = result!.createdAt;
+    dept.updatedAt = result!.updatedAt;
     expect(result).toEqual(dept);
     expect(prisma.department.findUnique).toHaveBeenCalledWith({ where: { id: 'dept-1' }, include: { site: true } });
   });
@@ -63,6 +65,8 @@ describe('PrismaDepartmentRepository', () => {
     const result = await repo.create(dept);
     dept.site.createdAt = result.site.createdAt;
     dept.site.updatedAt = result.site.updatedAt;
+    dept.createdAt = result.createdAt;
+    dept.updatedAt = result.updatedAt;
     expect(result).toEqual(dept);
     expect(prisma.department.create).toHaveBeenCalledWith({
       data: {
@@ -70,7 +74,9 @@ describe('PrismaDepartmentRepository', () => {
         label: 'IT',
         parentDepartmentId: null,
         managerUserId: 'user-1',
-        siteId: 'site-1'
+        siteId: 'site-1',
+        createdById: undefined,
+        updatedById: undefined
       }
     , include: { site: true } });
   });
@@ -89,6 +95,8 @@ describe('PrismaDepartmentRepository', () => {
     if (result) {
       dept.site.createdAt = result.site.createdAt;
       dept.site.updatedAt = result.site.updatedAt;
+      dept.createdAt = result.createdAt;
+      dept.updatedAt = result.updatedAt;
     }
     expect(result).toEqual(dept);
     expect(prisma.department.findFirst).toHaveBeenCalledWith({ where: { label: 'IT' }, include: { site: true } });
@@ -117,6 +125,8 @@ describe('PrismaDepartmentRepository', () => {
     const result = await repo.update(updated);
     updated.site.createdAt = result.site.createdAt;
     updated.site.updatedAt = result.site.updatedAt;
+    updated.createdAt = result.createdAt;
+    updated.updatedAt = result.updatedAt;
     expect(result).toEqual(updated);
     expect(prisma.department.update).toHaveBeenCalledWith({
       where: { id: 'dept-1' },
@@ -124,7 +134,8 @@ describe('PrismaDepartmentRepository', () => {
         label: 'Tech',
         parentDepartmentId: null,
         managerUserId: 'user-2',
-        siteId: 'site-1'
+        siteId: 'site-1',
+        updatedById: undefined
       },
       include: { site: true }
     });
@@ -145,6 +156,8 @@ describe('PrismaDepartmentRepository', () => {
     const result = await repo.findBySiteId('site-1');
     dept.site.createdAt = result[0].site.createdAt;
     dept.site.updatedAt = result[0].site.updatedAt;
+    dept.createdAt = result[0].createdAt;
+    dept.updatedAt = result[0].updatedAt;
     expect(result).toEqual([dept]);
     expect(prisma.department.findMany).toHaveBeenCalledWith({ where: { siteId: 'site-1' }, include: { site: true } });
   });
@@ -181,6 +194,8 @@ describe('PrismaDepartmentRepository', () => {
     const result = await repo.findAll();
     dept.site.createdAt = result[0].site.createdAt;
     dept.site.updatedAt = result[0].site.updatedAt;
+    dept.createdAt = result[0].createdAt;
+    dept.updatedAt = result[0].updatedAt;
     expect(result).toEqual([dept]);
     expect(prisma.department.findMany).toHaveBeenCalledWith({ include: { site: true } });
   });

--- a/backend/usecases/department/AddChildDepartmentUseCase.ts
+++ b/backend/usecases/department/AddChildDepartmentUseCase.ts
@@ -26,6 +26,8 @@ export class AddChildDepartmentUseCase {
       return null;
     }
     child.parentDepartmentId = parentId;
+    child.updatedAt = new Date();
+    child.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(child);
   }
 }

--- a/backend/usecases/department/AddDepartmentUserUseCase.ts
+++ b/backend/usecases/department/AddDepartmentUserUseCase.ts
@@ -29,6 +29,8 @@ export class AddDepartmentUserUseCase {
       return null;
     }
     user.department = department;
+    user.updatedAt = new Date();
+    user.updatedBy = this.checker.currentUser;
     return this.userRepository.update(user);
   }
 }

--- a/backend/usecases/department/CreateDepartmentUseCase.ts
+++ b/backend/usecases/department/CreateDepartmentUseCase.ts
@@ -20,6 +20,11 @@ export class CreateDepartmentUseCase {
    */
   async execute(department: Department): Promise<Department> {
     this.checker.check(PermissionKeys.CREATE_DEPARTMENT);
+    const now = new Date();
+    department.createdAt = now;
+    department.updatedAt = now;
+    department.createdBy = this.checker.currentUser;
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.create(department);
   }
 }

--- a/backend/usecases/department/RemoveChildDepartmentUseCase.ts
+++ b/backend/usecases/department/RemoveChildDepartmentUseCase.ts
@@ -25,6 +25,8 @@ export class RemoveChildDepartmentUseCase {
       return null;
     }
     child.parentDepartmentId = null;
+    child.updatedAt = new Date();
+    child.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(child);
   }
 }

--- a/backend/usecases/department/RemoveDepartmentManagerUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentManagerUseCase.ts
@@ -25,6 +25,8 @@ export class RemoveDepartmentManagerUseCase {
       return null;
     }
     department.managerUserId = null;
+    department.updatedAt = new Date();
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(department);
   }
 }

--- a/backend/usecases/department/RemoveDepartmentParentDepartmentUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentParentDepartmentUseCase.ts
@@ -25,6 +25,8 @@ export class RemoveDepartmentParentDepartmentUseCase {
       return null;
     }
     department.parentDepartmentId = null;
+    department.updatedAt = new Date();
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(department);
   }
 }

--- a/backend/usecases/department/RemoveDepartmentPermissionUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentPermissionUseCase.ts
@@ -26,6 +26,8 @@ export class RemoveDepartmentPermissionUseCase {
       return null;
     }
     department.permissions = department.permissions.filter(p => p.id !== permissionId);
+    department.updatedAt = new Date();
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(department);
   }
 }

--- a/backend/usecases/department/RemoveDepartmentUserUseCase.ts
+++ b/backend/usecases/department/RemoveDepartmentUserUseCase.ts
@@ -30,6 +30,8 @@ export class RemoveDepartmentUserUseCase {
       return null;
     }
     user.department = null as unknown as Department;
+    user.updatedAt = new Date();
+    user.updatedBy = this.checker.currentUser;
     return this.userRepository.update(user);
   }
 }

--- a/backend/usecases/department/SetDepartmentManagerUseCase.ts
+++ b/backend/usecases/department/SetDepartmentManagerUseCase.ts
@@ -26,6 +26,8 @@ export class SetDepartmentManagerUseCase {
       return null;
     }
     department.managerUserId = userId;
+    department.updatedAt = new Date();
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(department);
   }
 }

--- a/backend/usecases/department/SetDepartmentParentDepartmentUseCase.ts
+++ b/backend/usecases/department/SetDepartmentParentDepartmentUseCase.ts
@@ -26,6 +26,8 @@ export class SetDepartmentParentDepartmentUseCase {
       return null;
     }
     department.parentDepartmentId = parentDepartmentId;
+    department.updatedAt = new Date();
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(department);
   }
 }

--- a/backend/usecases/department/SetDepartmentPermissionUseCase.ts
+++ b/backend/usecases/department/SetDepartmentPermissionUseCase.ts
@@ -27,6 +27,8 @@ export class SetDepartmentPermissionUseCase {
       return null;
     }
     department.permissions.push(permission);
+    department.updatedAt = new Date();
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(department);
   }
 }

--- a/backend/usecases/department/UpdateDepartmentUseCase.ts
+++ b/backend/usecases/department/UpdateDepartmentUseCase.ts
@@ -20,6 +20,8 @@ export class UpdateDepartmentUseCase {
    */
   async execute(department: Department): Promise<Department> {
     this.checker.check(PermissionKeys.UPDATE_DEPARTMENT);
+    department.updatedAt = new Date();
+    department.updatedBy = this.checker.currentUser;
     return this.departmentRepository.update(department);
   }
 }


### PR DESCRIPTION
## Summary
- include creation/update audit fields on Department entity
- map new fields in PrismaDepartmentRepository
- extend Department schema and migration for audit fields
- serialize Department responses to avoid circular JSON
- update department use cases to handle audit tracking
- update tests to reflect new Department fields

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886785a972c8323ad5ad8f08ec2b4cb