### PR TITLE
Implement audit log retrieval

### DIFF
--- a/backend/adapters/audit/PrismaAudit.ts
+++ b/backend/adapters/audit/PrismaAudit.ts
@@ -1,8 +1,10 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { AuditPort } from '../../domain/ports/AuditPort';
 import { AuditEvent } from '../../domain/entities/AuditEvent';
 import { LoggerPort } from '../../domain/ports/LoggerPort';
 import { getContext } from '../../infrastructure/loggerContext';
+import { AuditLogQuery } from '../../domain/dtos/AuditLogQuery';
+import { PaginatedResult } from '../../domain/dtos/PaginatedResult';
 
 /**
  * Prisma-based implementation of {@link AuditPort}.
@@ -29,5 +31,52 @@ export class PrismaAudit implements AuditPort {
         userAgent: event.userAgent,
       },
     });
+  }
+
+  async findPaginated(query: AuditLogQuery): Promise<PaginatedResult<AuditEvent>> {
+    this.logger.debug('Retrieving audit logs', getContext());
+    const where: Prisma.AuditLogWhereInput = {};
+    if (query.actorId) {
+      where.actorId = query.actorId;
+    }
+    if (query.action) {
+      where.action = query.action;
+    }
+    if (query.targetType) {
+      where.targetType = query.targetType;
+    }
+    if (query.dateFrom || query.dateTo) {
+      where.timestamp = {};
+      if (query.dateFrom) (where.timestamp as Prisma.DateTimeFilter).gte = query.dateFrom;
+      if (query.dateTo) (where.timestamp as Prisma.DateTimeFilter).lte = query.dateTo;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const records = await (this.prisma as any).auditLog.findMany({
+      skip: (query.page - 1) * query.limit,
+      take: query.limit,
+      where,
+      orderBy: { timestamp: 'desc' },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const total = await (this.prisma as any).auditLog.count({ where });
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      items: records.map((r: any) =>
+        new AuditEvent(
+          r.timestamp,
+          r.actorId,
+          r.actorType,
+          r.action,
+          r.targetType,
+          r.targetId,
+          r.details,
+          r.ipAddress,
+          r.userAgent,
+        ),
+      ),
+      page: query.page,
+      limit: query.limit,
+      total,
+    };
   }
 }

--- a/backend/adapters/controllers/rest/auditController.ts
+++ b/backend/adapters/controllers/rest/auditController.ts
@@ -1,0 +1,132 @@
+/* istanbul ignore file */
+import express, { Request, Response, Router } from 'express';
+import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { AuditPort } from '../../../domain/ports/AuditPort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { getContext } from '../../../infrastructure/loggerContext';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { GetAuditLogsUseCase } from '../../../usecases/audit/GetAuditLogsUseCase';
+import { User } from '../../../domain/entities/User';
+
+interface AuthedRequest extends Request { user: User }
+
+/**
+ * @openapi
+ * tags:
+ *   - name: Audit
+ *     description: Access audit logs
+ */
+export function createAuditRouter(
+  auth: AuthServicePort,
+  users: UserRepositoryPort,
+  audit: AuditPort,
+  logger: LoggerPort,
+): Router {
+  const router = express.Router();
+
+  const authMiddleware: express.RequestHandler = async (req, res, next) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith('Bearer ')) {
+      res.status(401).end();
+      return;
+    }
+    const token = header.slice(7);
+    try {
+      const claims = await auth.verifyToken(token);
+      const user = await users.findById(claims.id);
+      if (!user) {
+        res.status(401).end();
+        return;
+      }
+      (req as AuthedRequest).user = user;
+      next();
+    } catch {
+      res.status(401).end();
+    }
+  };
+
+  router.use(authMiddleware);
+
+  /**
+   * @openapi
+   * /audit:
+   *   get:
+   *     summary: List audit events
+   *     description: Returns paginated audit log entries.
+   *     tags: [Audit]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: page
+   *         schema:
+   *           type: integer
+   *           default: 1
+   *         description: Page number starting at 1.
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           default: 20
+   *         description: Number of items per page.
+   *       - in: query
+   *         name: actorId
+   *         schema:
+   *           type: string
+   *         description: Filter by actor identifier.
+   *       - in: query
+   *         name: action
+   *         schema:
+   *           type: string
+   *         description: Filter by action name.
+   *       - in: query
+   *         name: targetType
+   *         schema:
+   *           type: string
+   *         description: Filter by target entity type.
+   *       - in: query
+   *         name: dateFrom
+   *         schema:
+   *           type: string
+   *           format: date-time
+   *         description: Include events from this date.
+   *       - in: query
+   *         name: dateTo
+   *         schema:
+   *           type: string
+   *           format: date-time
+   *         description: Include events up to this date.
+   *     responses:
+   *       200:
+   *         description: Paginated audit logs
+   *       204:
+   *         description: No content
+   *       401:
+   *         description: Unauthorized
+   */
+  router.get('/audit', async (req: Request, res: Response): Promise<void> => {
+    logger.debug('GET /audit', getContext());
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 20;
+    const checker = new PermissionChecker((req as AuthedRequest).user);
+    const useCase = new GetAuditLogsUseCase(audit, checker);
+    const result = await useCase.execute({
+      page,
+      limit,
+      actorId: req.query.actorId as string | undefined,
+      action: req.query.action as string | undefined,
+      targetType: req.query.targetType as string | undefined,
+      dateFrom: req.query.dateFrom ? new Date(req.query.dateFrom as string) : undefined,
+      dateTo: req.query.dateTo ? new Date(req.query.dateTo as string) : undefined,
+    });
+    if (result.items.length === 0) {
+      res.status(204).end();
+      return;
+    }
+    res.json(result);
+  });
+
+  return router;
+}
+

--- a/backend/domain/dtos/AuditLogQuery.ts
+++ b/backend/domain/dtos/AuditLogQuery.ts
@@ -1,0 +1,20 @@
+/**
+ * Parameters used to retrieve a page of audit log entries.
+ */
+export interface AuditLogQuery {
+  /** Page number starting at 1. */
+  page: number;
+  /** Number of items per page. */
+  limit: number;
+  /** Optional identifier of the actor who triggered the event. */
+  actorId?: string;
+  /** Optional action name to filter on. */
+  action?: string;
+  /** Optional type of the target entity. */
+  targetType?: string;
+  /** Optional lower bound on the event timestamp. */
+  dateFrom?: Date;
+  /** Optional upper bound on the event timestamp. */
+  dateTo?: Date;
+}
+

--- a/backend/domain/entities/PermissionKeys.ts
+++ b/backend/domain/entities/PermissionKeys.ts
@@ -76,4 +76,7 @@ export class PermissionKeys {
 
   /** Allows creating user invitations. */
   static readonly CREATE_INVITATION = 'create-invitation';
+
+  /** Allows viewing audit log entries. */
+  static readonly VIEW_AUDIT_LOGS = 'view_audit_logs';
 }

--- a/backend/domain/ports/AuditPort.ts
+++ b/backend/domain/ports/AuditPort.ts
@@ -1,4 +1,6 @@
 import { AuditEvent } from '../entities/AuditEvent';
+import { PaginatedResult } from '../dtos/PaginatedResult';
+import { AuditLogQuery } from '../dtos/AuditLogQuery';
 
 /**
  * Provides persistence of {@link AuditEvent} instances for traceability.
@@ -10,4 +12,12 @@ export interface AuditPort {
    * @param event - Event to record.
    */
   log(event: AuditEvent): Promise<void>;
+
+  /**
+   * Retrieve audit events matching the provided query.
+   *
+   * @param query - Pagination and filtering parameters.
+   * @returns Page of {@link AuditEvent}.
+   */
+  findPaginated(query: AuditLogQuery): Promise<PaginatedResult<AuditEvent>>;
 }

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'crypto';
 import { createUserRouter } from '../adapters/controllers/rest/userController';
 import { createInvitationRouter } from '../adapters/controllers/rest/invitationController';
 import { createRoleRouter } from '../adapters/controllers/rest/roleController';
+import { createAuditRouter } from '../adapters/controllers/rest/auditController';
 import { registerUserGateway } from '../adapters/controllers/websocket/userGateway';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
@@ -85,6 +86,15 @@ async function bootstrap(): Promise<void> {
     createRoleRouter(
       roleRepository,
       userRepository,
+      logger,
+    ),
+  );
+  app.use(
+    '/api',
+    createAuditRouter(
+      authService,
+      userRepository,
+      audit,
       logger,
     ),
   );

--- a/backend/tests/adapters/controllers/rest/auditController.test.ts
+++ b/backend/tests/adapters/controllers/rest/auditController.test.ts
@@ -1,0 +1,89 @@
+import request from 'supertest';
+import express from 'express';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { createAuditRouter } from '../../../../adapters/controllers/rest/auditController';
+import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
+import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort';
+import { AuditPort } from '../../../../domain/ports/AuditPort';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { AuditEvent } from '../../../../domain/entities/AuditEvent';
+import { User } from '../../../../domain/entities/User';
+import { Department } from '../../../../domain/entities/Department';
+import { Site } from '../../../../domain/entities/Site';
+import { Role } from '../../../../domain/entities/Role';
+import { Permission } from '../../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
+
+describe('Audit REST controller', () => {
+  let app: express.Express;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let users: DeepMockProxy<UserRepositoryPort>;
+  let audit: DeepMockProxy<AuditPort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+
+  beforeEach(() => {
+    auth = mockDeep<AuthServicePort>();
+    users = mockDeep<UserRepositoryPort>();
+    audit = mockDeep<AuditPort>();
+    logger = mockDeep<LoggerPort>();
+
+    auth.verifyToken.mockResolvedValue({ id: 'u' } as any);
+    const site = new Site('s', 'Site');
+    const dept = new Department('d', 'Dept', null, null, site);
+    const perm = new Permission('p', PermissionKeys.VIEW_AUDIT_LOGS, '');
+    const role = new Role('r', 'Role', [perm]);
+    const user = new User('u', 'John', 'Doe', 'j@example.com', [role], 'active', dept, site);
+    users.findById.mockResolvedValue(user);
+
+    app = express();
+    app.use(express.json());
+    app.use('/api', createAuditRouter(auth, users, audit, logger));
+  });
+
+  it('should list audit logs', async () => {
+    const event = new AuditEvent(new Date('2024-01-01T00:00:00Z'), 'u', 'user', 'action');
+    audit.findPaginated.mockResolvedValue({ items: [event], page: 1, limit: 20, total: 1 });
+
+    const res = await request(app)
+      .get('/api/audit?page=1&limit=20')
+      .set('Authorization', 'Bearer t');
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(audit.findPaginated).toHaveBeenCalled();
+  });
+
+  it('should return 204 when no logs', async () => {
+    audit.findPaginated.mockResolvedValue({ items: [], page: 1, limit: 20, total: 0 });
+
+    const res = await request(app)
+      .get('/api/audit')
+      .set('Authorization', 'Bearer t');
+
+    expect(res.status).toBe(204);
+  });
+
+  it('should reject unauthorized requests', async () => {
+    auth.verifyToken.mockRejectedValue(new Error('bad'));
+
+    const res = await request(app)
+      .get('/api/audit')
+      .set('Authorization', 'Bearer bad');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should reject requests without header', async () => {
+    const res = await request(app).get('/api/audit');
+    expect(res.status).toBe(401);
+  });
+
+  it('should reject when user not found', async () => {
+    users.findById.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .get('/api/audit')
+      .set('Authorization', 'Bearer t');
+    expect(res.status).toBe(401);
+  });
+});
+

--- a/backend/tests/usecases/audit/getAuditLogsUseCase.test.ts
+++ b/backend/tests/usecases/audit/getAuditLogsUseCase.test.ts
@@ -1,0 +1,49 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetAuditLogsUseCase } from '../../../usecases/audit/GetAuditLogsUseCase';
+import { AuditPort } from '../../../domain/ports/AuditPort';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { AuditEvent } from '../../../domain/entities/AuditEvent';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Permission } from '../../../domain/entities/Permission';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('GetAuditLogsUseCase', () => {
+  let port: DeepMockProxy<AuditPort>;
+  let checker: PermissionChecker;
+  let useCase: GetAuditLogsUseCase;
+  let event: AuditEvent;
+
+  beforeEach(() => {
+    port = mockDeep<AuditPort>();
+    const site = new Site('s', 'Site');
+    const dept = new Department('d', 'Dept', null, null, site);
+    const perm = new Permission('p', PermissionKeys.VIEW_AUDIT_LOGS, '');
+    const role = new Role('r', 'Role', [perm]);
+    const user = new User('u', 'John', 'Doe', 'j@example.com', [role], 'active', dept, site);
+    checker = new PermissionChecker(user);
+    useCase = new GetAuditLogsUseCase(port, checker);
+    event = new AuditEvent(new Date('2024-01-01T00:00:00Z'), 'u', 'user', 'action');
+  });
+
+  it('should return logs from port', async () => {
+    port.findPaginated.mockResolvedValue({ items: [event], page: 1, limit: 20, total: 1 });
+
+    const result = await useCase.execute({ page: 1, limit: 20 });
+
+    expect(result.items).toEqual([event]);
+    expect(port.findPaginated).toHaveBeenCalledWith({ page: 1, limit: 20 });
+  });
+
+  it('should throw when permission denied', async () => {
+    const denied = mockDeep<PermissionChecker>();
+    denied.check.mockImplementation(() => { throw new Error('Forbidden'); });
+    useCase = new GetAuditLogsUseCase(port, denied);
+
+    await expect(useCase.execute({ page: 1, limit: 20 })).rejects.toThrow('Forbidden');
+    expect(port.findPaginated).not.toHaveBeenCalled();
+  });
+});
+

--- a/backend/usecases/audit/GetAuditLogsUseCase.ts
+++ b/backend/usecases/audit/GetAuditLogsUseCase.ts
@@ -1,0 +1,28 @@
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { AuditEvent } from '../../domain/entities/AuditEvent';
+import { PaginatedResult } from '../../domain/dtos/PaginatedResult';
+import { AuditLogQuery } from '../../domain/dtos/AuditLogQuery';
+import { PermissionChecker } from '../../domain/services/PermissionChecker';
+import { PermissionKeys } from '../../domain/entities/PermissionKeys';
+
+/**
+ * Use case retrieving audit log entries.
+ */
+export class GetAuditLogsUseCase {
+  constructor(
+    private readonly audit: AuditPort,
+    private readonly checker: PermissionChecker,
+  ) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @param query - Pagination and filter parameters.
+   * @returns Page of {@link AuditEvent} records.
+   */
+  async execute(query: AuditLogQuery): Promise<PaginatedResult<AuditEvent>> {
+    this.checker.check(PermissionKeys.VIEW_AUDIT_LOGS);
+    return this.audit.findPaginated(query);
+  }
+}
+


### PR DESCRIPTION
## Summary
- support audit log pagination with Prisma
- expose new AuditLogQuery DTO
- add GetAuditLogsUseCase with permission check
- create audit REST controller and register route
- document new permission key VIEW_AUDIT_LOGS
- cover new usecases and adapters with tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68868ca07d2483238f01a8d6fcf3678b