### PR TITLE
Add account lock error handling

### DIFF
--- a/backend/domain/errors/AccountLockedError.ts
+++ b/backend/domain/errors/AccountLockedError.ts
@@ -1,0 +1,20 @@
+/**
+ * Error thrown when a user attempts to authenticate while their account
+ * is temporarily locked because of repeated failed login attempts.
+ */
+export class AccountLockedError extends Error {
+  /** Timestamp until which the account remains locked. */
+  readonly lockedUntil: Date;
+
+  /**
+   * Create a new error instance.
+   *
+   * @param lockedUntil - When the lock will expire.
+   * @param message - Optional custom message.
+   */
+  constructor(lockedUntil: Date, message = 'Account is temporarily locked due to multiple failed login attempts.') {
+    super(message);
+    this.lockedUntil = lockedUntil;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2927,6 +2927,26 @@
           },
           "403": {
             "description": "User account is suspended or archived"
+          },
+          "423": {
+            "description": "Account temporarily locked due to failed attempts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": { "type": "string" },
+                    "lockedUntil": { "type": "string", "format": "date-time" }
+                  },
+                  "example": {
+                    "error": "Account is temporarily locked due to multiple failed login attempts.",
+                    "code": "account_locked",
+                    "lockedUntil": "2030-01-01T00:00:00.000Z"
+                  }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- add `AccountLockedError` domain error
- use `AccountLockedError` in authentication use case
- report account lock from REST login endpoint
- document lock error in OpenAPI spec
- test account locked behaviour in use case and controller

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886af04ad58832396b6e09601a602ba