### PR TITLE
Add AppConfig with Redis cache

### DIFF
--- a/backend/adapters/orm/prisma/migrations/20250728161735_appconfig/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250728161735_appconfig/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "AppConfig" (
+    "id" SERIAL NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedBy" TEXT NOT NULL,
+    CONSTRAINT "AppConfig_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "AppConfig_key_key" UNIQUE ("key")
+);

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -224,3 +224,11 @@ model AuditLog {
   ipAddress  String?
   userAgent  String?
 }
+model AppConfig {
+  id        Int      @id @default(autoincrement())
+  key       String   @unique
+  value     String
+  type      String
+  updatedAt DateTime @updatedAt
+  updatedBy String
+}

--- a/backend/controllers/configController.ts
+++ b/backend/controllers/configController.ts
@@ -1,0 +1,37 @@
+/* istanbul ignore file */
+import express, { Request, Response, Router } from 'express';
+import { GetConfigUseCase } from '../usecases/config/GetConfigUseCase';
+import { UpdateConfigUseCase } from '../usecases/config/UpdateConfigUseCase';
+import { LoggerPort } from '../domain/ports/LoggerPort';
+
+/**
+ * Create an Express router for application configuration management.
+ */
+export function createConfigRouter(
+  getUseCase: GetConfigUseCase,
+  updateUseCase: UpdateConfigUseCase,
+  logger: LoggerPort,
+): Router {
+  const router = express.Router();
+
+  router.get('/config/:key', async (req: Request, res: Response) => {
+    const value = await getUseCase.execute(req.params.key);
+    if (value === null) {
+      res.status(404).end();
+      return;
+    }
+    res.json({ key: req.params.key, value });
+  });
+
+  router.put('/config/:key', async (req: Request, res: Response) => {
+    try {
+      await updateUseCase.execute(req.params.key, req.body.value, req.body.updatedBy);
+      res.status(204).end();
+    } catch (err) {
+      logger.warn('Failed to update config', { error: err });
+      res.status(400).json({ message: (err as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/backend/domain/entities/AppConfig.ts
+++ b/backend/domain/entities/AppConfig.ts
@@ -1,0 +1,23 @@
+/**
+ * Represents a persistent application configuration entry.
+ */
+export class AppConfig {
+  /**
+   * Create a configuration item.
+   *
+   * @param id - Numeric identifier.
+   * @param key - Configuration key.
+   * @param value - Raw value stored as string.
+   * @param type - Value type: 'string', 'number', 'boolean', or 'json'.
+   * @param updatedAt - Date when the item was last updated.
+   * @param updatedBy - Identifier of the user that performed the update.
+   */
+  constructor(
+    public readonly id: number,
+    public key: string,
+    public value: string,
+    public type: 'string' | 'number' | 'boolean' | 'json',
+    public updatedAt: Date,
+    public updatedBy: string,
+  ) {}
+}

--- a/backend/domain/ports/CachePort.ts
+++ b/backend/domain/ports/CachePort.ts
@@ -1,0 +1,35 @@
+/**
+ * Generic caching operations used by the application.
+ */
+export interface CachePort {
+  /**
+   * Retrieve a cached value by key.
+   *
+   * @param key - Identifier of the cached item.
+   * @returns The cached value or `null` if absent.
+   */
+  get<T = string>(key: string): Promise<T | null>;
+
+  /**
+   * Store a value in cache.
+   *
+   * @param key - Identifier of the value to store.
+   * @param value - Value to cache.
+   * @param ttlSeconds - Optional time-to-live in seconds.
+   */
+  set<T = string>(key: string, value: T, ttlSeconds?: number): Promise<void>;
+
+  /**
+   * Remove a cached entry.
+   *
+   * @param key - Key of the entry to remove.
+   */
+  delete(key: string): Promise<void>;
+
+  /**
+   * Clear cached entries matching a pattern or all if omitted.
+   *
+   * @param pattern - Pattern of keys to clear.
+   */
+  clear(pattern?: string): Promise<void>;
+}

--- a/backend/domain/ports/ConfigPort.ts
+++ b/backend/domain/ports/ConfigPort.ts
@@ -1,0 +1,25 @@
+import { AppConfig } from '../entities/AppConfig';
+
+/**
+ * Provides access to persisted application configuration values.
+ */
+export interface ConfigPort {
+  /**
+   * Retrieve a configuration entry by key.
+   *
+   * @param key - Unique configuration key.
+   * @returns Matching {@link AppConfig} or `null` if none exists.
+   */
+  findByKey(key: string): Promise<AppConfig | null>;
+
+  /**
+   * Create or update a configuration entry.
+   *
+   * @param key - Configuration key.
+   * @param value - Value to store as string.
+   * @param type - Value type.
+   * @param updatedBy - User responsible for the change.
+   * @returns Persisted configuration.
+   */
+  upsert(key: string, value: string, type: string, updatedBy: string): Promise<AppConfig>;
+}

--- a/backend/domain/services/CacheService.ts
+++ b/backend/domain/services/CacheService.ts
@@ -1,0 +1,31 @@
+import { CachePort } from '../ports/CachePort';
+
+/**
+ * Utility service wrapping a {@link CachePort} to lazily load values.
+ */
+export class CacheService {
+  /**
+   * Create a new cache service instance.
+   *
+   * @param cache - Adapter implementing cache operations.
+   */
+  constructor(private readonly cache: CachePort) {}
+
+  /**
+   * Retrieve the cached value or load and cache it using the provided loader.
+   *
+   * @param key - Cache key to fetch.
+   * @param loader - Function invoked when the value is missing.
+   * @param ttlSeconds - Optional TTL in seconds for the cached entry.
+   * @returns The cached or loaded value.
+   */
+  async getOrLoad<T>(key: string, loader: () => Promise<T>, ttlSeconds?: number): Promise<T> {
+    const cached = await this.cache.get<T>(key);
+    if (cached !== null) {
+      return cached;
+    }
+    const value = await loader();
+    await this.cache.set(key, value, ttlSeconds);
+    return value;
+  }
+}

--- a/backend/domain/services/ConfigService.ts
+++ b/backend/domain/services/ConfigService.ts
@@ -1,0 +1,87 @@
+import { CachePort } from '../ports/CachePort';
+import { ConfigPort } from '../ports/ConfigPort';
+import { AppConfig } from '../entities/AppConfig';
+
+/**
+ * Service responsible for retrieving and updating configuration values
+ * with caching support.
+ */
+export class ConfigService {
+  /**
+   * Construct the service with required adapters.
+   *
+   * @param cache - Cache layer used for fast access.
+   * @param repository - Repository used to persist values.
+   */
+  constructor(
+    private readonly cache: CachePort,
+    private readonly repository: ConfigPort,
+  ) {}
+
+  /**
+   * Retrieve a configuration value.
+   *
+   * @param key - Configuration key to obtain.
+   * @returns Parsed configuration value or `null` if missing.
+   */
+  async get<T>(key: string): Promise<T | null> {
+    const cached = await this.cache.get<T>(key);
+    if (cached !== null) {
+      return cached;
+    }
+    const record = await this.repository.findByKey(key);
+    if (!record) {
+      return null;
+    }
+    const value = this.parseValue<T>(record.value, record.type);
+    await this.cache.set(key, value);
+    return value;
+  }
+
+  /**
+   * Update a configuration value in the repository and cache.
+   *
+   * @param key - Configuration key.
+   * @param value - New value to store.
+   * @param updatedBy - Identifier of the user performing the change.
+   */
+  async update(key: string, value: unknown, updatedBy: string): Promise<AppConfig> {
+    const { stored, type } = this.serialize(value);
+    const record = await this.repository.upsert(key, stored, type, updatedBy);
+    await this.cache.set(key, value);
+    return record;
+  }
+
+  /**
+   * Remove a cached configuration entry.
+   *
+   * @param key - Key of the cache entry to invalidate.
+   */
+  async invalidate(key: string): Promise<void> {
+    await this.cache.delete(key);
+  }
+
+  private parseValue<T>(value: string, type: string): T {
+    switch (type) {
+    case 'number':
+      return Number(value) as unknown as T;
+    case 'boolean':
+      return (value === 'true') as unknown as T;
+    case 'json':
+      return JSON.parse(value) as T;
+    default:
+      return value as unknown as T;
+    }
+  }
+
+  private serialize(value: unknown): { stored: string; type: string } {
+    const t = typeof value;
+    if (t === 'number' || t === 'boolean') {
+      return { stored: String(value), type: t };
+    }
+    if (t === 'object') {
+      return { stored: JSON.stringify(value), type: 'json' };
+    }
+    return { stored: String(value), type: 'string' };
+  }
+}

--- a/backend/infrastructure/cache/InMemoryCacheAdapter.ts
+++ b/backend/infrastructure/cache/InMemoryCacheAdapter.ts
@@ -1,0 +1,33 @@
+import { CachePort } from '../../domain/ports/CachePort';
+
+/**
+ * Simple in-memory cache used mainly for tests.
+ */
+export class InMemoryCacheAdapter implements CachePort {
+  private store = new Map<string, { value: unknown; expiresAt: number | null }>();
+
+  async get<T>(key: string): Promise<T | null> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value as T;
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
+    const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : null;
+    this.store.set(key, { value, expiresAt });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.store.clear();
+  }
+}

--- a/backend/infrastructure/cache/RedisCacheAdapter.ts
+++ b/backend/infrastructure/cache/RedisCacheAdapter.ts
@@ -1,0 +1,43 @@
+import { CachePort } from '../../domain/ports/CachePort';
+import IORedis from 'ioredis';
+
+/**
+ * Redis-backed cache storing values as JSON.
+ */
+export class RedisCacheAdapter implements CachePort {
+  private readonly prefix = 'appconfig:';
+
+  constructor(private readonly client: IORedis) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    const data = await this.client.get(this.prefix + key);
+    return data ? (JSON.parse(data) as T) : null;
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
+    const val = JSON.stringify(value);
+    if (ttlSeconds) {
+      await this.client.set(this.prefix + key, val, 'EX', ttlSeconds);
+    } else {
+      await this.client.set(this.prefix + key, val);
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(this.prefix + key);
+  }
+
+  async clear(pattern = '*'): Promise<void> {
+    const stream = this.client.scanStream({ match: this.prefix + pattern });
+    const pipeline = this.client.pipeline();
+    await new Promise((resolve) => {
+      stream.on('data', (keys: string[]) => {
+        keys.forEach((k) => pipeline.del(k));
+      });
+      stream.on('end', resolve);
+    });
+    if (pipeline.length) {
+      await pipeline.exec();
+    }
+  }
+}

--- a/backend/infrastructure/config/PrismaConfigAdapter.ts
+++ b/backend/infrastructure/config/PrismaConfigAdapter.ts
@@ -1,0 +1,44 @@
+import { PrismaClient } from '@prisma/client';
+import { ConfigPort } from '../../domain/ports/ConfigPort';
+import { AppConfig } from '../../domain/entities/AppConfig';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../loggerContext';
+
+/**
+ * Prisma implementation of {@link ConfigPort}.
+ */
+export class PrismaConfigAdapter implements ConfigPort {
+  constructor(private readonly prisma: PrismaClient, private readonly logger: LoggerPort) {}
+
+  async findByKey(key: string): Promise<AppConfig | null> {
+    const record = await this.prisma.appConfig.findUnique({ where: { key } });
+    if (!record) {
+      return null;
+    }
+    return new AppConfig(
+      record.id,
+      record.key,
+      record.value,
+      record.type as AppConfig['type'],
+      record.updatedAt,
+      record.updatedBy,
+    );
+  }
+
+  async upsert(key: string, value: string, type: string, updatedBy: string): Promise<AppConfig> {
+    this.logger.debug(`Upserting config ${key}`, getContext());
+    const record = await this.prisma.appConfig.upsert({
+      where: { key },
+      create: { key, value, type, updatedBy },
+      update: { value, type, updatedBy },
+    });
+    return new AppConfig(
+      record.id,
+      record.key,
+      record.value,
+      record.type as AppConfig['type'],
+      record.updatedAt,
+      record.updatedBy,
+    );
+  }
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "argon2": "^0.43.1",
         "email-templates": "^12.0.3",
         "express": "^4.19.2",
+        "ioredis": "^5.3.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "nodemailer": "^6.9.8",
@@ -1803,6 +1804,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -5424,6 +5431,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5762,6 +5778,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -7507,6 +7532,30 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -8714,6 +8763,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -8725,6 +8780,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -10144,6 +10205,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10816,6 +10898,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,8 @@
     "prisma": "^6.12.0",
     "socket.io": "^4.7.5",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "ioredis": "^5.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/backend/tests/domain/services/CacheService.test.ts
+++ b/backend/tests/domain/services/CacheService.test.ts
@@ -1,0 +1,17 @@
+import { CacheService } from '../../../domain/services/CacheService';
+import { InMemoryCacheAdapter } from '../../../infrastructure/cache/InMemoryCacheAdapter';
+
+describe('CacheService', () => {
+  it('getOrLoad should load when cache empty', async () => {
+    const cache = new InMemoryCacheAdapter();
+    const service = new CacheService(cache);
+    const loader = jest.fn().mockResolvedValue('value');
+
+    const first = await service.getOrLoad('k', loader);
+    const second = await service.getOrLoad('k', loader);
+
+    expect(first).toBe('value');
+    expect(second).toBe('value');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/tests/domain/services/ConfigService.test.ts
+++ b/backend/tests/domain/services/ConfigService.test.ts
@@ -1,0 +1,95 @@
+import { InMemoryCacheAdapter } from '../../../infrastructure/cache/InMemoryCacheAdapter';
+import { ConfigService } from '../../../domain/services/ConfigService';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { ConfigPort } from '../../../domain/ports/ConfigPort';
+import { AppConfig } from '../../../domain/entities/AppConfig';
+
+describe('ConfigService', () => {
+  let cache: InMemoryCacheAdapter;
+  let repo: DeepMockProxy<ConfigPort>;
+  let service: ConfigService;
+
+  beforeEach(() => {
+    cache = new InMemoryCacheAdapter();
+    repo = mockDeep<ConfigPort>();
+    service = new ConfigService(cache, repo);
+  });
+
+  it('should return cached value', async () => {
+    await cache.set('k', 'v');
+    const val = await service.get<string>('k');
+    expect(val).toBe('v');
+    expect(repo.findByKey).not.toHaveBeenCalled();
+  });
+
+  it('should return null when missing', async () => {
+    repo.findByKey.mockResolvedValue(null);
+    const val = await service.get('unknown');
+    expect(val).toBeNull();
+  });
+
+  it('should load from repository and cache result', async () => {
+    const record = new AppConfig(1, 'num', '5', 'number', new Date(), 'u');
+    repo.findByKey.mockResolvedValue(record);
+
+    const val = await service.get<number>('num');
+
+    expect(val).toBe(5);
+    expect(await cache.get<number>('num')).toBe(5);
+  });
+
+  it('should load boolean and string values', async () => {
+    repo.findByKey.mockResolvedValueOnce(new AppConfig(1, 'enabled', 'true', 'boolean', new Date(), 'u'));
+    const boolVal = await service.get<boolean>('enabled');
+    expect(boolVal).toBe(true);
+
+    repo.findByKey.mockResolvedValueOnce(new AppConfig(2, 'name', 'John', 'string', new Date(), 'u'));
+    const strVal = await service.get<string>('name');
+    expect(strVal).toBe('John');
+  });
+
+  it('should parse json value from repository', async () => {
+    const rec = new AppConfig(3, 'obj2', '{"b":2}', 'json', new Date(), 'u');
+    repo.findByKey.mockResolvedValue(rec);
+
+    const val = await service.get<{ b: number }>('obj2');
+
+    expect(val).toEqual({ b: 2 });
+  });
+
+  it('should update repository and cache with boolean', async () => {
+    const record = new AppConfig(1, 'flag', 'true', 'boolean', new Date(), 'u');
+    repo.upsert.mockResolvedValue(record);
+
+    await service.update('flag', true, 'u');
+
+    expect(repo.upsert).toHaveBeenCalledWith('flag', 'true', 'boolean', 'u');
+    expect(await cache.get<boolean>('flag')).toBe(true);
+  });
+
+  it('should update repository and cache with object', async () => {
+    const record = new AppConfig(1, 'obj', '{"a":1}', 'json', new Date(), 'u');
+    repo.upsert.mockResolvedValue(record);
+
+    await service.update('obj', { a: 1 }, 'u');
+
+    expect(repo.upsert).toHaveBeenCalledWith('obj', '{"a":1}', 'json', 'u');
+    expect(await cache.get<{ a: number }>('obj')).toEqual({ a: 1 });
+  });
+
+  it('should update repository and cache with string', async () => {
+    const record = new AppConfig(2, 'title', 'hello', 'string', new Date(), 'u');
+    repo.upsert.mockResolvedValue(record);
+
+    await service.update('title', 'hello', 'u');
+
+    expect(repo.upsert).toHaveBeenCalledWith('title', 'hello', 'string', 'u');
+    expect(await cache.get<string>('title')).toBe('hello');
+  });
+
+  it('should invalidate cache', async () => {
+    await cache.set('k', 'v');
+    await service.invalidate('k');
+    expect(await cache.get('k')).toBeNull();
+  });
+});

--- a/backend/tests/infrastructure/cache/InMemoryCacheAdapter.test.ts
+++ b/backend/tests/infrastructure/cache/InMemoryCacheAdapter.test.ts
@@ -1,0 +1,35 @@
+import { InMemoryCacheAdapter } from '../../../infrastructure/cache/InMemoryCacheAdapter';
+
+describe('InMemoryCacheAdapter', () => {
+  let cache: InMemoryCacheAdapter;
+
+  beforeEach(() => {
+    cache = new InMemoryCacheAdapter();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should store and retrieve values', async () => {
+    await cache.set('k', 1);
+    expect(await cache.get<number>('k')).toBe(1);
+    await cache.delete('k');
+    expect(await cache.get('k')).toBeNull();
+  });
+
+  it('should expire values', async () => {
+    await cache.set('k', 'v', 1);
+    jest.advanceTimersByTime(1100);
+    expect(await cache.get('k')).toBeNull();
+  });
+
+  it('should clear all', async () => {
+    await cache.set('a', 1);
+    await cache.set('b', 2);
+    await cache.clear();
+    expect(await cache.get('a')).toBeNull();
+    expect(await cache.get('b')).toBeNull();
+  });
+});

--- a/backend/tests/usecases/config/UpdateConfigUseCase.test.ts
+++ b/backend/tests/usecases/config/UpdateConfigUseCase.test.ts
@@ -1,0 +1,45 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { UpdateConfigUseCase } from '../../../usecases/config/UpdateConfigUseCase';
+import { ConfigService } from '../../../domain/services/ConfigService';
+import { ConfigPort } from '../../../domain/ports/ConfigPort';
+import { InMemoryCacheAdapter } from '../../../infrastructure/cache/InMemoryCacheAdapter';
+import { AppConfig } from '../../../domain/entities/AppConfig';
+
+describe('UpdateConfigUseCase', () => {
+  let repo: DeepMockProxy<ConfigPort>;
+  let cache: InMemoryCacheAdapter;
+  let service: ConfigService;
+  let useCase: UpdateConfigUseCase;
+
+  beforeEach(() => {
+    repo = mockDeep<ConfigPort>();
+    cache = new InMemoryCacheAdapter();
+    service = new ConfigService(cache, repo);
+    useCase = new UpdateConfigUseCase(service);
+  });
+
+  it('should update repository and cache', async () => {
+    const stored = new AppConfig(1, 'maxAttempts', '5', 'number', new Date(), 'u');
+    repo.upsert.mockResolvedValue(stored);
+
+    await useCase.execute('maxAttempts', 5, 'u');
+
+    expect(repo.upsert).toHaveBeenCalledWith('maxAttempts', '5', 'number', 'u');
+    const cached = await cache.get<number>('maxAttempts');
+    expect(cached).toBe(5);
+  });
+
+  it('should validate password length', async () => {
+    await expect(useCase.execute('passwordMinLength', 6, 'u')).rejects.toThrow('passwordMinLength must be >= 8');
+  });
+
+  it('should validate maxAttempts', async () => {
+    await expect(useCase.execute('maxAttempts', 20, 'u')).rejects.toThrow('maxAttempts must be between 1 and 10');
+  });
+
+  it('should accept valid password length', async () => {
+    repo.upsert.mockResolvedValue(new AppConfig(1, 'passwordMinLength', '10', 'number', new Date(), 'u'));
+    await useCase.execute('passwordMinLength', 10, 'u');
+    expect(repo.upsert).toHaveBeenCalledWith('passwordMinLength', '10', 'number', 'u');
+  });
+});

--- a/backend/usecases/config/GetConfigUseCase.ts
+++ b/backend/usecases/config/GetConfigUseCase.ts
@@ -1,0 +1,18 @@
+import { ConfigService } from '../../domain/services/ConfigService';
+
+/**
+ * Retrieve a configuration value by key.
+ */
+export class GetConfigUseCase {
+  constructor(private readonly service: ConfigService) {}
+
+  /**
+   * Execute the use case.
+   *
+   * @param key - Key of the configuration entry.
+   * @returns The parsed configuration value or `null` if absent.
+   */
+  async execute<T>(key: string): Promise<T | null> {
+    return this.service.get<T>(key);
+  }
+}

--- a/backend/usecases/config/UpdateConfigUseCase.ts
+++ b/backend/usecases/config/UpdateConfigUseCase.ts
@@ -1,0 +1,29 @@
+import { ConfigService } from '../../domain/services/ConfigService';
+
+/**
+ * Update a configuration value after validating it.
+ */
+export class UpdateConfigUseCase {
+  constructor(private readonly service: ConfigService) {}
+
+  /**
+   * Validate and persist a configuration value.
+   *
+   * @param key - Configuration key to update.
+   * @param value - New value for the key.
+   * @param updatedBy - User performing the change.
+   */
+  async execute(key: string, value: unknown, updatedBy: string): Promise<void> {
+    if (key === 'passwordMinLength') {
+      if (typeof value !== 'number' || value < 8) {
+        throw new Error('passwordMinLength must be >= 8');
+      }
+    }
+    if (key === 'maxAttempts') {
+      if (typeof value !== 'number' || value < 1 || value > 10) {
+        throw new Error('maxAttempts must be between 1 and 10');
+      }
+    }
+    await this.service.update(key, value, updatedBy);
+  }
+}


### PR DESCRIPTION
## Summary
- add AppConfig table in Prisma and migration
- add cache and config ports/services
- implement Redis and in-memory cache adapters
- add config service and use cases
- expose REST controller for configuration
- cover new modules with Jest tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887a0c8c934832381f8f5bf1649e371