### PR TITLE
Implement config bootstrap service

### DIFF
--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -21,6 +21,7 @@ import {RemoveUserUseCase} from '../../../usecases/user/RemoveUserUseCase';
 import {GetUsersUseCase} from '../../../usecases/user/GetUsersUseCase';
 import {GetUserUseCase} from '../../../usecases/user/GetUserUseCase';
 import {LoggerPort} from '../../../domain/ports/LoggerPort';
+import { GetConfigUseCase } from '../../../usecases/config/GetConfigUseCase';
 import {getContext} from '../../../infrastructure/loggerContext';
 import {User} from '../../../domain/entities/User';
 import {Role} from '../../../domain/entities/Role';
@@ -202,6 +203,7 @@ export function createUserRouter(
   tokenService: TokenServicePort,
   refreshTokenRepository: RefreshTokenRepositoryPort,
   logger: LoggerPort,
+  getConfigUseCase: GetConfigUseCase,
 ): Router {
   const router = express.Router();
   const upload = multer();
@@ -383,6 +385,7 @@ export function createUserRouter(
           userRepository,
           audit,
           logger,
+          getConfigUseCase,
         );
         try {
           const result = await useCase.execute(email, password);

--- a/backend/domain/entities/AppConfigKeys.ts
+++ b/backend/domain/entities/AppConfigKeys.ts
@@ -1,0 +1,13 @@
+/**
+ * Central registry of application configuration keys.
+ */
+export class AppConfigKeys {
+  /** Enables account locking after login failures. */
+  static readonly ACCOUNT_LOCK_ON_LOGIN_FAIL = 'account_lock_on_login_fail';
+
+  /** Duration in seconds of the account lock. */
+  static readonly ACCOUNT_LOCK_DURATION = 'account_lock_duration';
+
+  /** Number of failed logins required before locking an account. */
+  static readonly ACCOUNT_LOCK_FAIL_THRESHOLD = 'account_lock_fail_threshold';
+}

--- a/backend/domain/services/BootstapService.ts
+++ b/backend/domain/services/BootstapService.ts
@@ -1,0 +1,29 @@
+import { ConfigService } from './ConfigService';
+import { LoggerPort } from '../ports/LoggerPort';
+import { AppConfigKeys } from '../entities/AppConfigKeys';
+
+/**
+ * Service initializing default application configuration values.
+ */
+export class BootstapService {
+  /**
+   * Create a new bootstrapper.
+   *
+   * @param config - Service used to persist configuration values.
+   * @param logger - Logger instance for runtime information.
+   */
+  constructor(
+    private readonly config: ConfigService,
+    private readonly logger: LoggerPort,
+  ) {}
+
+  /**
+   * Initialize mandatory configuration entries.
+   */
+  async initialize(): Promise<void> {
+    this.logger.info('Bootstrapping configuration');
+    await this.config.update(AppConfigKeys.ACCOUNT_LOCK_ON_LOGIN_FAIL, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_LOCK_DURATION, 900, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_LOCK_FAIL_THRESHOLD, 4, 'bootstrap');
+  }
+}

--- a/backend/tests/domain/services/BootstapService.test.ts
+++ b/backend/tests/domain/services/BootstapService.test.ts
@@ -1,0 +1,24 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { BootstapService } from '../../../domain/services/BootstapService';
+import { ConfigService } from '../../../domain/services/ConfigService';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { AppConfigKeys } from '../../../domain/entities/AppConfigKeys';
+
+describe('BootstapService', () => {
+  let config: DeepMockProxy<ConfigService>;
+  let logger: DeepMockProxy<LoggerPort>;
+  let service: BootstapService;
+
+  beforeEach(() => {
+    config = mockDeep<ConfigService>();
+    logger = mockDeep<LoggerPort>();
+    service = new BootstapService(config, logger);
+  });
+
+  it('should initialize configuration keys', async () => {
+    await service.initialize();
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_LOCK_ON_LOGIN_FAIL, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_LOCK_DURATION, 900, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_LOCK_FAIL_THRESHOLD, 4, 'bootstrap');
+  });
+});


### PR DESCRIPTION
## Summary
- bootstrap configuration keys on server startup
- use configuration values in AuthenticateUserUseCase
- expose config constants via `AppConfigKeys`
- adapt REST controller and server wiring
- add unit tests for bootstrap service and update existing tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887aebaa80c8323b342e03e8f9b50e4