### PR TITLE
Add openapi docs for config controller

### DIFF
--- a/backend/adapters/controllers/rest/configController.ts
+++ b/backend/adapters/controllers/rest/configController.ts
@@ -5,6 +5,37 @@ import { UpdateConfigUseCase } from '../../../usecases/config/UpdateConfigUseCas
 import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
 /**
+ * @openapi
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: JWT
+ *   schemas:
+ *     ConfigEntry:
+ *       description: Application configuration entry.
+ *       type: object
+ *       properties:
+ *         key:
+ *           type: string
+ *           description: Configuration key.
+ *         value:
+ *           description: Stored configuration value.
+ *           oneOf:
+ *             - type: string
+ *             - type: number
+ *             - type: boolean
+ *             - type: object
+ *       required:
+ *         - key
+ *         - value
+ * tags:
+ *   - name: Config
+ *     description: Manage application configuration
+ */
+
+/**
  * Create an Express router for application configuration management.
  */
 export function createConfigRouter(
@@ -14,6 +45,31 @@ export function createConfigRouter(
 ): Router {
   const router = express.Router();
 
+  /**
+   * @openapi
+   * /config/{key}:
+   *   get:
+   *     summary: Get configuration value
+   *     description: Return the value for the specified configuration key.
+   *     tags:
+   *       - Config
+   *     parameters:
+   *       - in: path
+   *         name: key
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Identifier of the configuration entry.
+   *     responses:
+   *       200:
+   *         description: Configuration value
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ConfigEntry'
+   *       404:
+   *         description: Configuration entry not found
+   */
   router.get('/config/:key', async (req: Request, res: Response) => {
     const value = await getUseCase.execute(req.params.key);
     if (value === null) {
@@ -23,6 +79,36 @@ export function createConfigRouter(
     res.json({ key: req.params.key, value });
   });
 
+  /**
+   * @openapi
+   * /config/{key}:
+   *   put:
+   *     summary: Update configuration value
+   *     description: Update the value of a configuration entry.
+   *     tags:
+   *       - Config
+   *     requestBody:
+   *       description: New value and user identifier performing the update.
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               value:
+   *                 description: New value to store.
+   *               updatedBy:
+   *                 type: string
+   *                 description: Identifier of the user updating the value.
+   *             required:
+   *               - value
+   *               - updatedBy
+   *     responses:
+   *       204:
+   *         description: Configuration updated successfully
+   *       400:
+   *         description: Validation error
+   */
   router.put('/config/:key', async (req: Request, res: Response) => {
     try {
       await updateUseCase.execute(req.params.key, req.body.value, req.body.updatedBy);


### PR DESCRIPTION
## Summary
- add @openapi blocks in `configController`

## Testing
- `npm run lint`
- `npm test` *(fails: global coverage threshold for branches (100%) not met: 98.55%)*

------
https://chatgpt.com/codex/tasks/task_e_6887c6eb64608323a5ea620f74c66db1