### PR TITLE
Add password and MFA config keys

### DIFF
--- a/backend/domain/entities/AppConfigKeys.ts
+++ b/backend/domain/entities/AppConfigKeys.ts
@@ -10,4 +10,44 @@ export class AppConfigKeys {
 
   /** Number of failed logins required before locking an account. */
   static readonly ACCOUNT_LOCK_FAIL_THRESHOLD = 'account_lock_fail_threshold';
+
+  /** Minimum allowed password length. */
+  static readonly ACCOUNT_PASSWORD_MIN_LENGTH = 'account_password_min_length';
+
+  /** Maximum allowed password length. */
+  static readonly ACCOUNT_PASSWORD_MAX_LENGTH = 'account_password_max_length';
+
+  /** Require passwords to contain at least one uppercase character. */
+  static readonly ACCOUNT_PASSWORD_MUST_HAVE_UPPERCASE =
+    'account_password_must_have_uppercase';
+
+  /** Require passwords to contain at least one lowercase character. */
+  static readonly ACCOUNT_PASSWORD_MUST_HAVE_LOWERCASE =
+    'account_password_must_have_lowercase';
+
+  /** Require passwords to contain at least one digit. */
+  static readonly ACCOUNT_PASSWORD_MUST_HAVE_DIGIT =
+    'account_password_must_have_digit';
+
+  /** Require passwords to contain at least one special character. */
+  static readonly ACCOUNT_PASSWORD_MUST_HAVE_SPECIAL_CHAR =
+    'account_password_must_have_special_char';
+
+  /** Enable password expiration policy. */
+  static readonly ACCOUNT_PASSWORD_EXPIRE = 'account_password_expire';
+
+  /** Number of days before a password must be changed. */
+  static readonly ACCOUNT_PASSWORD_EXPIRE_AFTER = 'account_password_expire_after';
+
+  /** Enable password history check when updating password. */
+  static readonly ACCOUNT_PASSWORD_HISTORY = 'account_password_history';
+
+  /** Number of previous passwords remembered for history check. */
+  static readonly ACCOUNT_PASSWORD_HISTORY_COUNT = 'account_password_history_count';
+
+  /** Allow users to enable multi-factor authentication. */
+  static readonly ACCOUNT_ALLOW_MFA = 'account_allow_mfa';
+
+  /** Require users to enable multi-factor authentication. */
+  static readonly ACCOUNT_REQUIRE_MFA = 'account_require_mfa';
 }

--- a/backend/domain/services/BootstapService.ts
+++ b/backend/domain/services/BootstapService.ts
@@ -32,6 +32,18 @@ export class BootstapService {
     await this.config.update(AppConfigKeys.ACCOUNT_LOCK_ON_LOGIN_FAIL, true, 'bootstrap');
     await this.config.update(AppConfigKeys.ACCOUNT_LOCK_DURATION, 900, 'bootstrap');
     await this.config.update(AppConfigKeys.ACCOUNT_LOCK_FAIL_THRESHOLD, 4, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_MIN_LENGTH, 8, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_MAX_LENGTH, 30, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_UPPERCASE, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_LOWERCASE, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_DIGIT, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_SPECIAL_CHAR, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_EXPIRE, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_EXPIRE_AFTER, 90, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_HISTORY, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_PASSWORD_HISTORY_COUNT, 50, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_ALLOW_MFA, true, 'bootstrap');
+    await this.config.update(AppConfigKeys.ACCOUNT_REQUIRE_MFA, false, 'bootstrap');
 
     this.logger.info('Bootstrapping permissions');
     const keys = Object.values(PermissionKeys);

--- a/backend/tests/domain/services/BootstapService.test.ts
+++ b/backend/tests/domain/services/BootstapService.test.ts
@@ -25,6 +25,18 @@ describe('BootstapService', () => {
     expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_LOCK_ON_LOGIN_FAIL, true, 'bootstrap');
     expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_LOCK_DURATION, 900, 'bootstrap');
     expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_LOCK_FAIL_THRESHOLD, 4, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_MIN_LENGTH, 8, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_MAX_LENGTH, 30, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_UPPERCASE, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_LOWERCASE, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_DIGIT, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_SPECIAL_CHAR, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_EXPIRE, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_EXPIRE_AFTER, 90, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_HISTORY, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_PASSWORD_HISTORY_COUNT, 50, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_ALLOW_MFA, true, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.ACCOUNT_REQUIRE_MFA, false, 'bootstrap');
   });
 
   it('should create missing permissions', async () => {


### PR DESCRIPTION
## Summary
- add new account password and MFA configuration keys
- initialize new config in BootstrapService with defaults
- test new configuration initialization

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887e12d30848323adf64a00a98750aa