### PR TITLE
Add password policy enforcement

### DIFF
--- a/backend/domain/errors/InvalidPasswordException.ts
+++ b/backend/domain/errors/InvalidPasswordException.ts
@@ -1,0 +1,14 @@
+/**
+ * Error thrown when a password does not meet the configured complexity rules.
+ */
+export class InvalidPasswordException extends Error {
+  /**
+   * Create a new instance.
+   *
+   * @param message - Detailed validation message.
+   */
+  constructor(message = 'Password does not meet complexity requirements') {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/backend/domain/services/PasswordValidator.ts
+++ b/backend/domain/services/PasswordValidator.ts
@@ -1,0 +1,63 @@
+import { ConfigService } from './ConfigService';
+import { AppConfigKeys } from '../entities/AppConfigKeys';
+import { InvalidPasswordException } from '../errors/InvalidPasswordException';
+
+/**
+ * Utility responsible for validating password complexity according to
+ * application configuration values.
+ */
+export class PasswordValidator {
+  /**
+   * Instantiate the validator.
+   *
+   * @param config - Service used to retrieve configuration values.
+   */
+  constructor(private readonly config: ConfigService) {}
+
+  /**
+   * Validate the provided password against configured rules.
+   *
+   * @param password - Password string to validate.
+   * @throws {@link InvalidPasswordException} when validation fails.
+   */
+  async validate(password: string): Promise<void> {
+    const minLength =
+      (await this.config.get<number>(AppConfigKeys.ACCOUNT_PASSWORD_MIN_LENGTH)) ?? 8;
+    const maxLength =
+      (await this.config.get<number>(AppConfigKeys.ACCOUNT_PASSWORD_MAX_LENGTH)) ?? 30;
+    const mustHaveUpper =
+      (await this.config.get<boolean>(
+        AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_UPPERCASE,
+      )) ?? true;
+    const mustHaveLower =
+      (await this.config.get<boolean>(
+        AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_LOWERCASE,
+      )) ?? true;
+    const mustHaveDigit =
+      (await this.config.get<boolean>(AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_DIGIT)) ??
+      true;
+    const mustHaveSpecial =
+      (await this.config.get<boolean>(
+        AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_SPECIAL_CHAR,
+      )) ?? true;
+
+    if (password.length < minLength) {
+      throw new InvalidPasswordException('Password too short');
+    }
+    if (password.length > maxLength) {
+      throw new InvalidPasswordException('Password too long');
+    }
+    if (mustHaveUpper && !/[A-Z]/.test(password)) {
+      throw new InvalidPasswordException('Password must contain an uppercase letter');
+    }
+    if (mustHaveLower && !/[a-z]/.test(password)) {
+      throw new InvalidPasswordException('Password must contain a lowercase letter');
+    }
+    if (mustHaveDigit && !/[0-9]/.test(password)) {
+      throw new InvalidPasswordException('Password must contain a digit');
+    }
+    if (mustHaveSpecial && !/[^A-Za-z0-9]/.test(password)) {
+      throw new InvalidPasswordException('Password must contain a special character');
+    }
+  }
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -29,6 +29,7 @@ import { InMemoryCacheAdapter } from '../adapters/cache/InMemoryCacheAdapter';
 import { ConfigService } from '../domain/services/ConfigService';
 import { GetConfigUseCase } from '../usecases/config/GetConfigUseCase';
 import { BootstapService } from '../domain/services/BootstapService';
+import { PasswordValidator } from '../domain/services/PasswordValidator';
 
 async function bootstrap(): Promise<void> {
   const logger = new ConsoleLoggerAdapter();
@@ -55,6 +56,7 @@ async function bootstrap(): Promise<void> {
   const configRepo = new PrismaConfigAdapter(prisma, logger);
   const cache = new InMemoryCacheAdapter();
   const configService = new ConfigService(cache, configRepo);
+  const passwordValidator = new PasswordValidator(configService);
   const getConfigUseCase = new GetConfigUseCase(configService);
   const bootstrapService = new BootstapService(configService, logger, permissionRepository);
   await bootstrapService.initialize();
@@ -94,6 +96,7 @@ async function bootstrap(): Promise<void> {
       refreshRepo,
       logger,
       getConfigUseCase,
+      passwordValidator,
     ),
   );
   app.use(

--- a/backend/tests/domain/services/PasswordValidator.test.ts
+++ b/backend/tests/domain/services/PasswordValidator.test.ts
@@ -1,0 +1,71 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { PasswordValidator } from '../../../domain/services/PasswordValidator';
+import { ConfigService } from '../../../domain/services/ConfigService';
+import { AppConfigKeys } from '../../../domain/entities/AppConfigKeys';
+import { InvalidPasswordException } from '../../../domain/errors/InvalidPasswordException';
+
+describe('PasswordValidator', () => {
+  let config: DeepMockProxy<ConfigService>;
+  let validator: PasswordValidator;
+
+  beforeEach(() => {
+    config = mockDeep<ConfigService>();
+    (config.get as jest.Mock).mockImplementation(async (key: string): Promise<unknown> => {
+      switch (key) {
+      case AppConfigKeys.ACCOUNT_PASSWORD_MIN_LENGTH:
+        return 8;
+      case AppConfigKeys.ACCOUNT_PASSWORD_MAX_LENGTH:
+        return 12;
+      case AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_UPPERCASE:
+        return true;
+      case AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_LOWERCASE:
+        return true;
+      case AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_DIGIT:
+        return true;
+      case AppConfigKeys.ACCOUNT_PASSWORD_MUST_HAVE_SPECIAL_CHAR:
+        return true;
+      default:
+        return null;
+      }
+    });
+    validator = new PasswordValidator(config);
+  });
+
+  it('should accept valid password', async () => {
+    await expect(validator.validate('Valid1!A')).resolves.toBeUndefined();
+  });
+
+  it('should reject short password', async () => {
+    await expect(validator.validate('V1!a')).rejects.toBeInstanceOf(InvalidPasswordException);
+  });
+
+  it('should reject long password', async () => {
+    await expect(validator.validate('VeryLongPassword1!')).rejects.toBeInstanceOf(
+      InvalidPasswordException,
+    );
+  });
+
+  it('should reject missing uppercase', async () => {
+    await expect(validator.validate('valid1!a')).rejects.toBeInstanceOf(
+      InvalidPasswordException,
+    );
+  });
+
+  it('should reject missing lowercase', async () => {
+    await expect(validator.validate('VALID1!A')).rejects.toBeInstanceOf(
+      InvalidPasswordException,
+    );
+  });
+
+  it('should reject missing digit', async () => {
+    await expect(validator.validate('Valid!!A')).rejects.toBeInstanceOf(
+      InvalidPasswordException,
+    );
+  });
+
+  it('should reject missing special char', async () => {
+    await expect(validator.validate('Valid11A')).rejects.toBeInstanceOf(
+      InvalidPasswordException,
+    );
+  });
+});

--- a/backend/tests/usecases/user/RegisterUserUseCase.test.ts
+++ b/backend/tests/usecases/user/RegisterUserUseCase.test.ts
@@ -2,6 +2,8 @@ import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { RegisterUserUseCase } from '../../../usecases/user/RegisterUserUseCase';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { TokenServicePort } from '../../../domain/ports/TokenServicePort';
+import { PasswordValidator } from '../../../domain/services/PasswordValidator';
+import { InvalidPasswordException } from '../../../domain/errors/InvalidPasswordException';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
@@ -10,6 +12,7 @@ import { Site } from '../../../domain/entities/Site';
 describe('RegisterUserUseCase', () => {
   let repository: DeepMockProxy<UserRepositoryPort>;
   let tokenService: DeepMockProxy<TokenServicePort>;
+  let passwordValidator: DeepMockProxy<PasswordValidator>;
   let useCase: RegisterUserUseCase;
   let user: User;
   let role: Role;
@@ -19,7 +22,8 @@ describe('RegisterUserUseCase', () => {
   beforeEach(() => {
     repository = mockDeep<UserRepositoryPort>();
     tokenService = mockDeep<TokenServicePort>();
-    useCase = new RegisterUserUseCase(repository, tokenService);
+    passwordValidator = mockDeep<PasswordValidator>();
+    useCase = new RegisterUserUseCase(repository, tokenService, passwordValidator);
     role = new Role('role-1', 'Admin');
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
@@ -31,15 +35,25 @@ describe('RegisterUserUseCase', () => {
     tokenService.generateAccessToken.mockReturnValue('t');
     tokenService.generateRefreshToken.mockResolvedValue('r');
 
-    const result = await useCase.execute(user);
+    passwordValidator.validate.mockResolvedValue();
+    const result = await useCase.execute(user, 'Password1!');
 
     expect(result).toEqual({ user, token: 't', refreshToken: 'r' });
     expect(user.createdAt).toBeInstanceOf(Date);
     expect(user.updatedAt).toBeInstanceOf(Date);
     expect(user.createdBy).toBeNull();
     expect(user.updatedBy).toBeNull();
+    expect(passwordValidator.validate).toHaveBeenCalledWith('Password1!');
     expect(repository.create).toHaveBeenCalledWith(user);
     expect(tokenService.generateAccessToken).toHaveBeenCalledWith(user);
     expect(tokenService.generateRefreshToken).toHaveBeenCalledWith(user);
+  });
+
+  it('should throw when password invalid', async () => {
+    passwordValidator.validate.mockRejectedValue(new InvalidPasswordException('bad'));
+
+    await expect(useCase.execute(user, 'bad')).rejects.toBeInstanceOf(
+      InvalidPasswordException,
+    );
   });
 });

--- a/backend/tests/usecases/user/ResetPasswordUseCase.test.ts
+++ b/backend/tests/usecases/user/ResetPasswordUseCase.test.ts
@@ -1,19 +1,33 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { ResetPasswordUseCase } from '../../../usecases/user/ResetPasswordUseCase';
 import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { PasswordValidator } from '../../../domain/services/PasswordValidator';
+import { InvalidPasswordException } from '../../../domain/errors/InvalidPasswordException';
 
 describe('ResetPasswordUseCase', () => {
   let service: DeepMockProxy<AuthServicePort>;
+  let validator: DeepMockProxy<PasswordValidator>;
   let useCase: ResetPasswordUseCase;
 
   beforeEach(() => {
     service = mockDeep<AuthServicePort>();
-    useCase = new ResetPasswordUseCase(service);
+    validator = mockDeep<PasswordValidator>();
+    useCase = new ResetPasswordUseCase(service, validator);
   });
 
   it('should reset password via service', async () => {
-    await useCase.execute('token', 'new');
+    validator.validate.mockResolvedValue();
+    await useCase.execute('token', 'newPass1!');
 
-    expect(service.resetPassword).toHaveBeenCalledWith('token', 'new');
+    expect(validator.validate).toHaveBeenCalledWith('newPass1!');
+    expect(service.resetPassword).toHaveBeenCalledWith('token', 'newPass1!');
+  });
+
+  it('should throw when password invalid', async () => {
+    validator.validate.mockRejectedValue(new InvalidPasswordException('bad'));
+
+    await expect(useCase.execute('tok', 'bad')).rejects.toBeInstanceOf(
+      InvalidPasswordException,
+    );
   });
 });

--- a/backend/usecases/user/ResetPasswordUseCase.ts
+++ b/backend/usecases/user/ResetPasswordUseCase.ts
@@ -1,10 +1,15 @@
 import { AuthServicePort } from '../../domain/ports/AuthServicePort';
+import { PasswordValidator } from '../../domain/services/PasswordValidator';
+import { InvalidPasswordException } from '../../domain/errors/InvalidPasswordException';
 
 /**
  * Use case for completing a password reset.
  */
 export class ResetPasswordUseCase {
-  constructor(private readonly authService: AuthServicePort) {}
+  constructor(
+    private readonly authService: AuthServicePort,
+    private readonly passwordValidator: PasswordValidator,
+  ) {}
 
   /**
    * Execute the password reset.
@@ -13,6 +18,12 @@ export class ResetPasswordUseCase {
    * @param newPassword - The new password to set.
    */
   async execute(token: string, newPassword: string): Promise<void> {
+    await this.passwordValidator.validate(newPassword).catch((err) => {
+      if (err instanceof InvalidPasswordException) {
+        throw err;
+      }
+      throw new InvalidPasswordException(err.message);
+    });
     await this.authService.resetPassword(token, newPassword);
   }
 }


### PR DESCRIPTION
## Summary
- implement `PasswordValidator` service and `InvalidPasswordException`
- validate passwords in `RegisterUserUseCase` and `ResetPasswordUseCase`
- use new validator in REST controller and server wiring
- document password constraint in OpenAPI
- add corresponding Jest tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688862b33e60832394e5c38415d1d9ec