### PR TITLE
Add cron scheduler

### DIFF
--- a/backend/adapters/scheduler/NodeCronScheduler.ts
+++ b/backend/adapters/scheduler/NodeCronScheduler.ts
@@ -1,0 +1,34 @@
+import cron from 'node-cron';
+import { SchedulerPort, ScheduledJob } from '../../domain/ports/SchedulerPort';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+
+/**
+ * Scheduler adapter using the `node-cron` library.
+ */
+export class NodeCronScheduler implements SchedulerPort {
+  /**
+   * Create a new scheduler.
+   *
+   * @param logger - Logger used to output execution information.
+   */
+  constructor(private readonly logger: LoggerPort) {}
+
+  registerJobs(jobs: ScheduledJob[]): void {
+    for (const job of jobs) {
+      try {
+        cron.schedule(job.schedule, async () => {
+          this.logger.info(`[Scheduler] Job ${job.name} started`);
+          try {
+            await job.handler();
+            this.logger.info(`[Scheduler] Job ${job.name} completed`);
+          } catch (err) {
+            this.logger.error(`[Scheduler] Job ${job.name} failed`, { error: err });
+          }
+        });
+        this.logger.info(`[Scheduler] Registered job ${job.name} (${job.schedule})`);
+      } catch (err) {
+        this.logger.error(`[Scheduler] Failed to register job ${job.name}`, { error: err });
+      }
+    }
+  }
+}

--- a/backend/adapters/scheduler/jobs.ts
+++ b/backend/adapters/scheduler/jobs.ts
@@ -1,0 +1,15 @@
+import { ScheduledJob } from '../../domain/ports/SchedulerPort';
+import { DummyCronUseCase } from '../../usecases/cron/DummyCronUseCase';
+import { ConsoleLoggerAdapter } from '../logger/ConsoleLoggerAdapter';
+
+const logger = new ConsoleLoggerAdapter();
+const dummyUseCase = new DummyCronUseCase(logger);
+
+/** Array of jobs scheduled by the application. */
+export const scheduledJobs: ScheduledJob[] = [
+  {
+    name: 'DummyJob',
+    schedule: '0 * * * *', // every hour
+    handler: () => dummyUseCase.execute(),
+  },
+];

--- a/backend/domain/ports/SchedulerPort.ts
+++ b/backend/domain/ports/SchedulerPort.ts
@@ -1,0 +1,23 @@
+/**
+ * Defines a cron job scheduled by the application.
+ */
+export type ScheduledJob = {
+  /** Descriptive job name used in logs. */
+  name: string;
+  /** Cron expression specifying the execution schedule. */
+  schedule: string;
+  /** Function executed when the job triggers. */
+  handler: () => Promise<void> | void;
+};
+
+/**
+ * Scheduler port responsible for registering and executing cron jobs.
+ */
+export interface SchedulerPort {
+  /**
+   * Register and start a collection of scheduled jobs.
+   *
+   * @param jobs - Jobs to register with the scheduler.
+   */
+  registerJobs(jobs: ScheduledJob[]): void;
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -33,6 +33,8 @@ import { ConfigService } from '../domain/services/ConfigService';
 import { GetConfigUseCase } from '../usecases/config/GetConfigUseCase';
 import { BootstapService } from '../domain/services/BootstapService';
 import { PasswordValidator } from '../domain/services/PasswordValidator';
+import { NodeCronScheduler } from '../adapters/scheduler/NodeCronScheduler';
+import { scheduledJobs } from '../adapters/scheduler/jobs';
 
 async function bootstrap(): Promise<void> {
   const logger = new ConsoleLoggerAdapter();
@@ -132,6 +134,9 @@ async function bootstrap(): Promise<void> {
   const httpServer = http.createServer(app);
   const io = new SocketIOServer(httpServer);
   registerUserGateway(io, authService, logger);
+
+  const scheduler = new NodeCronScheduler(logger);
+  scheduler.registerJobs(scheduledJobs);
 
   const port = parseInt(process.env.PORT ?? '3000', 10);
   httpServer.listen(port, () => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "ioredis": "^5.3.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
+        "node-cron": "^3.0.3",
         "nodemailer": "^6.9.8",
         "prisma": "^6.12.0",
         "socket.io": "^4.7.5",
@@ -31,6 +32,7 @@
         "@types/jsonwebtoken": "^9.0.2",
         "@types/multer": "^2.0.0",
         "@types/node": "^24.1.0",
+        "@types/node-cron": "^3.0.11",
         "@types/nodemailer": "^6.4.17",
         "@types/socket.io-client": "^1.4.36",
         "@types/supertest": "^6.0.2",
@@ -3849,6 +3851,13 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/nodemailer": {
       "version": "6.4.17",
@@ -9341,6 +9350,27 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-fetch": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,14 +26,15 @@
     "argon2": "^0.43.1",
     "email-templates": "^12.0.3",
     "express": "^4.19.2",
+    "ioredis": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
+    "node-cron": "^3.0.3",
     "nodemailer": "^6.9.8",
     "prisma": "^6.12.0",
     "socket.io": "^4.7.5",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1",
-    "ioredis": "^5.3.2"
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
@@ -43,6 +44,7 @@
     "@types/jsonwebtoken": "^9.0.2",
     "@types/multer": "^2.0.0",
     "@types/node": "^24.1.0",
+    "@types/node-cron": "^3.0.11",
     "@types/nodemailer": "^6.4.17",
     "@types/socket.io-client": "^1.4.36",
     "@types/supertest": "^6.0.2",

--- a/backend/tests/adapters/scheduler/NodeCronScheduler.test.ts
+++ b/backend/tests/adapters/scheduler/NodeCronScheduler.test.ts
@@ -1,0 +1,49 @@
+import cron from 'node-cron';
+import { NodeCronScheduler } from '../../../adapters/scheduler/NodeCronScheduler';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { mockDeep } from 'jest-mock-extended';
+
+jest.mock('node-cron', () => ({ schedule: jest.fn() }));
+
+describe('NodeCronScheduler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should execute registered job', async () => {
+    const scheduleMock = cron.schedule as unknown as jest.Mock;
+    const logger = mockDeep<LoggerPort>();
+    const scheduler = new NodeCronScheduler(logger);
+    const handler = jest.fn();
+
+    scheduler.registerJobs([{ name: 'test', schedule: '* * * * *', handler }]);
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    const cb = scheduleMock.mock.calls[0][1] as () => Promise<void>;
+    await cb();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('should log error when job throws', async () => {
+    const scheduleMock = cron.schedule as unknown as jest.Mock;
+    const logger = mockDeep<LoggerPort>();
+    const scheduler = new NodeCronScheduler(logger);
+    const handler = jest.fn().mockRejectedValue(new Error('boom'));
+
+    scheduler.registerJobs([{ name: 'test', schedule: '* * * * *', handler }]);
+
+    const cb = scheduleMock.mock.calls[0][1] as () => Promise<void>;
+    await cb();
+    expect(logger.error).toHaveBeenCalledWith('[Scheduler] Job test failed', { error: expect.any(Error) });
+  });
+
+  it('should log registration error', () => {
+    const scheduleMock = cron.schedule as unknown as jest.Mock;
+    scheduleMock.mockImplementationOnce(() => { throw new Error('bad'); });
+    const logger = mockDeep<LoggerPort>();
+    const scheduler = new NodeCronScheduler(logger);
+
+    scheduler.registerJobs([{ name: 'fail', schedule: '* * * * *', handler: jest.fn() }]);
+
+    expect(logger.error).toHaveBeenCalledWith('[Scheduler] Failed to register job fail', { error: expect.any(Error) });
+  });
+});

--- a/backend/usecases/cron/DummyCronUseCase.ts
+++ b/backend/usecases/cron/DummyCronUseCase.ts
@@ -1,0 +1,20 @@
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+
+/**
+ * Example use case executed periodically by the scheduler.
+ */
+export class DummyCronUseCase {
+  /**
+   * Create a new instance.
+   *
+   * @param logger - Logger used to output execution information.
+   */
+  constructor(private readonly logger: LoggerPort) {}
+
+  /**
+   * Execute the use case logic.
+   */
+  async execute(): Promise<void> {
+    this.logger.info('DummyCronUseCase executed');
+  }
+}


### PR DESCRIPTION
## Summary
- add SchedulerPort interface
- implement NodeCronScheduler adapter with node-cron
- create DummyCronUseCase and scheduled jobs list
- initialize scheduler in server
- provide Jest tests for scheduler

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68887ba2ca1c8323bf136fc66944443e