### PR TITLE
Implement refresh token audit log

### DIFF
--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -485,9 +485,14 @@ export function createUserRouter(
           refreshTokenRepository,
           tokenService,
           userRepository,
+          audit,
         );
         try {
-          const result = await useCase.execute(refreshToken);
+          const result = await useCase.execute(
+            refreshToken,
+            req.ip,
+            req.headers['user-agent'],
+          );
           logger.debug('Tokens rotated', getContext());
           res.json(result);
         } catch (err) {

--- a/backend/tests/usecases/user/RotateRefreshTokenUseCase.test.ts
+++ b/backend/tests/usecases/user/RotateRefreshTokenUseCase.test.ts
@@ -1,0 +1,50 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { RotateRefreshTokenUseCase } from '../../../usecases/user/RotateRefreshTokenUseCase';
+import { RefreshTokenPort } from '../../../domain/ports/RefreshTokenPort';
+import { TokenServicePort } from '../../../domain/ports/TokenServicePort';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { AuditPort } from '../../../domain/ports/AuditPort';
+import { AuditEvent } from '../../../domain/entities/AuditEvent';
+import { RefreshToken } from '../../../domain/entities/RefreshToken';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+describe('RotateRefreshTokenUseCase', () => {
+  let refreshRepo: DeepMockProxy<RefreshTokenPort>;
+  let tokenService: DeepMockProxy<TokenServicePort>;
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let audit: DeepMockProxy<AuditPort>;
+  let useCase: RotateRefreshTokenUseCase;
+  let user: User;
+
+  beforeEach(() => {
+    refreshRepo = mockDeep<RefreshTokenPort>();
+    tokenService = mockDeep<TokenServicePort>();
+    userRepo = mockDeep<UserRepositoryPort>();
+    audit = mockDeep<AuditPort>();
+    const role = new Role('r', 'Role');
+    const site = new Site('s', 'Site');
+    const dept = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'John', 'Doe', 'j@example.com', [role], 'active', dept, site);
+    useCase = new RotateRefreshTokenUseCase(refreshRepo, tokenService, userRepo, audit);
+  });
+
+  it('should log refresh event', async () => {
+    const token = new RefreshToken('1', 'u', 'h', new Date(Date.now() + 1000));
+    refreshRepo.findValidByToken.mockResolvedValue(token);
+    userRepo.findById.mockResolvedValue(user);
+    tokenService.generateRefreshToken.mockResolvedValue('newR');
+    tokenService.generateAccessToken.mockReturnValue('newT');
+
+    await useCase.execute('old', '1.1.1.1', 'agent');
+
+    expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.actorId).toBe('u');
+    expect(event.action).toBe('auth.refresh');
+    expect(event.ipAddress).toBe('1.1.1.1');
+    expect(event.userAgent).toBe('agent');
+  });
+});

--- a/backend/usecases/user/RotateRefreshTokenUseCase.ts
+++ b/backend/usecases/user/RotateRefreshTokenUseCase.ts
@@ -2,6 +2,8 @@
 import { RefreshTokenPort } from '../../domain/ports/RefreshTokenPort';
 import { TokenServicePort } from '../../domain/ports/TokenServicePort';
 import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { AuditEvent } from '../../domain/entities/AuditEvent';
 import { InvalidRefreshTokenException } from '../../domain/errors/InvalidRefreshTokenException';
 
 /**
@@ -12,14 +14,21 @@ export class RotateRefreshTokenUseCase {
     private readonly refreshTokenPort: RefreshTokenPort,
     private readonly tokenService: TokenServicePort,
     private readonly userRepository: UserRepositoryPort,
+    private readonly auditPort: AuditPort,
   ) {}
 
   /**
    * Rotate a refresh token and return new tokens.
    *
    * @param oldToken - Token presented by the client.
+   * @param ipAddress - Optional IP address of the requester.
+   * @param userAgent - Optional user agent string.
    */
-  async execute(oldToken: string): Promise<{ token: string; refreshToken: string }> {
+  async execute(
+    oldToken: string,
+    ipAddress?: string,
+    userAgent?: string,
+  ): Promise<{ token: string; refreshToken: string }> {
     const existing = await this.refreshTokenPort.findValidByToken(oldToken);
     if (!existing) throw new InvalidRefreshTokenException();
 
@@ -28,6 +37,20 @@ export class RotateRefreshTokenUseCase {
 
     const newRefresh = await this.tokenService.generateRefreshToken(user);
     await this.refreshTokenPort.markAsUsed(existing.id, newRefresh);
+
+    await this.auditPort.log(
+      new AuditEvent(
+        new Date(),
+        user.id,
+        'user',
+        'auth.refresh',
+        'user',
+        user.id,
+        undefined,
+        ipAddress,
+        userAgent,
+      ),
+    );
 
     const newJwt = this.tokenService.generateAccessToken(user);
 


### PR DESCRIPTION
## Summary
- audit refresh token rotation
- wire audit port in user controller
- test RotateRefreshTokenUseCase audit logging

## Testing
- `npm run lint`
- `npm test` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_6888c9ea207883238c30c85b28ddca9b