### PR TITLE
Implement revoke all refresh tokens on logout

### DIFF
--- a/backend/adapters/repositories/PrismaRefreshTokenRepository.ts
+++ b/backend/adapters/repositories/PrismaRefreshTokenRepository.ts
@@ -69,4 +69,12 @@ export class PrismaRefreshTokenRepository implements RefreshTokenPort {
       data: { revokedAt: new Date() },
     });
   }
+
+  async revokeAll(userId: string): Promise<void> {
+    this.logger.debug('RefreshToken revokeAll', getContext());
+    await this.prisma.refreshToken.updateMany({
+      where: { userId },
+      data: { revokedAt: new Date() },
+    });
+  }
 }

--- a/backend/domain/ports/RefreshTokenPort.ts
+++ b/backend/domain/ports/RefreshTokenPort.ts
@@ -34,4 +34,11 @@ export interface RefreshTokenPort {
    * @param reason - Optional reason for revocation.
    */
   revoke(tokenId: string, reason?: string): Promise<void>;
+
+  /**
+   * Revoke all refresh tokens owned by a user.
+   *
+   * @param userId - Identifier of the token owner.
+   */
+  revokeAll(userId: string): Promise<void>;
 }

--- a/backend/tests/adapters/auth/JWTAuthServiceAdapter.test.ts
+++ b/backend/tests/adapters/auth/JWTAuthServiceAdapter.test.ts
@@ -114,6 +114,10 @@ describe('JWTAuthServiceAdapter', () => {
     await expect(adapter.resetPassword('t', 'p')).rejects.toThrow('Not implemented');
   });
 
+  it('should throw on invalid token', async () => {
+    await expect(adapter.verifyToken('invalid')).rejects.toThrow();
+  });
+
   it('should fail when user cannot be fetched after password check', async () => {
     const hash = await argon2.hash('p');
     prisma.user.findUnique.mockResolvedValue({ id: 'u', password: hash } as any);

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -425,6 +425,30 @@ describe('User REST controller', () => {
     expect(refreshRepo.markAsUsed).toHaveBeenCalled();
   });
 
+  it('should logout and revoke all refresh tokens', async () => {
+    refreshRepo.findValidByToken.mockResolvedValue(
+      new RefreshToken('1', 'u', 'oldh', new Date(Date.now() + 1000)),
+    );
+
+    const res = await request(app)
+      .post('/api/auth/logout')
+      .send({ refreshToken: 'old' });
+
+    expect(res.status).toBe(200);
+    expect(refreshRepo.findValidByToken).toHaveBeenCalledWith('old');
+    expect(refreshRepo.revokeAll).toHaveBeenCalledWith('u');
+  });
+
+  it('should return 401 for invalid logout token', async () => {
+    refreshRepo.findValidByToken.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/auth/logout')
+      .send({ refreshToken: 'bad' });
+
+    expect(res.status).toBe(401);
+  });
+
   it('should return 401 for invalid refresh token', async () => {
     refreshRepo.findValidByToken.mockResolvedValue(null);
 

--- a/backend/usecases/user/RevokeRefreshTokensUseCase.ts
+++ b/backend/usecases/user/RevokeRefreshTokensUseCase.ts
@@ -9,13 +9,14 @@ export class RevokeRefreshTokensUseCase {
   constructor(private readonly refreshTokenPort: RefreshTokenPort) {}
 
   /**
-   * Revoke the provided token.
+   * Revoke all tokens owned by the user that issued the provided refresh token.
+   *
    * @param token - Plain refresh token.
    */
   async execute(token: string): Promise<void> {
     const existing = await this.refreshTokenPort.findValidByToken(token);
     if (!existing) throw new InvalidRefreshTokenException();
 
-    await this.refreshTokenPort.revoke(existing.id, 'User logout or security event');
+    await this.refreshTokenPort.revokeAll(existing.userId);
   }
 }


### PR DESCRIPTION
## Summary
- expand `RefreshTokenPort` with `revokeAll`
- implement token revocation in `PrismaRefreshTokenRepository`
- update `RevokeRefreshTokensUseCase` to revoke all tokens for a user
- extend logout controller tests
- cover refresh token port and auth adapter with new tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888cbd828bc8323a6c20a421a72bd65