### PR TITLE
Revoke tokens on password reset or removal

### DIFF
--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -404,7 +404,9 @@ describe('User REST controller', () => {
 
     expect(res.status).toBe(204);
     expect(passwordValidator.validate).toHaveBeenCalledWith('new');
+    expect(auth.verifyToken).toHaveBeenCalledWith('tok');
     expect(auth.resetPassword).toHaveBeenCalledWith('tok', 'new');
+    expect(refreshRepo.revokeAll).toHaveBeenCalledWith('u');
   });
 
   it('should refresh tokens', async () => {

--- a/backend/tests/usecases/user/RemoveUserUseCase.test.ts
+++ b/backend/tests/usecases/user/RemoveUserUseCase.test.ts
@@ -2,6 +2,7 @@ import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { RemoveUserUseCase } from '../../../usecases/user/RemoveUserUseCase';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { RefreshTokenPort } from '../../../domain/ports/RefreshTokenPort';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
@@ -11,11 +12,13 @@ import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 
 describe('RemoveUserUseCase', () => {
   let repository: DeepMockProxy<UserRepositoryPort>;
+  let refreshRepo: DeepMockProxy<RefreshTokenPort>;
   let useCase: RemoveUserUseCase;
   let checker: PermissionChecker;
 
   beforeEach(() => {
     repository = mockDeep<UserRepositoryPort>();
+    refreshRepo = mockDeep<RefreshTokenPort>();
     checker = new PermissionChecker(
       new User(
         'actor',
@@ -28,20 +31,22 @@ describe('RemoveUserUseCase', () => {
         new Site('s', 'Site'),
       ),
     );
-    useCase = new RemoveUserUseCase(repository, checker);
+    useCase = new RemoveUserUseCase(repository, checker, refreshRepo);
   });
 
   it('should delete user via repository', async () => {
     await useCase.execute('user-1');
 
     expect(repository.delete).toHaveBeenCalledWith('user-1');
+    expect(refreshRepo.revokeAll).toHaveBeenCalledWith('user-1');
   });
 
   it('should throw when permission denied', async () => {
     const denied = mockDeep<PermissionChecker>();
     denied.check.mockImplementation(() => { throw new Error('Forbidden'); });
-    useCase = new RemoveUserUseCase(repository, denied);
+    useCase = new RemoveUserUseCase(repository, denied, refreshRepo);
     await expect(useCase.execute('user-1')).rejects.toThrow('Forbidden');
     expect(repository.delete).not.toHaveBeenCalled();
+    expect(refreshRepo.revokeAll).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/usecases/user/ResetPasswordUseCase.test.ts
+++ b/backend/tests/usecases/user/ResetPasswordUseCase.test.ts
@@ -3,39 +3,45 @@ import { ResetPasswordUseCase } from '../../../usecases/user/ResetPasswordUseCas
 import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
 import { PasswordValidator } from '../../../domain/services/PasswordValidator';
 import { InvalidPasswordException } from '../../../domain/errors/InvalidPasswordException';
+import { RefreshTokenPort } from '../../../domain/ports/RefreshTokenPort';
 
 describe('ResetPasswordUseCase', () => {
   let service: DeepMockProxy<AuthServicePort>;
   let validator: DeepMockProxy<PasswordValidator>;
+  let refreshRepo: DeepMockProxy<RefreshTokenPort>;
   let useCase: ResetPasswordUseCase;
 
   beforeEach(() => {
     service = mockDeep<AuthServicePort>();
     validator = mockDeep<PasswordValidator>();
-    useCase = new ResetPasswordUseCase(service, validator);
+    refreshRepo = mockDeep<RefreshTokenPort>();
+    useCase = new ResetPasswordUseCase(service, validator, refreshRepo);
   });
 
   it('should reset password via service', async () => {
     validator.validate.mockResolvedValue();
-    await useCase.execute('token', 'newPass1!');
+    await useCase.execute('u1', 'token', 'newPass1!');
 
     expect(validator.validate).toHaveBeenCalledWith('newPass1!');
     expect(service.resetPassword).toHaveBeenCalledWith('token', 'newPass1!');
+    expect(refreshRepo.revokeAll).toHaveBeenCalledWith('u1');
   });
 
   it('should throw when password invalid', async () => {
     validator.validate.mockRejectedValue(new InvalidPasswordException('bad'));
 
-    await expect(useCase.execute('tok', 'bad')).rejects.toBeInstanceOf(
+    await expect(useCase.execute('u1', 'tok', 'bad')).rejects.toBeInstanceOf(
       InvalidPasswordException,
     );
+    expect(refreshRepo.revokeAll).not.toHaveBeenCalled();
   });
 
   it('should wrap unexpected errors as InvalidPasswordException', async () => {
     validator.validate.mockRejectedValue(new Error('oops'));
 
-    await expect(useCase.execute('tok', 'bad'))
+    await expect(useCase.execute('u1', 'tok', 'bad'))
       .rejects.toEqual(new InvalidPasswordException('oops'));
     expect(service.resetPassword).not.toHaveBeenCalled();
+    expect(refreshRepo.revokeAll).not.toHaveBeenCalled();
   });
 });

--- a/backend/usecases/user/RemoveUserUseCase.ts
+++ b/backend/usecases/user/RemoveUserUseCase.ts
@@ -1,6 +1,7 @@
 import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
 import { PermissionChecker } from '../../domain/services/PermissionChecker';
 import { PermissionKeys } from '../../domain/entities/PermissionKeys';
+import { RefreshTokenPort } from '../../domain/ports/RefreshTokenPort';
 
 /**
  * Use case for removing a user and all associated data from the system.
@@ -9,15 +10,18 @@ export class RemoveUserUseCase {
   constructor(
     private readonly userRepository: UserRepositoryPort,
     private readonly checker: PermissionChecker,
+    private readonly refreshTokenRepository: RefreshTokenPort,
   ) {}
 
   /**
    * Execute the removal.
    *
    * @param userId - Identifier of the user to delete.
+   * Also revokes all refresh tokens owned by the user.
    */
   async execute(userId: string): Promise<void> {
     this.checker.check(PermissionKeys.DELETE_USER);
     await this.userRepository.delete(userId);
+    await this.refreshTokenRepository.revokeAll(userId);
   }
 }


### PR DESCRIPTION
## Summary
- revoke refresh tokens when a user resets their password
- revoke refresh tokens when a user is removed
- update REST controller to decode user and pass to the use cases
- extend unit tests for these scenarios

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888ddf62410832385391484b1004b1d