### PR TITLE
Add IP and User-Agent metadata to refresh tokens

### DIFF
--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -344,7 +344,12 @@ export function createUserRouter(
         tokenService,
         passwordValidator,
       );
-      const result = await useCase.execute(parseUser(req.body), req.body.password);
+      const result = await useCase.execute(
+        parseUser(req.body),
+        req.body.password,
+        req.ip,
+        req.get('user-agent') || undefined,
+      );
       logger.debug('User registered', getContext());
       res.status(201).json(result);
     });
@@ -414,7 +419,12 @@ export function createUserRouter(
           getConfigUseCase,
         );
         try {
-          const result = await useCase.execute(email, password);
+          const result = await useCase.execute(
+            email,
+            password,
+            req.ip,
+            req.get('user-agent') || undefined,
+          );
           logger.debug('User authenticated', getContext());
           res.json(result);
         } catch (err) {

--- a/backend/adapters/orm/prisma/migrations/20250729150340_add_refresh_ip/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250729150340_add_refresh_ip/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "RefreshToken" ADD COLUMN "ipAddress" TEXT;
+ALTER TABLE "RefreshToken" ADD COLUMN "userAgent" TEXT;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -212,6 +212,8 @@ model RefreshToken {
   revokedAt  DateTime?
   replacedBy String?
   usedAt     DateTime?
+  ipAddress  String?
+  userAgent  String?
 
   user User @relation(fields: [userId], references: [id])
 }

--- a/backend/adapters/repositories/PrismaRefreshTokenRepository.ts
+++ b/backend/adapters/repositories/PrismaRefreshTokenRepository.ts
@@ -21,6 +21,8 @@ export class PrismaRefreshTokenRepository implements RefreshTokenPort {
         tokenHash: token.tokenHash,
         expiresAt: token.expiresAt,
         createdAt: token.createdAt,
+        ipAddress: token.ipAddress,
+        userAgent: token.userAgent,
       },
     });
   }
@@ -45,6 +47,8 @@ export class PrismaRefreshTokenRepository implements RefreshTokenPort {
           record.revokedAt,
           record.replacedBy,
           record.usedAt,
+          record.ipAddress ?? undefined,
+          record.userAgent ?? undefined,
         );
       }
     }

--- a/backend/adapters/token/JWTTokenServiceAdapter.ts
+++ b/backend/adapters/token/JWTTokenServiceAdapter.ts
@@ -39,13 +39,30 @@ export class JWTTokenServiceAdapter implements TokenServicePort {
     );
   }
 
-  async generateRefreshToken(user: User): Promise<string> {
+  async generateRefreshToken(
+    user: User,
+    ipAddress?: string,
+    userAgent?: string,
+  ): Promise<string> {
     this.logger.debug('Generating refresh token', getContext());
     const token = randomUUID();
     const hash = await argon2.hash(token);
-    const expires = new Date(Date.now() + this.parseDuration(this.refreshDuration));
+    const expires = new Date(
+      Date.now() + this.parseDuration(this.refreshDuration),
+    );
     await this.refreshRepo.save(
-      new RefreshToken(randomUUID(), user.id, hash, expires),
+      new RefreshToken(
+        randomUUID(),
+        user.id,
+        hash,
+        expires,
+        new Date(),
+        null,
+        null,
+        null,
+        ipAddress,
+        userAgent,
+      ),
     );
     return token;
   }

--- a/backend/domain/entities/RefreshToken.ts
+++ b/backend/domain/entities/RefreshToken.ts
@@ -24,5 +24,9 @@ export class RefreshToken {
     public revokedAt: Date | null = null,
     public replacedBy: string | null = null,
     public usedAt: Date | null = null,
+    /** Optional IP address where the token was issued. */
+    public ipAddress?: string,
+    /** Optional user agent string associated with the request. */
+    public userAgent?: string,
   ) {}
 }

--- a/backend/domain/ports/TokenServicePort.ts
+++ b/backend/domain/ports/TokenServicePort.ts
@@ -18,5 +18,9 @@ export interface TokenServicePort {
    * @param user - User owning the token.
    * @returns The created refresh token string.
    */
-  generateRefreshToken(user: User): Promise<string>;
+  generateRefreshToken(
+    user: User,
+    ipAddress?: string,
+    userAgent?: string,
+  ): Promise<string>;
 }

--- a/backend/tests/adapters/token/JWTTokenServiceAdapter.test.ts
+++ b/backend/tests/adapters/token/JWTTokenServiceAdapter.test.ts
@@ -33,17 +33,19 @@ describe('JWTTokenServiceAdapter', () => {
   });
 
   it('should generate refresh token and store it', async () => {
-    const token = await service.generateRefreshToken(user);
+    const token = await service.generateRefreshToken(user, '1.1.1.1', 'agent');
     expect(repo.save).toHaveBeenCalled();
     const saved = repo.save.mock.calls[0][0];
     expect(saved.userId).toBe('u');
+    expect(saved.ipAddress).toBe('1.1.1.1');
+    expect(saved.userAgent).toBe('agent');
   });
 
   it('should parse duration units', async () => {
     const units = ['1s', '1m', '1h', '1d', '1w', '10', '1y'];
     for (const u of units) {
       const svc = new JWTTokenServiceAdapter(secret, repo, logger, '15m', u);
-      await svc.generateRefreshToken(user);
+      await svc.generateRefreshToken(user, undefined, undefined);
     }
     expect(repo.save).toHaveBeenCalledTimes(units.length);
   });

--- a/backend/tests/usecases/user/RefreshAccessTokenUseCase.test.ts
+++ b/backend/tests/usecases/user/RefreshAccessTokenUseCase.test.ts
@@ -37,7 +37,7 @@ describe('RefreshAccessTokenUseCase', () => {
     tokenService.generateAccessToken.mockReturnValue('newT');
     tokenService.generateRefreshToken.mockResolvedValue('newR');
 
-    const result = await useCase.execute('old');
+    const result = await useCase.execute('old', 'ip', 'agent');
 
     expect(result).toEqual({ token: 'newT', refreshToken: 'newR' });
     expect(refreshRepo.markAsUsed).toHaveBeenCalled();
@@ -45,13 +45,13 @@ describe('RefreshAccessTokenUseCase', () => {
 
   it('should throw when token missing', async () => {
     refreshRepo.findValidByToken.mockResolvedValue(null);
-    await expect(useCase.execute('bad')).rejects.toThrow('Invalid or expired refresh token');
+    await expect(useCase.execute('bad', 'ip', 'agent')).rejects.toThrow('Invalid or expired refresh token');
   });
 
   it('should throw when token expired', async () => {
     const token = new RefreshToken('1', 'u', 'h', new Date(Date.now() - 1000));
     refreshRepo.findValidByToken.mockResolvedValue(token);
-    await expect(useCase.execute('old')).rejects.toThrow('Invalid or expired refresh token');
+    await expect(useCase.execute('old', 'ip', 'agent')).rejects.toThrow('Invalid or expired refresh token');
   });
 
   it('should throw when user suspended', async () => {
@@ -59,14 +59,14 @@ describe('RefreshAccessTokenUseCase', () => {
     refreshRepo.findValidByToken.mockResolvedValue(token);
     const suspended = new User('u', 'John', 'Doe', 'john@example.com', [new Role('r', 'Role')], 'suspended', new Department('d', 'Dept', null, null, new Site('s', 'Site')), new Site('s', 'Site'));
     userRepo.findById.mockResolvedValue(suspended);
-    await expect(useCase.execute('old')).rejects.toThrow('User account is suspended or archived');
+    await expect(useCase.execute('old', 'ip', 'agent')).rejects.toThrow('User account is suspended or archived');
   });
 
   it('should throw when user not found', async () => {
     const token = new RefreshToken('1', 'u', 'h', new Date(Date.now() + 1000));
     refreshRepo.findValidByToken.mockResolvedValue(token);
     userRepo.findById.mockResolvedValue(null);
-    await expect(useCase.execute('t')).rejects.toThrow('Invalid or expired refresh token');
+    await expect(useCase.execute('t', 'ip', 'agent')).rejects.toThrow('Invalid or expired refresh token');
   });
 });
 

--- a/backend/tests/usecases/user/RotateRefreshTokenUseCase.test.ts
+++ b/backend/tests/usecases/user/RotateRefreshTokenUseCase.test.ts
@@ -40,6 +40,12 @@ describe('RotateRefreshTokenUseCase', () => {
 
     await useCase.execute('old', '1.1.1.1', 'agent');
 
+    expect(tokenService.generateRefreshToken).toHaveBeenCalledWith(
+      user,
+      '1.1.1.1',
+      'agent',
+    );
+
     expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
     const event = audit.log.mock.calls[0][0] as AuditEvent;
     expect(event.actorId).toBe('u');

--- a/backend/usecases/user/AuthenticateUserUseCase.ts
+++ b/backend/usecases/user/AuthenticateUserUseCase.ts
@@ -34,6 +34,8 @@ export class AuthenticateUserUseCase {
   async execute(
     email: string,
     password: string,
+    ipAddress?: string,
+    userAgent?: string,
   ): Promise<{
     user: User;
     token: string;
@@ -68,7 +70,11 @@ export class AuthenticateUserUseCase {
       const willExpire = daysSinceChange >= expirationDays - warningDays;
       await this.userRepository.update(user);
       const token = this.tokenService.generateAccessToken(user);
-      const refreshToken = await this.tokenService.generateRefreshToken(user);
+      const refreshToken = await this.tokenService.generateRefreshToken(
+        user,
+        ipAddress,
+        userAgent,
+      );
       return { user, token, refreshToken, passwordWillExpireSoon: willExpire };
     } catch (err) {
       const lockOnFail =

--- a/backend/usecases/user/RefreshAccessTokenUseCase.ts
+++ b/backend/usecases/user/RefreshAccessTokenUseCase.ts
@@ -21,7 +21,11 @@ export class RefreshAccessTokenUseCase {
    * @param refreshToken - Previous refresh token issued to the user.
    * @returns Newly generated access and refresh tokens.
    */
-  async execute(refreshToken: string): Promise<{ token: string; refreshToken: string; user?: User }> {
+  async execute(
+    refreshToken: string,
+    ipAddress?: string,
+    userAgent?: string,
+  ): Promise<{ token: string; refreshToken: string; user?: User }> {
     this.logger.debug('Refreshing access token');
     const stored = await this.refreshRepo.findValidByToken(refreshToken);
     if (!stored || stored.expiresAt.getTime() <= Date.now()) {
@@ -43,7 +47,11 @@ export class RefreshAccessTokenUseCase {
     user.lastActivity = new Date();
     await this.userRepository.update(user);
     const token = this.tokenService.generateAccessToken(user);
-    const newRefresh = await this.tokenService.generateRefreshToken(user);
+    const newRefresh = await this.tokenService.generateRefreshToken(
+      user,
+      ipAddress,
+      userAgent,
+    );
     this.logger.debug('Access token refreshed');
     return { token, refreshToken: newRefresh };
   }

--- a/backend/usecases/user/RegisterUserUseCase.ts
+++ b/backend/usecases/user/RegisterUserUseCase.ts
@@ -24,6 +24,8 @@ export class RegisterUserUseCase {
   async execute(
     user: User,
     password: string,
+    ipAddress?: string,
+    userAgent?: string,
   ): Promise<{ user: User; token: string; refreshToken: string }> {
     await this.passwordValidator.validate(password).catch((err) => {
       if (err instanceof InvalidPasswordException) {
@@ -37,7 +39,11 @@ export class RegisterUserUseCase {
     user.updatedBy = null;
     const created = await this.userRepository.create(user);
     const token = this.tokenService.generateAccessToken(created);
-    const refreshToken = await this.tokenService.generateRefreshToken(created);
+    const refreshToken = await this.tokenService.generateRefreshToken(
+      created,
+      ipAddress,
+      userAgent,
+    );
     return { user: created, token, refreshToken };
   }
 }

--- a/backend/usecases/user/RotateRefreshTokenUseCase.ts
+++ b/backend/usecases/user/RotateRefreshTokenUseCase.ts
@@ -35,7 +35,11 @@ export class RotateRefreshTokenUseCase {
     const user = await this.userRepository.findById(existing.userId);
     if (!user) throw new InvalidRefreshTokenException();
 
-    const newRefresh = await this.tokenService.generateRefreshToken(user);
+    const newRefresh = await this.tokenService.generateRefreshToken(
+      user,
+      ipAddress,
+      userAgent,
+    );
     await this.refreshTokenPort.markAsUsed(existing.id, newRefresh);
 
     await this.auditPort.log(


### PR DESCRIPTION
## Summary
- extend `RefreshToken` entity with `ipAddress` and `userAgent`
- persist new metadata via Prisma and repository
- accept IP and user-agent in token service and use cases
- update REST controllers to pass request metadata
- add prisma migration and adjust tests

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888e0f07d048323bb73d97ef8d3f209