### PR TITLE
Handle InvalidRefreshTokenException

### DIFF
--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -461,6 +461,10 @@ describe('User REST controller', () => {
       .send({ refreshToken: 'bad' });
 
     expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      error: 'Invalid or expired refresh token',
+      code: 'INVALID_REFRESH_TOKEN',
+    });
   });
 
   it('should return 401 for invalid refresh token', async () => {
@@ -471,6 +475,10 @@ describe('User REST controller', () => {
       .send({ refreshToken: 'bad' });
 
     expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      error: 'Invalid or expired refresh token',
+      code: 'INVALID_REFRESH_TOKEN',
+    });
   });
 
   it('should list users', async () => {


### PR DESCRIPTION
## Summary
- refine refresh and logout error handling
- test new error response schema

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888fa07af1883239e5ea0a85b993004