### PR TITLE
Add ErrorResponse schema for auth endpoints

### DIFF
--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -188,6 +188,19 @@ import {requireBodyParams} from './requestValidator';
  *         - email
  *         - department
  *         - site
+ *     ErrorResponse:
+ *       description: Error information when a request fails.
+ *       type: object
+ *       properties:
+ *         error:
+ *           type: string
+ *           description: Human readable error message.
+ *         code:
+ *           type: string
+ *           description: Machine readable error code.
+ *       required:
+ *         - error
+ *         - code
  */
 
 /**
@@ -486,6 +499,10 @@ export function createUserRouter(
      *         description: Validation error.
      *       401:
      *         description: Invalid or expired refresh token
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
      *       429:
      *         description: Refresh token rotation attempted too soon
      */
@@ -550,7 +567,11 @@ export function createUserRouter(
      *         description: Validation error.
      *       401:
      *         description: Invalid or expired refresh token
-     */
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+ */
     router.post(
       '/auth/logout',
       requireBodyParams({ refreshToken: { validator: 'string' } }),

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3413,7 +3413,63 @@
             "description": "Validation error."
           },
           "401": {
-            "description": "Invalid or expired refresh token"
+            "description": "Invalid or expired refresh token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Refresh token rotation attempted too soon"
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "summary": "Revoke refresh token.",
+        "description": "Invalidates the provided refresh token, logging the user out.\n",
+        "tags": [
+          "User"
+        ],
+        "requestBody": {
+          "description": "Refresh token to revoke.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "refreshToken": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "refreshToken"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Logged out successfully"
+          },
+          "400": {
+            "description": "Validation error."
+          },
+          "401": {
+            "description": "Invalid or expired refresh token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -4241,6 +4297,24 @@
           "email",
           "department",
           "site"
+        ]
+      },
+      "ErrorResponse": {
+        "description": "Error information when a request fails.",
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human readable error message."
+          },
+          "code": {
+            "type": "string",
+            "description": "Machine readable error code."
+          }
+        },
+        "required": [
+          "error",
+          "code"
         ]
       }
     }


### PR DESCRIPTION
## Summary
- document `ErrorResponse` schema in OpenAPI components
- update `/auth/refresh` and `/auth/logout` docs to use `ErrorResponse`
- regenerate `backend/openapi.json`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889020289048323a8dfc61150711bbe