### PR TITLE
Add MFA service and OTP store ports

### DIFF
--- a/backend/domain/ports/MfaServicePort.ts
+++ b/backend/domain/ports/MfaServicePort.ts
@@ -1,0 +1,47 @@
+import { User } from '../entities/User';
+
+/**
+ * Service handling multi-factor authentication operations.
+ */
+export interface MfaServicePort {
+  /**
+   * Generate and persist a new TOTP secret for the user.
+   *
+   * @param user - User enabling TOTP authentication.
+   * @returns The generated secret encoded in base32.
+   */
+  generateTotpSecret(user: User): Promise<string>;
+
+  /**
+   * Verify a time-based one time password for the user.
+   *
+   * @param user - User submitting the token.
+   * @param token - TOTP value to verify.
+   * @returns `true` when the token is valid.
+   */
+  verifyTotp(user: User, token: string): Promise<boolean>;
+
+  /**
+   * Generate and send a one time password via email.
+   *
+   * @param user - User requesting the code.
+   * @returns The generated code so it can be sent or logged.
+   */
+  generateEmailOtp(user: User): Promise<string>;
+
+  /**
+   * Verify an email delivered one time password.
+   *
+   * @param user - User providing the code.
+   * @param otp - One time password received by email.
+   * @returns `true` when the code matches.
+   */
+  verifyEmailOtp(user: User, otp: string): Promise<boolean>;
+
+  /**
+   * Disable multi-factor authentication for the user.
+   *
+   * @param user - User disabling MFA.
+   */
+  disableMfa(user: User): Promise<void>;
+}

--- a/backend/domain/ports/OtpStorePort.ts
+++ b/backend/domain/ports/OtpStorePort.ts
@@ -1,0 +1,32 @@
+import { User } from '../entities/User';
+
+/**
+ * Persistence mechanism for one time passwords used by MFA workflows.
+ */
+export interface OtpStorePort {
+  /**
+   * Store an OTP value for a user.
+   *
+   * @param user - Owner of the OTP.
+   * @param otp - Code to persist.
+   * @param ttlSeconds - Expiration delay in seconds.
+   */
+  store(user: User, otp: string, ttlSeconds: number): Promise<void>;
+
+  /**
+   * Verify an OTP previously stored for the user.
+   * The OTP should be removed when successfully validated.
+   *
+   * @param user - Owner of the OTP.
+   * @param otp - Code submitted for verification.
+   * @returns `true` when the code matches and is still valid.
+   */
+  verify(user: User, otp: string): Promise<boolean>;
+
+  /**
+   * Delete any OTP associated with the user without verification.
+   *
+   * @param user - Owner of the OTP to remove.
+   */
+  delete(user: User): Promise<void>;
+}

--- a/backend/tests/domain/ports/MfaServicePort.test.ts
+++ b/backend/tests/domain/ports/MfaServicePort.test.ts
@@ -1,0 +1,70 @@
+import { MfaServicePort } from '../../../domain/ports/MfaServicePort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+class MockMfaService implements MfaServicePort {
+  private totp = new Map<string, string>();
+  private email = new Map<string, string>();
+
+  async generateTotpSecret(user: User): Promise<string> {
+    const secret = `totp-${user.id}`;
+    this.totp.set(user.id, secret);
+    return secret;
+  }
+
+  async verifyTotp(user: User, token: string): Promise<boolean> {
+    return this.totp.get(user.id) === token;
+  }
+
+  async generateEmailOtp(user: User): Promise<string> {
+    const otp = `code-${user.id}`;
+    this.email.set(user.id, otp);
+    return otp;
+  }
+
+  async verifyEmailOtp(user: User, otp: string): Promise<boolean> {
+    const match = this.email.get(user.id) === otp;
+    if (match) {
+      this.email.delete(user.id);
+    }
+    return match;
+  }
+
+  async disableMfa(user: User): Promise<void> {
+    this.totp.delete(user.id);
+    this.email.delete(user.id);
+  }
+}
+
+describe('MfaServicePort Interface', () => {
+  let service: MockMfaService;
+  let user: User;
+
+  beforeEach(() => {
+    service = new MockMfaService();
+    const role = new Role('r', 'Role');
+    const site = new Site('s', 'Site');
+    const dept = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'A', 'B', 'a@example.com', [role], 'active', dept, site);
+  });
+
+  it('should generate and verify totp', async () => {
+    const secret = await service.generateTotpSecret(user);
+    expect(await service.verifyTotp(user, secret)).toBe(true);
+  });
+
+  it('should generate and verify email otp', async () => {
+    const code = await service.generateEmailOtp(user);
+    expect(await service.verifyEmailOtp(user, code)).toBe(true);
+  });
+
+  it('should disable mfa', async () => {
+    await service.generateTotpSecret(user);
+    await service.generateEmailOtp(user);
+    await service.disableMfa(user);
+    expect(await service.verifyTotp(user, 'x')).toBe(false);
+    expect(await service.verifyEmailOtp(user, 'x')).toBe(false);
+  });
+});

--- a/backend/tests/domain/ports/OtpStorePort.test.ts
+++ b/backend/tests/domain/ports/OtpStorePort.test.ts
@@ -1,0 +1,60 @@
+import { OtpStorePort } from '../../../domain/ports/OtpStorePort';
+import { User } from '../../../domain/entities/User';
+import { Role } from '../../../domain/entities/Role';
+import { Department } from '../../../domain/entities/Department';
+import { Site } from '../../../domain/entities/Site';
+
+class InMemoryOtpStore implements OtpStorePort {
+  private data = new Map<string, { otp: string; expires: number }>();
+
+  async store(user: User, otp: string, ttlSeconds: number): Promise<void> {
+    this.data.set(user.id, { otp, expires: Date.now() + ttlSeconds * 1000 });
+  }
+
+  async verify(user: User, otp: string): Promise<boolean> {
+    const entry = this.data.get(user.id);
+    if (!entry || entry.expires < Date.now() || entry.otp !== otp) {
+      return false;
+    }
+    this.data.delete(user.id);
+    return true;
+  }
+
+  async delete(user: User): Promise<void> {
+    this.data.delete(user.id);
+  }
+}
+
+describe('OtpStorePort Interface', () => {
+  let store: InMemoryOtpStore;
+  let user: User;
+
+  beforeEach(() => {
+    store = new InMemoryOtpStore();
+    const role = new Role('r', 'Role');
+    const site = new Site('s', 'Site');
+    const dept = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'A', 'B', 'a@example.com', [role], 'active', dept, site);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should store and verify otp', async () => {
+    await store.store(user, '111', 5);
+    expect(await store.verify(user, '111')).toBe(true);
+  });
+
+  it('should fail verification on wrong code', async () => {
+    await store.store(user, '111', 5);
+    expect(await store.verify(user, '222')).toBe(false);
+  });
+
+  it('should expire otp', async () => {
+    await store.store(user, '111', 1);
+    jest.advanceTimersByTime(1100);
+    expect(await store.verify(user, '111')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `MfaServicePort` interface for MFA operations
- add `OtpStorePort` interface for storing one-time passwords
- test new ports with simple in-memory implementations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688915047e608323b0b8c8650d2747dd