### PR TITLE
Implement MFA improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # sovrane
 La souveraineté de vos données, à portée de main
+
+## Authentification multi-facteurs
+
+Le backend prend en charge l'authentification par code TOTP ou par email. Les secrets TOTP sont chiffrés en AES‑256 à l'aide de la variable `MFA_ENCRYPTION_KEY`.
+Les OTP sont stockés dans le cache configuré (Redis ou mémoire) et expirent automatiquement.
+Le nombre de tentatives de vérification est limité.
+
+Consultez [backend/docs/MFA.md](backend/docs/MFA.md) pour plus de détails sur la configuration.

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -883,7 +883,7 @@ export function createUserRouter(
       requireBodyParams({ type: { validator: 'string' } }),
       async (req: Request, res: Response): Promise<void> => {
         logger.debug('POST /auth/mfa/enable', getContext());
-        const useCase = new EnableMfaUseCase(userRepository);
+        const useCase = new EnableMfaUseCase(userRepository, refreshTokenRepository);
         const updated = await useCase.execute(
           (req as AuthedRequest).user,
           req.body.type,
@@ -908,7 +908,7 @@ export function createUserRouter(
      */
     router.post('/auth/mfa/disable', async (req: Request, res: Response): Promise<void> => {
       logger.debug('POST /auth/mfa/disable', getContext());
-      const useCase = new DisableMfaUseCase(userRepository, mfaService);
+      const useCase = new DisableMfaUseCase(userRepository, mfaService, refreshTokenRepository);
       await useCase.execute((req as AuthedRequest).user);
       res.status(204).end();
     });

--- a/backend/docs/MFA.md
+++ b/backend/docs/MFA.md
@@ -1,0 +1,8 @@
+# Configuration MFA
+
+La fonctionnalité MFA repose sur un service TOTP par défaut.
+
+- `MFA_ENCRYPTION_KEY` : clé hexadécimale utilisée pour chiffrer le secret TOTP stocké sur l'utilisateur.
+- `REDIS_HOST` et variables associées : définissent le cache utilisé pour stocker temporairement les OTP ainsi que les compteurs d'essais.
+
+Lorsqu'un utilisateur active ou désactive le MFA, tous ses refresh tokens sont révoqués afin d'obliger une reconnexion.

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -74,6 +74,7 @@ async function bootstrap(): Promise<void> {
   const passwordValidator = new PasswordValidator(configService);
   const mfaService = new TOTPAdapter(
     userRepository,
+    cache,
     logger,
     process.env.MFA_ENCRYPTION_KEY ??
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'.slice(0, 64),

--- a/backend/tests/adapters/mfa/EmailOTPAdapter.test.ts
+++ b/backend/tests/adapters/mfa/EmailOTPAdapter.test.ts
@@ -19,7 +19,7 @@ describe('EmailOTPAdapter', () => {
     cache = new InMemoryCacheAdapter();
     mailer = mockDeep<NodemailerEmailServiceAdapter>();
     logger = mockDeep<LoggerPort>();
-    adapter = new EmailOTPAdapter(cache, mailer, logger, 5);
+    adapter = new EmailOTPAdapter(cache, mailer, logger, 5, 3);
     const role = new Role('r', 'Role');
     const site = new Site('s', 'Site');
     const dept = new Department('d', 'Dept', null, null, site);
@@ -44,6 +44,14 @@ describe('EmailOTPAdapter', () => {
     expect(await adapter.verifyEmailOtp(user, '111111')).toBe(false);
     jest.advanceTimersByTime(6000);
     expect(await adapter.verifyEmailOtp(user, code)).toBe(false);
+  });
+
+  it('should limit verification attempts', async () => {
+    await adapter.generateEmailOtp(user);
+    await adapter.verifyEmailOtp(user, '1');
+    await adapter.verifyEmailOtp(user, '2');
+    await adapter.verifyEmailOtp(user, '3');
+    expect(await adapter.verifyEmailOtp(user, '4')).toBe(false);
   });
 
   it('should clear code on disable', async () => {

--- a/backend/tests/usecases/user/DisableMfaUseCase.test.ts
+++ b/backend/tests/usecases/user/DisableMfaUseCase.test.ts
@@ -2,6 +2,7 @@ import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { DisableMfaUseCase } from '../../../usecases/user/DisableMfaUseCase';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { MfaServicePort } from '../../../domain/ports/MfaServicePort';
+import { RefreshTokenPort } from '../../../domain/ports/RefreshTokenPort';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
@@ -10,13 +11,15 @@ import { Site } from '../../../domain/entities/Site';
 describe('DisableMfaUseCase', () => {
   let repo: DeepMockProxy<UserRepositoryPort>;
   let mfa: DeepMockProxy<MfaServicePort>;
+  let refresh: DeepMockProxy<RefreshTokenPort>;
   let useCase: DisableMfaUseCase;
   let user: User;
 
   beforeEach(() => {
     repo = mockDeep<UserRepositoryPort>();
     mfa = mockDeep<MfaServicePort>();
-    useCase = new DisableMfaUseCase(repo, mfa);
+    refresh = mockDeep<RefreshTokenPort>();
+    useCase = new DisableMfaUseCase(repo, mfa, refresh);
     const role = new Role('r', 'Role');
     const site = new Site('s', 'Site');
     const dept = new Department('d', 'Dept', null, null, site);
@@ -36,5 +39,6 @@ describe('DisableMfaUseCase', () => {
     expect(user.mfaSecret).toBeNull();
     expect(user.mfaRecoveryCodes).toEqual([]);
     expect(repo.update).toHaveBeenCalledWith(user);
+    expect(refresh.revokeAll).toHaveBeenCalledWith(user.id);
   });
 });

--- a/backend/tests/usecases/user/EnableMfaUseCase.test.ts
+++ b/backend/tests/usecases/user/EnableMfaUseCase.test.ts
@@ -1,6 +1,7 @@
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { EnableMfaUseCase } from '../../../usecases/user/EnableMfaUseCase';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { RefreshTokenPort } from '../../../domain/ports/RefreshTokenPort';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
@@ -8,12 +9,14 @@ import { Site } from '../../../domain/entities/Site';
 
 describe('EnableMfaUseCase', () => {
   let repo: DeepMockProxy<UserRepositoryPort>;
+  let refresh: DeepMockProxy<RefreshTokenPort>;
   let useCase: EnableMfaUseCase;
   let user: User;
 
   beforeEach(() => {
     repo = mockDeep<UserRepositoryPort>();
-    useCase = new EnableMfaUseCase(repo);
+    refresh = mockDeep<RefreshTokenPort>();
+    useCase = new EnableMfaUseCase(repo, refresh);
     const role = new Role('r', 'Role');
     const site = new Site('s', 'Site');
     const dept = new Department('d', 'Dept', null, null, site);
@@ -27,5 +30,6 @@ describe('EnableMfaUseCase', () => {
     expect(user.mfaType).toBe('email');
     expect(user.mfaRecoveryCodes).toEqual(['1']);
     expect(repo.update).toHaveBeenCalledWith(user);
+    expect(refresh.revokeAll).toHaveBeenCalledWith(user.id);
   });
 });

--- a/backend/usecases/user/DisableMfaUseCase.ts
+++ b/backend/usecases/user/DisableMfaUseCase.ts
@@ -1,6 +1,7 @@
 import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
 import { MfaServicePort } from '../../domain/ports/MfaServicePort';
 import { User } from '../../domain/entities/User';
+import { RefreshTokenPort } from '../../domain/ports/RefreshTokenPort';
 
 /**
  * Use case disabling multi-factor authentication.
@@ -9,6 +10,8 @@ export class DisableMfaUseCase {
   constructor(
     private readonly userRepository: UserRepositoryPort,
     private readonly mfaService: MfaServicePort,
+    /** Repository used to revoke existing refresh tokens. */
+    private readonly refreshTokenRepository: RefreshTokenPort,
   ) {}
 
   /**
@@ -23,5 +26,6 @@ export class DisableMfaUseCase {
     user.mfaSecret = null;
     user.mfaRecoveryCodes = [];
     await this.userRepository.update(user);
+    await this.refreshTokenRepository.revokeAll(user.id);
   }
 }


### PR DESCRIPTION
## Summary
- add encryption and OTP validation limits
- revoke refresh tokens when toggling MFA
- document MFA configuration
- cover new cases with tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688927d5b65c8323a0ae27ea98bf36ce