### PR TITLE
Increase backend test coverage to 100%

### DIFF
--- a/backend/tests/usecases/user/EnableMfaUseCase.test.ts
+++ b/backend/tests/usecases/user/EnableMfaUseCase.test.ts
@@ -32,4 +32,12 @@ describe('EnableMfaUseCase', () => {
     expect(repo.update).toHaveBeenCalledWith(user);
     expect(refresh.revokeAll).toHaveBeenCalledWith(user.id);
   });
+
+  it('should use default recovery codes when none provided', async () => {
+    repo.update.mockResolvedValue(user);
+    await expect(useCase.execute(user, 'totp')).resolves.toBe(user);
+    expect(user.mfaRecoveryCodes).toEqual([]);
+    expect(repo.update).toHaveBeenCalledWith(user);
+    expect(refresh.revokeAll).toHaveBeenCalledWith(user.id);
+  });
 });

--- a/backend/tests/usecases/user/RotateRefreshTokenUseCase.test.ts
+++ b/backend/tests/usecases/user/RotateRefreshTokenUseCase.test.ts
@@ -11,6 +11,7 @@ import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
 import { RefreshTokenTooSoonException } from '../../../domain/errors/RefreshTokenTooSoonException';
+import { InvalidRefreshTokenException } from '../../../domain/errors/InvalidRefreshTokenException';
 
 describe('RotateRefreshTokenUseCase', () => {
   let refreshRepo: DeepMockProxy<RefreshTokenPort>;
@@ -68,6 +69,16 @@ describe('RotateRefreshTokenUseCase', () => {
 
     await expect(useCase.execute('old')).rejects.toBeInstanceOf(
       RefreshTokenTooSoonException,
+    );
+  });
+
+  it('should reject when user not found', async () => {
+    const token = new RefreshToken('1', 'u', 'h', new Date(Date.now() + 1000));
+    refreshRepo.findValidByToken.mockResolvedValue(token);
+    userRepo.findById.mockResolvedValue(null);
+
+    await expect(useCase.execute('old')).rejects.toBeInstanceOf(
+      InvalidRefreshTokenException,
     );
   });
 });


### PR DESCRIPTION
## Summary
- add missing test cases for `EnableMfaUseCase`
- add user-not-found path test for `RotateRefreshTokenUseCase`
- regenerate coverage

## Testing
- `npm run lint`
- `npm test`
- `npx jest --coverage --coverageReporters=json-summary`

------
https://chatgpt.com/codex/tasks/task_e_68893741d39c83238a7e09beff966376