### PR TITLE
Ensure permission check for group retrieval

### DIFF
--- a/backend/adapters/controllers/rest/groupController.ts
+++ b/backend/adapters/controllers/rest/groupController.ts
@@ -17,6 +17,7 @@ import {RemoveGroupResponsibleUseCase} from '../../../usecases/group/RemoveGroup
 import {GetGroupMembersUseCase} from '../../../usecases/group/GetGroupMembersUseCase';
 import {GetGroupResponsiblesUseCase} from '../../../usecases/group/GetGroupResponsiblesUseCase';
 import {PermissionChecker} from '../../../domain/services/PermissionChecker';
+import {PermissionKeys} from '../../../domain/entities/PermissionKeys';
 import { TokenExpiredException } from '../../../domain/errors/TokenExpiredException';
 
 /**
@@ -262,6 +263,13 @@ export function createGroupRouter(
      */
   router.get('/groups/:id', async (req, res): Promise<void> => {
     logger.debug('GET /groups/:id', getContext());
+    const checker = new PermissionChecker((req as unknown as AuthedRequest).user);
+    try {
+      checker.check(PermissionKeys.READ_GROUP);
+    } catch {
+      res.status(403).end();
+      return;
+    }
     const group = await groupRepository.findById(req.params.id);
     if (!group) {
       res.status(404).end();


### PR DESCRIPTION
## Summary
- include PermissionKeys in group controller
- verify READ_GROUP permission via PermissionChecker before returning group

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68894126ab28832399a1eae4502037a5