### PR TITLE
Add config permissions and route checks

### DIFF
--- a/backend/domain/entities/PermissionKeys.ts
+++ b/backend/domain/entities/PermissionKeys.ts
@@ -85,4 +85,10 @@ export class PermissionKeys {
 
   /** Allows updating user profile pictures. */
   static readonly UPDATE_USER_PICTURE = 'update-user-picture';
+
+  /** Allows reading application configuration values. */
+  static readonly READ_CONFIG = 'read-config';
+
+  /** Allows updating application configuration values. */
+  static readonly UPDATE_CONFIG = 'update-config';
 }

--- a/backend/tests/adapters/controllers/rest/configController.test.ts
+++ b/backend/tests/adapters/controllers/rest/configController.test.ts
@@ -1,0 +1,86 @@
+import request from 'supertest';
+import express from 'express';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { createConfigRouter } from '../../../../adapters/controllers/rest/configController';
+import { GetConfigUseCase } from '../../../../usecases/config/GetConfigUseCase';
+import { UpdateConfigUseCase } from '../../../../usecases/config/UpdateConfigUseCase';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { User } from '../../../../domain/entities/User';
+import { Role } from '../../../../domain/entities/Role';
+import { Permission } from '../../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
+import { Site } from '../../../../domain/entities/Site';
+import { Department } from '../../../../domain/entities/Department';
+
+describe('Config REST controller', () => {
+  let app: express.Express;
+  let getUseCase: DeepMockProxy<GetConfigUseCase>;
+  let updateUseCase: DeepMockProxy<UpdateConfigUseCase>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let site: Site;
+  let dept: Department;
+  let role: Role;
+  let user: User;
+
+  beforeEach(() => {
+    getUseCase = mockDeep<GetConfigUseCase>();
+    updateUseCase = mockDeep<UpdateConfigUseCase>();
+    logger = mockDeep<LoggerPort>();
+    site = new Site('s', 'Site');
+    dept = new Department('d', 'Dept', null, null, site);
+    role = new Role('r', 'Role', [new Permission('p', PermissionKeys.READ_CONFIG, '')]);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
+
+    app = express();
+    app.use(express.json());
+    app.use('/api', (req, _res, next) => { (req as any).user = user; next(); });
+    app.use('/api', createConfigRouter(getUseCase, updateUseCase, logger));
+  });
+
+  it('should return configuration value', async () => {
+    getUseCase.execute.mockResolvedValue('v');
+
+    const res = await request(app).get('/api/config/key');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ key: 'key', value: 'v' });
+  });
+
+  it('should return 404 when entry missing', async () => {
+    getUseCase.execute.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/config/missing');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('should forbid when read permission missing', async () => {
+    role.permissions = [];
+
+    const res = await request(app).get('/api/config/key');
+
+    expect(res.status).toBe(403);
+  });
+
+  it('should update configuration value', async () => {
+    role.permissions.push(new Permission('p2', PermissionKeys.UPDATE_CONFIG, ''));
+    updateUseCase.execute.mockResolvedValue();
+
+    const res = await request(app)
+      .put('/api/config/key')
+      .send({ value: 'v', updatedBy: 'u' });
+
+    expect(res.status).toBe(204);
+    expect(updateUseCase.execute).toHaveBeenCalledWith('key', 'v', 'u');
+  });
+
+  it('should forbid update when permission missing', async () => {
+    role.permissions = [];
+
+    const res = await request(app)
+      .put('/api/config/key')
+      .send({ value: 'v', updatedBy: 'u' });
+
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add `READ_CONFIG` and `UPDATE_CONFIG` permission keys
- enforce permissions in config routes
- test new configuration router behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889426780a88323a738be6acf535bba