### PR TITLE
Add role permission checks

### DIFF
--- a/backend/domain/entities/PermissionKeys.ts
+++ b/backend/domain/entities/PermissionKeys.ts
@@ -74,6 +74,21 @@ export class PermissionKeys {
   /** Allows managing group responsibles. */
   static readonly MANAGE_GROUP_RESPONSIBLES = 'manage-group-responsibles';
 
+  /** Allows listing roles. */
+  static readonly READ_ROLES = 'read-roles';
+
+  /** Allows reading role details. */
+  static readonly READ_ROLE = 'read-role';
+
+  /** Allows creating a role. */
+  static readonly CREATE_ROLE = 'create-role';
+
+  /** Allows updating role information. */
+  static readonly UPDATE_ROLE = 'update-role';
+
+  /** Allows deleting a role. */
+  static readonly DELETE_ROLE = 'delete-role';
+
   /** Allows creating user invitations. */
   static readonly CREATE_INVITATION = 'create-invitation';
 

--- a/backend/tests/adapters/controllers/rest/roleController.test.ts
+++ b/backend/tests/adapters/controllers/rest/roleController.test.ts
@@ -7,6 +7,10 @@ import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort'
 import { LoggerPort } from '../../../../domain/ports/LoggerPort';
 import { Role } from '../../../../domain/entities/Role';
 import { Permission } from '../../../../domain/entities/Permission';
+import { Department } from '../../../../domain/entities/Department';
+import { Site } from '../../../../domain/entities/Site';
+import { User } from '../../../../domain/entities/User';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
 
 describe('Role REST controller', () => {
   let app: express.Express;
@@ -15,6 +19,9 @@ describe('Role REST controller', () => {
   let logger: ReturnType<typeof mockDeep<LoggerPort>>;
   let role: Role;
   let permission: Permission;
+  let user: User;
+  let site: Site;
+  let dept: Department;
 
   beforeEach(() => {
     roleRepo = mockDeep<RoleRepositoryPort>();
@@ -27,8 +34,18 @@ describe('Role REST controller', () => {
     userRepo.findByRoleId.mockResolvedValue([]);
     roleRepo.delete.mockResolvedValue();
 
+    site = new Site('s', 'Site');
+    dept = new Department('d', 'Dept', null, null, site);
+    const rootPerm = new Permission('root', PermissionKeys.ROOT, 'root');
+    const adminRole = new Role('admin', 'Admin', [rootPerm]);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [adminRole], 'active', dept, site);
+
     app = express();
     app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).user = user;
+      next();
+    });
     app.use('/api', createRoleRouter(roleRepo, userRepo, logger));
   });
 


### PR DESCRIPTION
## Summary
- extend permission list with role permissions
- enforce permissions in role REST controller
- update role controller tests with authenticated user

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688946bad1d48323ad0e3138031ac5fa