### PR TITLE
Add site permissions checks

### DIFF
--- a/backend/domain/entities/PermissionKeys.ts
+++ b/backend/domain/entities/PermissionKeys.ts
@@ -118,4 +118,13 @@ export class PermissionKeys {
 
   /** Allows updating application configuration values. */
   static readonly UPDATE_CONFIG = 'update-config';
+
+  /** Allows listing available sites. */
+  static readonly READ_SITES = 'read-sites';
+
+  /** Allows reading a single site. */
+  static readonly READ_SITE = 'read-site';
+
+  /** Allows creating, updating or deleting sites. */
+  static readonly MANAGE_SITES = 'manage-sites';
 }


### PR DESCRIPTION
## Summary
- add site related permission keys
- enforce permissions in site controller
- update site controller tests with auth context

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688949b0f9e483239fba46c47453f5e7