### PR TITLE
Add read permission constant and controller update

### DIFF
--- a/backend/adapters/controllers/rest/permissionController.ts
+++ b/backend/adapters/controllers/rest/permissionController.ts
@@ -180,10 +180,10 @@ export function createPermissionRouter(
     logger.debug('GET /permissions/:id', getContext());
     const checker = new PermissionChecker((req as AuthedRequest).user);
     try {
-      checker.check(PermissionKeys.READ_PERMISSIONS);
+      checker.check(PermissionKeys.READ_PERMISSION);
     } catch (err) {
-      logger.warn('Permission denied reading permission', {...getContext(), error: err});
-      res.status(403).json({error: 'Forbidden'});
+      logger.warn('Permission denied reading permission', { ...getContext(), error: err });
+      res.status(403).json({ error: 'Forbidden' });
       return;
     }
     const useCase = new GetPermissionUseCase(repository);

--- a/backend/domain/entities/PermissionKeys.ts
+++ b/backend/domain/entities/PermissionKeys.ts
@@ -95,6 +95,9 @@ export class PermissionKeys {
   /** Allows listing existing permissions. */
   static readonly READ_PERMISSIONS = 'read-permissions';
 
+  /** Allows reading a single permission. */
+  static readonly READ_PERMISSION = 'read-permission';
+
   /** Allows registering a new permission. */
   static readonly CREATE_PERMISSION = 'create-permission';
 


### PR DESCRIPTION
## Summary
- add `READ_PERMISSION` in permission keys
- check `READ_PERMISSION` when retrieving one permission

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894cf4ba34832386a50ba24fe04d97