### PR TITLE
Add config delete use case and audit logging

### DIFF
--- a/backend/tests/usecases/config/DeleteConfigUseCase.test.ts
+++ b/backend/tests/usecases/config/DeleteConfigUseCase.test.ts
@@ -1,0 +1,50 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { DeleteConfigUseCase } from '../../../usecases/config/DeleteConfigUseCase';
+import { ConfigService } from '../../../domain/services/ConfigService';
+import { ConfigPort } from '../../../domain/ports/ConfigPort';
+import { InMemoryCacheAdapter } from '../../../adapters/cache/InMemoryCacheAdapter';
+import { AppConfig } from '../../../domain/entities/AppConfig';
+import { AuditPort } from '../../../domain/ports/AuditPort';
+import { AuditEvent } from '../../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../../domain/entities/AuditEventType';
+
+describe('DeleteConfigUseCase', () => {
+  let repo: DeepMockProxy<ConfigPort>;
+  let cache: InMemoryCacheAdapter;
+  let service: ConfigService;
+  let audit: DeepMockProxy<AuditPort>;
+  let useCase: DeleteConfigUseCase;
+
+  beforeEach(() => {
+    repo = mockDeep<ConfigPort>();
+    cache = new InMemoryCacheAdapter();
+    service = new ConfigService(cache, repo);
+    audit = mockDeep<AuditPort>();
+    useCase = new DeleteConfigUseCase(service, audit);
+  });
+
+  it('should delete existing config and log event', async () => {
+    const record = new AppConfig(1, 'foo', 'bar', 'string', new Date(), 'u');
+    repo.findByKey.mockResolvedValue(record);
+    repo.delete.mockResolvedValue(record);
+    await cache.set('foo', 'bar');
+
+    await useCase.execute('foo', 'u');
+
+    expect(repo.delete).toHaveBeenCalledWith('foo');
+    expect(await cache.get('foo')).toBeNull();
+    expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.action).toBe(AuditEventType.CONFIG_DELETED);
+    expect(event.details).toEqual({ key: 'foo', oldValue: 'bar', newValue: null });
+  });
+
+  it('should not log when key missing', async () => {
+    repo.findByKey.mockResolvedValue(null);
+
+    await useCase.execute('missing', 'u');
+
+    expect(repo.delete).not.toHaveBeenCalled();
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/config/UpdateConfigUseCase.test.ts
+++ b/backend/tests/usecases/config/UpdateConfigUseCase.test.ts
@@ -4,29 +4,53 @@ import { ConfigService } from '../../../domain/services/ConfigService';
 import { ConfigPort } from '../../../domain/ports/ConfigPort';
 import { InMemoryCacheAdapter } from '../../../adapters/cache/InMemoryCacheAdapter';
 import { AppConfig } from '../../../domain/entities/AppConfig';
+import { AuditPort } from '../../../domain/ports/AuditPort';
+import { AuditEvent } from '../../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../../domain/entities/AuditEventType';
 
 describe('UpdateConfigUseCase', () => {
   let repo: DeepMockProxy<ConfigPort>;
   let cache: InMemoryCacheAdapter;
   let service: ConfigService;
+  let audit: DeepMockProxy<AuditPort>;
   let useCase: UpdateConfigUseCase;
 
   beforeEach(() => {
     repo = mockDeep<ConfigPort>();
     cache = new InMemoryCacheAdapter();
     service = new ConfigService(cache, repo);
-    useCase = new UpdateConfigUseCase(service);
+    audit = mockDeep<AuditPort>();
+    useCase = new UpdateConfigUseCase(service, audit);
   });
 
   it('should update repository and cache', async () => {
     const stored = new AppConfig(1, 'maxAttempts', '5', 'number', new Date(), 'u');
     repo.upsert.mockResolvedValue(stored);
+    repo.findByKey.mockResolvedValue(null);
 
     await useCase.execute('maxAttempts', 5, 'u');
 
     expect(repo.upsert).toHaveBeenCalledWith('maxAttempts', '5', 'number', 'u');
     const cached = await cache.get<number>('maxAttempts');
     expect(cached).toBe(5);
+    expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.action).toBe(AuditEventType.CONFIG_CREATED);
+    expect(event.details).toEqual({ key: 'maxAttempts', oldValue: null, newValue: 5 });
+  });
+
+  it('should log update when entry exists', async () => {
+    const stored = new AppConfig(1, 'maxAttempts', '5', 'number', new Date(), 'u');
+    repo.upsert.mockResolvedValue(stored);
+    repo.findByKey.mockResolvedValue(stored);
+    await cache.set('maxAttempts', 5); // ensure service.get returns cached value
+
+    await useCase.execute('maxAttempts', 6, 'u');
+
+    expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.action).toBe(AuditEventType.CONFIG_UPDATED);
+    expect(event.details).toEqual({ key: 'maxAttempts', oldValue: 5, newValue: 6 });
   });
 
   it('should validate password length', async () => {

--- a/backend/usecases/config/DeleteConfigUseCase.ts
+++ b/backend/usecases/config/DeleteConfigUseCase.ts
@@ -1,0 +1,35 @@
+import { ConfigService } from '../../domain/services/ConfigService';
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { AuditEvent } from '../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../domain/entities/AuditEventType';
+
+/**
+ * Use case for deleting a configuration entry.
+ */
+export class DeleteConfigUseCase {
+  constructor(
+    private readonly service: ConfigService,
+    private readonly audit: AuditPort,
+  ) {}
+
+  /**
+   * Delete a configuration entry and log the action.
+   *
+   * @param key - Key of the configuration item to remove.
+   * @param deletedBy - Identifier of the user performing the deletion.
+   */
+  async execute(key: string, deletedBy: string): Promise<void> {
+    const oldValue = await this.service.get<unknown>(key);
+    const record = await this.service.delete(key);
+    if (!record) {
+      return;
+    }
+    await this.audit.log(
+      new AuditEvent(new Date(), deletedBy, 'user', AuditEventType.CONFIG_DELETED, 'config', key, {
+        key,
+        oldValue,
+        newValue: null,
+      }),
+    );
+  }
+}

--- a/backend/usecases/config/UpdateConfigUseCase.ts
+++ b/backend/usecases/config/UpdateConfigUseCase.ts
@@ -1,10 +1,16 @@
 import { ConfigService } from '../../domain/services/ConfigService';
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { AuditEvent } from '../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../domain/entities/AuditEventType';
 
 /**
  * Update a configuration value after validating it.
  */
 export class UpdateConfigUseCase {
-  constructor(private readonly service: ConfigService) {}
+  constructor(
+    private readonly service: ConfigService,
+    private readonly audit: AuditPort,
+  ) {}
 
   /**
    * Validate and persist a configuration value.
@@ -14,6 +20,8 @@ export class UpdateConfigUseCase {
    * @param updatedBy - User performing the change.
    */
   async execute(key: string, value: unknown, updatedBy: string): Promise<void> {
+    const oldValue = await this.service.get<unknown>(key);
+
     if (key === 'passwordMinLength') {
       if (typeof value !== 'number' || value < 8) {
         throw new Error('passwordMinLength must be >= 8');
@@ -24,6 +32,19 @@ export class UpdateConfigUseCase {
         throw new Error('maxAttempts must be between 1 and 10');
       }
     }
+
     await this.service.update(key, value, updatedBy);
+
+    const action =
+      oldValue === null
+        ? AuditEventType.CONFIG_CREATED
+        : AuditEventType.CONFIG_UPDATED;
+    await this.audit.log(
+      new AuditEvent(new Date(), updatedBy, 'user', action, 'config', key, {
+        key,
+        oldValue,
+        newValue: value,
+      }),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- log audit events when updating config
- support deleting config values with auditing
- test update & delete config use cases

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f2c906848323a916deb519e4dcc0