### PR TITLE
Add sensitive route audit middleware

### DIFF
--- a/backend/infrastructure/sensitiveRouteAuditMiddleware.ts
+++ b/backend/infrastructure/sensitiveRouteAuditMiddleware.ts
@@ -1,0 +1,79 @@
+import { RequestHandler } from 'express';
+import { AuditPort } from '../domain/ports/AuditPort';
+import { AuthServicePort } from '../domain/ports/AuthServicePort';
+import { LoggerPort } from '../domain/ports/LoggerPort';
+import { GetConfigUseCase } from '../usecases/config/GetConfigUseCase';
+import { AuditEvent } from '../domain/entities/AuditEvent';
+import { AuditEventType } from '../domain/entities/AuditEventType';
+import { getContext } from './loggerContext';
+
+const DEFAULT_PATTERNS = ['/api/admin/*', '/api/audit', '/api/config/*'];
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function compile(pattern: string): RegExp {
+  return new RegExp('^' + pattern.split('*').map(escapeRegex).join('.*') + '$');
+}
+
+/**
+ * Create an Express middleware that logs access to sensitive routes.
+ *
+ * The middleware loads path patterns from the `audit_sensitive_routes`
+ * configuration entry. When absent, a default list is used. Requests matching
+ * one of the patterns result in an audit event with type
+ * {@link AuditEventType.SENSITIVE_ROUTE_ACCESSED}.
+ *
+ * @param audit - Adapter used to persist audit events.
+ * @param auth - Service used to resolve the current user from a token.
+ * @param config - Use case to fetch configuration values.
+ * @param logger - Logger for debug information.
+ * @returns Configured Express request handler.
+ */
+export function createSensitiveRouteAuditMiddleware(
+  audit: AuditPort,
+  auth: AuthServicePort,
+  config: GetConfigUseCase,
+  logger: LoggerPort,
+): RequestHandler {
+  let regexps: RegExp[] | null = null;
+
+  return async (req, _res, next) => {
+    if (!regexps) {
+      const patterns =
+        (await config.execute<string[]>('audit_sensitive_routes')) ?? DEFAULT_PATTERNS;
+      regexps = patterns.map(compile);
+    }
+
+    const matched = regexps.some((r) => r.test(req.path));
+    if (matched) {
+      logger.debug('Sensitive route accessed', getContext());
+      let userId: string | null = null;
+      const header = req.headers.authorization;
+      if (header?.startsWith('Bearer ')) {
+        const token = header.slice(7);
+        try {
+          const user = await auth.verifyToken(token);
+          userId = user.id;
+        } catch (err) {
+          logger.warn('Failed to resolve user for audit', { ...getContext(), error: err });
+        }
+      }
+
+      await audit.log(
+        new AuditEvent(
+          new Date(),
+          userId,
+          userId ? 'user' : 'system',
+          AuditEventType.SENSITIVE_ROUTE_ACCESSED,
+          undefined,
+          undefined,
+          { method: req.method, path: req.path, ip: req.ip },
+        ),
+      );
+    }
+
+    next();
+  };
+}

--- a/backend/tests/infrastructure/sensitiveRouteAuditMiddleware.test.ts
+++ b/backend/tests/infrastructure/sensitiveRouteAuditMiddleware.test.ts
@@ -1,0 +1,80 @@
+import express from 'express';
+import request from 'supertest';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { createSensitiveRouteAuditMiddleware } from '../../infrastructure/sensitiveRouteAuditMiddleware';
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { AuthServicePort } from '../../domain/ports/AuthServicePort';
+import { GetConfigUseCase } from '../../usecases/config/GetConfigUseCase';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { AuditEvent } from '../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../domain/entities/AuditEventType';
+
+describe('sensitive route audit middleware', () => {
+  let audit: DeepMockProxy<AuditPort>;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let config: DeepMockProxy<GetConfigUseCase>;
+  let logger: DeepMockProxy<LoggerPort>;
+  let app: express.Express;
+
+  beforeEach(() => {
+    audit = mockDeep<AuditPort>();
+    auth = mockDeep<AuthServicePort>();
+    config = mockDeep<GetConfigUseCase>();
+    logger = mockDeep<LoggerPort>();
+
+    config.execute.mockResolvedValue(['/api/admin/*']);
+    auth.verifyToken.mockResolvedValue({ id: 'u' } as any);
+
+    app = express();
+    app.use(createSensitiveRouteAuditMiddleware(audit, auth, config, logger));
+    app.get('/api/admin/data', (_req, res) => res.json({ ok: true }));
+    app.get('/open', (_req, res) => res.json({ ok: true }));
+  });
+
+  it('should log when a sensitive route is accessed', async () => {
+    const res = await request(app)
+      .get('/api/admin/data')
+      .set('Authorization', 'Bearer t');
+
+    expect(res.status).toBe(200);
+    expect(audit.log).toHaveBeenCalledTimes(1);
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.action).toBe(AuditEventType.SENSITIVE_ROUTE_ACCESSED);
+    expect(event.actorId).toBe('u');
+    expect(event.details).toEqual({ method: 'GET', path: '/api/admin/data', ip: expect.any(String) });
+    expect(config.execute).toHaveBeenCalledTimes(1);
+
+    await request(app).get('/api/admin/data');
+    expect(config.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore non matching routes', async () => {
+    await request(app).get('/open');
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+
+  it('should handle invalid tokens', async () => {
+    auth.verifyToken.mockRejectedValue(new Error('bad'));
+    await request(app)
+      .get('/api/admin/data')
+      .set('Authorization', 'Bearer bad');
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.actorId).toBeNull();
+  });
+
+  it('should handle missing authorization header', async () => {
+    await request(app).get('/api/admin/data');
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.actorId).toBeNull();
+  });
+
+  it('should use default patterns when config missing', async () => {
+    const cfg = mockDeep<GetConfigUseCase>();
+    cfg.execute.mockResolvedValue(null);
+    const inst = express();
+    inst.use(createSensitiveRouteAuditMiddleware(audit, auth, cfg, logger));
+    inst.get('/api/audit', (_req, res) => res.json({ ok: true }));
+    await request(inst).get('/api/audit');
+    expect(audit.log).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add middleware to audit sensitive route access
- test sensitive route auditing logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889fb58d5f08323a25304ca37fa01ed