### PR TITLE
Add audit details tests

### DIFF
--- a/backend/tests/adapters/controllers/rest/configController.test.ts
+++ b/backend/tests/adapters/controllers/rest/configController.test.ts
@@ -108,4 +108,17 @@ describe('Config REST controller', () => {
 
     expect(res.status).toBe(403);
   });
+
+  it('should return 400 when delete use case fails', async () => {
+    role.permissions.push(new Permission('p3', PermissionKeys.DELETE_CONFIG, ''));
+    deleteUseCase.execute.mockRejectedValue(new Error('boom'));
+
+    const res = await request(app)
+      .delete('/api/config/key')
+      .send({ deletedBy: 'u' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ message: 'boom' });
+    expect(logger.warn).toHaveBeenCalled();
+  });
 });

--- a/backend/tests/usecases/config/DeleteConfigUseCase.test.ts
+++ b/backend/tests/usecases/config/DeleteConfigUseCase.test.ts
@@ -36,6 +36,10 @@ describe('DeleteConfigUseCase', () => {
     expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
     const event = audit.log.mock.calls[0][0] as AuditEvent;
     expect(event.action).toBe(AuditEventType.CONFIG_DELETED);
+    expect(event.actorId).toBe('u');
+    expect(event.actorType).toBe('user');
+    expect(event.targetType).toBe('config');
+    expect(event.targetId).toBe('foo');
     expect(event.details).toEqual({ key: 'foo', oldValue: 'bar', newValue: null });
   });
 

--- a/backend/tests/usecases/config/UpdateConfigUseCase.test.ts
+++ b/backend/tests/usecases/config/UpdateConfigUseCase.test.ts
@@ -36,6 +36,10 @@ describe('UpdateConfigUseCase', () => {
     expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
     const event = audit.log.mock.calls[0][0] as AuditEvent;
     expect(event.action).toBe(AuditEventType.CONFIG_CREATED);
+    expect(event.actorId).toBe('u');
+    expect(event.actorType).toBe('user');
+    expect(event.targetType).toBe('config');
+    expect(event.targetId).toBe('maxAttempts');
     expect(event.details).toEqual({ key: 'maxAttempts', oldValue: null, newValue: 5 });
   });
 
@@ -50,6 +54,10 @@ describe('UpdateConfigUseCase', () => {
     expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
     const event = audit.log.mock.calls[0][0] as AuditEvent;
     expect(event.action).toBe(AuditEventType.CONFIG_UPDATED);
+    expect(event.actorId).toBe('u');
+    expect(event.actorType).toBe('user');
+    expect(event.targetType).toBe('config');
+    expect(event.targetId).toBe('maxAttempts');
     expect(event.details).toEqual({ key: 'maxAttempts', oldValue: 5, newValue: 6 });
   });
 


### PR DESCRIPTION
## Summary
- verify audit event details in DeleteConfigUseCase
- verify audit event details in UpdateConfigUseCase
- test DELETE route error handling in config controller

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889ffaf75a0832397011d1746d5e5de