### PR TITLE
Add alert thresholds bootstrap config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,15 @@ LOCK_ACCOUNT_ON_LOGIN_FAIL=true
 # Account lock duration in seconds
 ACCOUNT_LOCK_DURATION=900
 
+# Number of lockouts before alerting administrators
+LOCKOUT_ALERT_THRESHOLD=5
+
+# Consecutive failed logins before alerting administrators
+FAILED_LOGIN_ALERT_THRESHOLD=10
+
+# Time window in minutes for counting failed logins
+FAILED_LOGIN_TIME_WINDOW=15
+
 # Path for storing uploaded documents
 STORAGE_PATH=./uploads
 

--- a/backend/domain/entities/AppConfigKeys.ts
+++ b/backend/domain/entities/AppConfigKeys.ts
@@ -59,4 +59,13 @@ export class AppConfigKeys {
    * Path patterns considered sensitive and therefore audited when accessed.
    */
   static readonly AUDIT_SENSITIVE_ROUTES = 'audit_sensitive_routes';
+
+  /** Number of lock events before sending an alert. */
+  static readonly LOCKOUT_ALERT_THRESHOLD = 'lockout_alert_threshold';
+
+  /** Consecutive failed logins before issuing an alert. */
+  static readonly FAILED_LOGIN_ALERT_THRESHOLD = 'failed_login_alert_threshold';
+
+  /** Time window in minutes for counting failed logins. */
+  static readonly FAILED_LOGIN_TIME_WINDOW = 'failed_login_time_window';
 }

--- a/backend/domain/services/BootstapService.ts
+++ b/backend/domain/services/BootstapService.ts
@@ -54,6 +54,9 @@ export class BootstapService {
       ['/api/admin/*', '/api/audit', '/api/config/*'],
       'bootstrap',
     );
+    await this.config.update(AppConfigKeys.LOCKOUT_ALERT_THRESHOLD, 5, 'bootstrap');
+    await this.config.update(AppConfigKeys.FAILED_LOGIN_ALERT_THRESHOLD, 10, 'bootstrap');
+    await this.config.update(AppConfigKeys.FAILED_LOGIN_TIME_WINDOW, 15, 'bootstrap');
 
     this.logger.info('Bootstrapping permissions');
     const keys = Object.values(PermissionKeys);

--- a/backend/tests/domain/services/BootstapService.test.ts
+++ b/backend/tests/domain/services/BootstapService.test.ts
@@ -42,6 +42,9 @@ describe('BootstapService', () => {
       ['/api/admin/*', '/api/audit', '/api/config/*'],
       'bootstrap',
     );
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.LOCKOUT_ALERT_THRESHOLD, 5, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.FAILED_LOGIN_ALERT_THRESHOLD, 10, 'bootstrap');
+    expect(config.update).toHaveBeenCalledWith(AppConfigKeys.FAILED_LOGIN_TIME_WINDOW, 15, 'bootstrap');
   });
 
   it('should create missing permissions', async () => {


### PR DESCRIPTION
## Summary
- register new alert-related configuration keys
- bootstrap defaults for new config keys
- test new bootstrap configuration updates
- document default alert settings in `.env.example`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a07322f948323be764fc8b1fb4cf5