### PR TITLE
Add security alert entity and notification port

### DIFF
--- a/backend/domain/entities/SecurityAlert.ts
+++ b/backend/domain/entities/SecurityAlert.ts
@@ -1,0 +1,21 @@
+/**
+ * Information about a security alert triggered by suspicious login activity.
+ */
+export interface SecurityAlert {
+  /**
+   * Type of alert that occurred.
+   *
+   * - `lockout` when a user account is temporarily locked.
+   * - `failedLogin` when consecutive login attempts fail without a lockout.
+   */
+  type: 'lockout' | 'failedLogin';
+
+  /** Number of attempts detected during the time window. */
+  count: number;
+
+  /** Threshold of attempts after which the alert is triggered. */
+  threshold: number;
+
+  /** Time window in seconds used to evaluate the attempts. */
+  window: number;
+}

--- a/backend/domain/ports/NotificationPort.ts
+++ b/backend/domain/ports/NotificationPort.ts
@@ -1,0 +1,14 @@
+/**
+ * Generic notification service used to inform users of important events.
+ * Implementations may deliver messages via email, chat or other channels.
+ */
+export interface NotificationPort {
+  /**
+   * Send a notification to a list of recipients.
+   *
+   * @param recipients - Array of recipient identifiers such as emails.
+   * @param subject - Short subject describing the notification.
+   * @param message - Body of the notification message.
+   */
+  notify(recipients: string[], subject: string, message: string): Promise<void>;
+}

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,0 +1,2 @@
+export * from './domain/entities/SecurityAlert';
+export * from './domain/ports/NotificationPort';


### PR DESCRIPTION
## Summary
- define `SecurityAlert` entity to describe account lockout and failed login events
- add `NotificationPort` for sending notifications
- export these constructs from backend entry point

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a0b7c4d5483239df985118515f58c