### PR TITLE
Add EmailNotificationAdapter

### DIFF
--- a/backend/adapters/notification/EmailNotificationAdapter.ts
+++ b/backend/adapters/notification/EmailNotificationAdapter.ts
@@ -1,0 +1,34 @@
+import { NotificationPort } from '../../domain/ports/NotificationPort';
+import { EmailServicePort } from '../../domain/ports/EmailServicePort';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
+
+/**
+ * Notification adapter sending messages via {@link EmailServicePort}.
+ */
+export class EmailNotificationAdapter implements NotificationPort {
+  /**
+   * Create a new adapter instance.
+   *
+   * @param emailService - Email service used to deliver messages.
+   * @param logger - Logger used to report errors.
+   */
+  constructor(
+    private readonly emailService: EmailServicePort,
+    private readonly logger: LoggerPort,
+  ) {}
+
+  /** @inheritdoc */
+  async notify(recipients: string[], subject: string, message: string): Promise<void> {
+    for (const to of recipients) {
+      try {
+        await this.emailService.sendMail({ to, subject, text: message });
+      } catch (err) {
+        this.logger.error(`Failed to send notification email to ${to}`, {
+          ...getContext(),
+          error: err,
+        });
+      }
+    }
+  }
+}

--- a/backend/tests/adapters/notification/EmailNotificationAdapter.test.ts
+++ b/backend/tests/adapters/notification/EmailNotificationAdapter.test.ts
@@ -1,0 +1,32 @@
+import { EmailNotificationAdapter } from '../../../adapters/notification/EmailNotificationAdapter';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { EmailServicePort } from '../../../domain/ports/EmailServicePort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+
+describe('EmailNotificationAdapter', () => {
+  let email: DeepMockProxy<EmailServicePort>;
+  let logger: DeepMockProxy<LoggerPort>;
+  let adapter: EmailNotificationAdapter;
+
+  beforeEach(() => {
+    email = mockDeep<EmailServicePort>();
+    logger = mockDeep<LoggerPort>();
+    adapter = new EmailNotificationAdapter(email, logger);
+  });
+
+  it('should send an email to each recipient', async () => {
+    await adapter.notify(['a@test.com', 'b@test.com'], 'Sub', 'msg');
+    expect(email.sendMail).toHaveBeenCalledTimes(2);
+    expect(email.sendMail).toHaveBeenCalledWith({ to: 'a@test.com', subject: 'Sub', text: 'msg' });
+    expect(email.sendMail).toHaveBeenCalledWith({ to: 'b@test.com', subject: 'Sub', text: 'msg' });
+  });
+
+  it('should log error when sending fails', async () => {
+    email.sendMail.mockRejectedValueOnce(new Error('boom'));
+    await adapter.notify(['err@test.com'], 's', 'm');
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send notification email to err@test.com',
+      { error: expect.any(Error) },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement email-based notification adapter
- log failures when sending notifications
- test email notification adapter behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a0ec9298083239a443105f17a31e1