### PR TITLE
Add security alert detection use case

### DIFF
--- a/backend/tests/usecases/SecurityAlertDetectorUseCase.test.ts
+++ b/backend/tests/usecases/SecurityAlertDetectorUseCase.test.ts
@@ -1,0 +1,99 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { SecurityAlertDetectorUseCase } from '../../usecases/SecurityAlertDetectorUseCase';
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { GetConfigUseCase } from '../../usecases/config/GetConfigUseCase';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { AppConfigKeys } from '../../domain/entities/AppConfigKeys';
+import { AuditEventType } from '../../domain/entities/AuditEventType';
+
+describe('SecurityAlertDetectorUseCase', () => {
+  let audit: DeepMockProxy<AuditPort>;
+  let config: DeepMockProxy<GetConfigUseCase>;
+  let logger: DeepMockProxy<LoggerPort>;
+  let useCase: SecurityAlertDetectorUseCase;
+
+  beforeEach(() => {
+    audit = mockDeep<AuditPort>();
+    config = mockDeep<GetConfigUseCase>();
+    logger = mockDeep<LoggerPort>();
+    (config.execute as jest.Mock).mockImplementation(async (key: string) => {
+      switch (key) {
+      case AppConfigKeys.LOCKOUT_ALERT_THRESHOLD:
+        return 5;
+      case AppConfigKeys.FAILED_LOGIN_ALERT_THRESHOLD:
+        return 10;
+      case AppConfigKeys.FAILED_LOGIN_TIME_WINDOW:
+        return 15;
+      default:
+        return null;
+      }
+    });
+    useCase = new SecurityAlertDetectorUseCase(audit, config, logger);
+  });
+
+  it('should return no alerts when counts below thresholds', async () => {
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 4 });
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 8 });
+
+    await expect(useCase.execute()).resolves.toEqual([]);
+    expect(audit.findPaginated).toHaveBeenNthCalledWith(1, {
+      page: 1,
+      limit: 1,
+      action: AuditEventType.USER_ACCOUNT_LOCKED,
+      dateFrom: expect.any(Date),
+    });
+    expect(audit.findPaginated).toHaveBeenNthCalledWith(2, {
+      page: 1,
+      limit: 1,
+      action: AuditEventType.USER_LOGIN_FAILED,
+      dateFrom: expect.any(Date),
+    });
+  });
+
+  it('should alert on lockouts only', async () => {
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 6 });
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 4 });
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([
+      { type: 'lockout', count: 6, threshold: 5, window: 15 * 60 },
+    ]);
+  });
+
+  it('should alert on failed logins only', async () => {
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 3 });
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 12 });
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([
+      { type: 'failedLogin', count: 12, threshold: 10, window: 15 * 60 },
+    ]);
+  });
+
+  it('should alert on both lockouts and failed logins', async () => {
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 8 });
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 11 });
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([
+      { type: 'lockout', count: 8, threshold: 5, window: 15 * 60 },
+      { type: 'failedLogin', count: 11, threshold: 10, window: 15 * 60 },
+    ]);
+  });
+
+  it('should use default values when config missing', async () => {
+    (config.execute as jest.Mock).mockResolvedValue(null);
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 6 });
+    audit.findPaginated.mockResolvedValueOnce({ items: [], page: 1, limit: 1, total: 12 });
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([
+      { type: 'lockout', count: 6, threshold: 5, window: 15 * 60 },
+      { type: 'failedLogin', count: 12, threshold: 10, window: 15 * 60 },
+    ]);
+  });
+});

--- a/backend/usecases/SecurityAlertDetectorUseCase.ts
+++ b/backend/usecases/SecurityAlertDetectorUseCase.ts
@@ -1,0 +1,78 @@
+import { AuditPort } from '../domain/ports/AuditPort';
+import { GetConfigUseCase } from './config/GetConfigUseCase';
+import { LoggerPort } from '../domain/ports/LoggerPort';
+import { SecurityAlert } from '../domain/entities/SecurityAlert';
+import { AppConfigKeys } from '../domain/entities/AppConfigKeys';
+import { AuditEventType } from '../domain/entities/AuditEventType';
+
+/**
+ * Detects suspicious activity in audit logs and returns security alerts
+ * when configured thresholds are exceeded.
+ */
+export class SecurityAlertDetectorUseCase {
+  constructor(
+    private readonly audit: AuditPort,
+    private readonly config: GetConfigUseCase,
+    private readonly logger: LoggerPort,
+  ) {}
+
+  /**
+   * Check recent audit events for account lockouts and failed logins.
+   *
+   * @returns Array of alerts that were triggered, empty if none.
+   */
+  async execute(): Promise<SecurityAlert[]> {
+    this.logger.debug('Checking security alerts');
+    const lockoutThreshold =
+      (await this.config.execute<number>(AppConfigKeys.LOCKOUT_ALERT_THRESHOLD)) ??
+      5;
+    const failedThreshold =
+      (await this.config.execute<number>(
+        AppConfigKeys.FAILED_LOGIN_ALERT_THRESHOLD,
+      )) ?? 10;
+    const windowMinutes =
+      (await this.config.execute<number>(AppConfigKeys.FAILED_LOGIN_TIME_WINDOW)) ??
+      15;
+
+    const dateFrom = new Date(Date.now() - windowMinutes * 60 * 1000);
+
+    const lockouts = await this.audit.findPaginated({
+      page: 1,
+      limit: 1,
+      action: AuditEventType.USER_ACCOUNT_LOCKED,
+      dateFrom,
+    });
+    const failed = await this.audit.findPaginated({
+      page: 1,
+      limit: 1,
+      action: AuditEventType.USER_LOGIN_FAILED,
+      dateFrom,
+    });
+
+    const alerts: SecurityAlert[] = [];
+    if (lockouts.total > lockoutThreshold) {
+      alerts.push({
+        type: 'lockout',
+        count: lockouts.total,
+        threshold: lockoutThreshold,
+        window: windowMinutes * 60,
+      });
+    }
+    if (failed.total > failedThreshold) {
+      alerts.push({
+        type: 'failedLogin',
+        count: failed.total,
+        threshold: failedThreshold,
+        window: windowMinutes * 60,
+      });
+    }
+
+    if (alerts.length > 0) {
+      this.logger.info('Security alerts detected', { alerts });
+    } else {
+      this.logger.debug('No security alerts detected');
+    }
+
+    return alerts;
+  }
+}


### PR DESCRIPTION
## Summary
- add `SecurityAlertDetectorUseCase` for detecting lockout/failed login alerts
- test alert detection logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a134e4b408323938f30ee2a4d544f