### PR TITLE
Add security alert detector scheduled job

### DIFF
--- a/backend/adapters/scheduler/jobs.ts
+++ b/backend/adapters/scheduler/jobs.ts
@@ -1,13 +1,16 @@
 import { ScheduledJob } from '../../domain/ports/SchedulerPort';
 import { DummyCronUseCase } from '../../usecases/cron/DummyCronUseCase';
-import { ConsoleLoggerAdapter } from '../logger/ConsoleLoggerAdapter';
 import { SendPasswordExpiryWarningsUseCase } from '../../usecases/SendPasswordExpiryWarningsUseCase';
 import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
 import { EmailServicePort } from '../../domain/ports/EmailServicePort';
 import { GetConfigUseCase } from '../../usecases/config/GetConfigUseCase';
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { NotificationPort } from '../../domain/ports/NotificationPort';
+import { SecurityAlertDetectorUseCase } from '../../usecases/SecurityAlertDetectorUseCase';
+import { AuditEvent } from '../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../domain/entities/AuditEventType';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
 
-const logger = new ConsoleLoggerAdapter();
-const dummyUseCase = new DummyCronUseCase(logger);
 
 /**
  * Build the array of scheduled jobs using provided dependencies.
@@ -19,11 +22,20 @@ export function createScheduledJobs(deps: {
   userRepository: UserRepositoryPort;
   mailer: EmailServicePort;
   config: GetConfigUseCase;
+  audit: AuditPort;
+  notification: NotificationPort;
+  logger: LoggerPort;
 }): ScheduledJob[] {
   const warningUseCase = new SendPasswordExpiryWarningsUseCase(
     deps.userRepository,
     deps.mailer,
     deps.config,
+  );
+  const dummyUseCase = new DummyCronUseCase(deps.logger);
+  const securityUseCase = new SecurityAlertDetectorUseCase(
+    deps.audit,
+    deps.config,
+    deps.logger,
   );
 
   return [
@@ -36,6 +48,34 @@ export function createScheduledJobs(deps: {
       name: 'PasswordExpiryWarning',
       schedule: '0 12 * * *',
       handler: () => warningUseCase.execute(),
+    },
+    {
+      name: 'SecurityAlertDetector',
+      schedule: '*/5 * * * *',
+      handler: async (): Promise<void> => {
+        const alerts = await securityUseCase.execute();
+        if (alerts.length > 0) {
+          const lines = alerts.map((a) =>
+            `${a.type}: ${a.count}/${a.threshold} in ${a.window}s`,
+          );
+          await deps.notification.notify(
+            [process.env.ADMIN_EMAIL ?? 'admin@admin.com'],
+            'Security alerts',
+            lines.join('\n'),
+          );
+          await deps.audit.log(
+            new AuditEvent(
+              new Date(),
+              null,
+              'system',
+              AuditEventType.SECURITY_ALERT,
+              'security',
+              undefined,
+              { alerts },
+            ),
+          );
+        }
+      },
     },
   ];
 }

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -17,6 +17,7 @@ import { JWTAuthServiceAdapter } from '../adapters/auth/JWTAuthServiceAdapter';
 import { JWTTokenServiceAdapter } from '../adapters/token/JWTTokenServiceAdapter';
 import { ConsoleLoggerAdapter } from '../adapters/logger/ConsoleLoggerAdapter';
 import { ConsoleEmailServiceAdapter } from '../adapters/email/ConsoleEmailServiceAdapter';
+import { EmailNotificationAdapter } from '../adapters/notification/EmailNotificationAdapter';
 import { LocalFileStorageAdapter } from '../adapters/storage/LocalFileStorageAdapter';
 import { AvatarService } from '../domain/services/AvatarService';
 import { PrismaRefreshTokenRepository } from '../adapters/repositories/PrismaRefreshTokenRepository';
@@ -49,6 +50,7 @@ async function bootstrap(): Promise<void> {
   const invitationRepository = new PrismaInvitationRepository(prisma, logger);
   const permissionRepository = new PrismaPermissionRepository(prisma, logger);
   const emailService = new ConsoleEmailServiceAdapter(logger);
+  const notificationService = new EmailNotificationAdapter(emailService, logger);
   const storage = new LocalFileStorageAdapter(process.env.STORAGE_PATH ?? './uploads', logger);
   const avatarService = new AvatarService(storage, userRepository, logger);
 
@@ -159,6 +161,9 @@ async function bootstrap(): Promise<void> {
       userRepository,
       mailer: emailService,
       config: getConfigUseCase,
+      audit,
+      notification: notificationService,
+      logger,
     }),
   );
 


### PR DESCRIPTION
## Summary
- inject more dependencies into scheduler job creation
- notify admins on security alerts every 5 minutes
- wire email notifications into server bootstrap

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a152e0a0083238a4feda9f9a809c4