### PR TITLE
Add audit configuration entity and Prisma model

### DIFF
--- a/backend/adapters/orm/prisma/migrations/20250730132818_add_audit_config/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250730132818_add_audit_config/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "AuditConfig" (
+    "id" SERIAL NOT NULL,
+    "levels" TEXT[] NOT NULL,
+    "categories" TEXT[] NOT NULL,
+    "updatedAt" TIMESTAMP(3),
+    "updatedBy" TEXT,
+    "singleton" INTEGER NOT NULL DEFAULT 1,
+
+    CONSTRAINT "AuditConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuditConfig_singleton_key" ON "AuditConfig"("singleton");

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -208,10 +208,10 @@ model Invitation {
 }
 
 model RefreshToken {
-  id         String   @id @default(uuid())
+  id         String    @id @default(uuid())
   userId     String
   tokenHash  String
-  createdAt  DateTime @default(now())
+  createdAt  DateTime  @default(now())
   expiresAt  DateTime
   revokedAt  DateTime?
   replacedBy String?
@@ -242,4 +242,13 @@ model AppConfig {
   type      String
   updatedAt DateTime? @updatedAt
   updatedBy String?
+}
+
+model AuditConfig {
+  id         Int       @id @default(autoincrement())
+  levels     String[]
+  categories String[]
+  updatedAt  DateTime? @updatedAt
+  updatedBy  String?
+  singleton  Int       @unique @default(1)
 }

--- a/backend/domain/entities/AuditConfig.ts
+++ b/backend/domain/entities/AuditConfig.ts
@@ -1,0 +1,21 @@
+/**
+ * Represents the audit logging configuration stored in the system.
+ */
+export class AuditConfig {
+  /**
+   * Create a new configuration instance.
+   *
+   * @param id - Numeric identifier of the persisted configuration row.
+   * @param levels - Collection of enabled audit levels (e.g. 'info', 'error').
+   * @param categories - Audit event categories to record.
+   * @param updatedAt - Date when the configuration was last modified.
+   * @param updatedBy - Identifier of the user who performed the last update.
+   */
+  constructor(
+    public readonly id: number,
+    public levels: string[],
+    public categories: string[],
+    public updatedAt: Date | null,
+    public updatedBy: string | null,
+  ) {}
+}

--- a/backend/domain/ports/AuditConfigPort.ts
+++ b/backend/domain/ports/AuditConfigPort.ts
@@ -1,0 +1,23 @@
+import { AuditConfig } from '../entities/AuditConfig';
+
+/**
+ * Provides access to the single audit configuration entry.
+ */
+export interface AuditConfigPort {
+  /**
+   * Retrieve the stored audit configuration.
+   *
+   * @returns The {@link AuditConfig} instance or `null` if none exists.
+   */
+  get(): Promise<AuditConfig | null>;
+
+  /**
+   * Update the audit configuration.
+   *
+   * @param levels - Enabled audit levels to persist.
+   * @param categories - Categories of events to record.
+   * @param updatedBy - Identifier of the user performing the update.
+   * @returns The persisted {@link AuditConfig} after update.
+   */
+  update(levels: string[], categories: string[], updatedBy: string): Promise<AuditConfig>;
+}

--- a/backend/tests/domain/entities/AuditConfig.test.ts
+++ b/backend/tests/domain/entities/AuditConfig.test.ts
@@ -1,0 +1,12 @@
+import { AuditConfig } from '../../../domain/entities/AuditConfig';
+
+describe('AuditConfig Entity', () => {
+  it('should store provided values', () => {
+    const cfg = new AuditConfig(1, ['info'], ['auth'], new Date('2024-01-01T00:00:00Z'), 'user');
+    expect(cfg.id).toBe(1);
+    expect(cfg.levels).toEqual(['info']);
+    expect(cfg.categories).toEqual(['auth']);
+    expect(cfg.updatedAt?.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+    expect(cfg.updatedBy).toBe('user');
+  });
+});

--- a/backend/tests/domain/ports/AuditConfigPort.test.ts
+++ b/backend/tests/domain/ports/AuditConfigPort.test.ts
@@ -1,0 +1,35 @@
+import { AuditConfigPort } from '../../../domain/ports/AuditConfigPort';
+import { AuditConfig } from '../../../domain/entities/AuditConfig';
+
+class InMemoryAuditConfigRepo implements AuditConfigPort {
+  private config: AuditConfig | null = null;
+  async get(): Promise<AuditConfig | null> {
+    return this.config;
+  }
+  async update(levels: string[], categories: string[], updatedBy: string): Promise<AuditConfig> {
+    const cfg = new AuditConfig(1, levels, categories, new Date(), updatedBy);
+    this.config = cfg;
+    return cfg;
+  }
+}
+
+describe('AuditConfigPort Interface', () => {
+  let repo: InMemoryAuditConfigRepo;
+
+  beforeEach(() => {
+    repo = new InMemoryAuditConfigRepo();
+  });
+
+  it('should return null when no config is stored', async () => {
+    expect(await repo.get()).toBeNull();
+  });
+
+  it('should store and return configuration', async () => {
+    const cfg = await repo.update(['warn'], ['security'], 'tester');
+    const stored = await repo.get();
+    expect(stored).toEqual(cfg);
+    expect(stored?.levels).toEqual(['warn']);
+    expect(stored?.categories).toEqual(['security']);
+    expect(stored?.updatedBy).toBe('tester');
+  });
+});


### PR DESCRIPTION
## Summary
- add `AuditConfig` entity and `AuditConfigPort`
- create Prisma `AuditConfig` model and migration
- add tests for the new entity and port

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a1d2ed9a483239719dd5c6df531ae