### PR TITLE
Add audit config service and adapter

### DIFF
--- a/backend/adapters/audit/PrismaAuditConfigAdapter.ts
+++ b/backend/adapters/audit/PrismaAuditConfigAdapter.ts
@@ -1,0 +1,45 @@
+import { PrismaClient } from '@prisma/client';
+import { AuditConfigPort } from '../../domain/ports/AuditConfigPort';
+import { AuditConfig } from '../../domain/entities/AuditConfig';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
+
+/**
+ * Prisma-based implementation of {@link AuditConfigPort}.
+ */
+export class PrismaAuditConfigAdapter implements AuditConfigPort {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly logger: LoggerPort,
+  ) {}
+
+  async get(): Promise<AuditConfig | null> {
+    const record = await this.prisma.auditConfig.findUnique({ where: { singleton: 1 } });
+    if (!record) {
+      return null;
+    }
+    return new AuditConfig(
+      record.id,
+      record.levels,
+      record.categories,
+      record.updatedAt,
+      record.updatedBy,
+    );
+  }
+
+  async update(levels: string[], categories: string[], updatedBy: string): Promise<AuditConfig> {
+    this.logger.debug('Updating audit config', getContext());
+    const record = await this.prisma.auditConfig.upsert({
+      where: { singleton: 1 },
+      create: { singleton: 1, levels, categories, updatedBy },
+      update: { levels, categories, updatedBy },
+    });
+    return new AuditConfig(
+      record.id,
+      record.levels,
+      record.categories,
+      record.updatedAt,
+      record.updatedBy,
+    );
+  }
+}

--- a/backend/adapters/cache/RedisCacheAdapter.ts
+++ b/backend/adapters/cache/RedisCacheAdapter.ts
@@ -5,9 +5,10 @@ import IORedis from 'ioredis';
  * Redis-backed cache storing values as JSON.
  */
 export class RedisCacheAdapter implements CachePort {
-  private readonly prefix = 'appconfig:';
-
-  constructor(private readonly client: IORedis) {}
+  constructor(
+    private readonly client: IORedis,
+    private readonly prefix = 'appconfig:',
+  ) {}
 
   async get<T>(key: string): Promise<T | null> {
     const data = await this.client.get(this.prefix + key);

--- a/backend/domain/services/AuditConfigService.ts
+++ b/backend/domain/services/AuditConfigService.ts
@@ -1,0 +1,67 @@
+import { CachePort } from '../ports/CachePort';
+import { AuditConfigPort } from '../ports/AuditConfigPort';
+import { AuditConfig } from '../entities/AuditConfig';
+
+/**
+ * Service handling retrieval and persistence of audit logging configuration
+ * with caching support.
+ */
+export class AuditConfigService {
+  /**
+   * Key used to store the configuration in cache.
+   */
+  private readonly cacheKey = 'audit-config';
+
+  /**
+   * Create a new audit configuration service.
+   *
+   * @param cache - Cache layer for quick access.
+   * @param repository - Repository used to persist configuration changes.
+   */
+  constructor(
+    private readonly cache: CachePort,
+    private readonly repository: AuditConfigPort,
+  ) {}
+
+  /**
+   * Retrieve the audit configuration.
+   *
+   * @returns The stored {@link AuditConfig} or `null` when none exists.
+   */
+  async get(): Promise<AuditConfig | null> {
+    const cached = await this.cache.get<AuditConfig>(this.cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+    const config = await this.repository.get();
+    if (config) {
+      await this.cache.set(this.cacheKey, config);
+    }
+    return config;
+  }
+
+  /**
+   * Update the audit configuration and cache the result.
+   *
+   * @param levels - Enabled audit levels to persist.
+   * @param categories - Categories of events to log.
+   * @param updatedBy - Identifier of the user applying the update.
+   * @returns The updated configuration instance.
+   */
+  async update(
+    levels: string[],
+    categories: string[],
+    updatedBy: string,
+  ): Promise<AuditConfig> {
+    const config = await this.repository.update(levels, categories, updatedBy);
+    await this.cache.set(this.cacheKey, config);
+    return config;
+  }
+
+  /**
+   * Invalidate the cached configuration entry.
+   */
+  async invalidate(): Promise<void> {
+    await this.cache.delete(this.cacheKey);
+  }
+}

--- a/backend/tests/adapters/audit/PrismaAuditConfigAdapter.test.ts
+++ b/backend/tests/adapters/audit/PrismaAuditConfigAdapter.test.ts
@@ -1,0 +1,57 @@
+import { PrismaAuditConfigAdapter } from '../../../adapters/audit/PrismaAuditConfigAdapter';
+import { PrismaClient } from '@prisma/client';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+
+describe('PrismaAuditConfigAdapter', () => {
+  let prisma: DeepMockProxy<PrismaClient>;
+  let logger: DeepMockProxy<LoggerPort>;
+  let adapter: PrismaAuditConfigAdapter;
+
+  beforeEach(() => {
+    prisma = mockDeep<PrismaClient>();
+    logger = mockDeep<LoggerPort>();
+    adapter = new PrismaAuditConfigAdapter(prisma, logger);
+  });
+
+  it('should return null when config missing', async () => {
+    (prisma as any).auditConfig.findUnique.mockResolvedValue(null);
+    const result = await adapter.get();
+    expect(result).toBeNull();
+  });
+
+  it('should retrieve audit config', async () => {
+    const record = {
+      id: 1,
+      levels: ['info'],
+      categories: ['auth'],
+      updatedAt: new Date('2024-01-01T00:00:00Z'),
+      updatedBy: 'u',
+      singleton: 1,
+    };
+    (prisma as any).auditConfig.findUnique.mockResolvedValue(record);
+    const result = await adapter.get();
+    expect(result?.id).toBe(1);
+    expect(result?.levels).toEqual(['info']);
+    expect(result?.categories).toEqual(['auth']);
+  });
+
+  it('should upsert audit config', async () => {
+    const record = {
+      id: 2,
+      levels: ['error'],
+      categories: ['system'],
+      updatedAt: new Date('2024-01-02T00:00:00Z'),
+      updatedBy: 'a',
+      singleton: 1,
+    };
+    (prisma as any).auditConfig.upsert.mockResolvedValue(record);
+    const result = await adapter.update(['error'], ['system'], 'a');
+    expect(result.id).toBe(2);
+    expect((prisma as any).auditConfig.upsert).toHaveBeenCalledWith({
+      where: { singleton: 1 },
+      create: { singleton: 1, levels: ['error'], categories: ['system'], updatedBy: 'a' },
+      update: { levels: ['error'], categories: ['system'], updatedBy: 'a' },
+    });
+  });
+});

--- a/backend/tests/domain/services/AuditConfigService.test.ts
+++ b/backend/tests/domain/services/AuditConfigService.test.ts
@@ -1,0 +1,54 @@
+import { AuditConfigService } from '../../../domain/services/AuditConfigService';
+import { InMemoryCacheAdapter } from '../../../adapters/cache/InMemoryCacheAdapter';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AuditConfigPort } from '../../../domain/ports/AuditConfigPort';
+import { AuditConfig } from '../../../domain/entities/AuditConfig';
+
+describe('AuditConfigService', () => {
+  let cache: InMemoryCacheAdapter;
+  let repo: DeepMockProxy<AuditConfigPort>;
+  let service: AuditConfigService;
+
+  beforeEach(() => {
+    cache = new InMemoryCacheAdapter();
+    repo = mockDeep<AuditConfigPort>();
+    service = new AuditConfigService(cache, repo);
+  });
+
+  it('should return cached config', async () => {
+    const cfg = new AuditConfig(1, ['info'], ['auth'], new Date(), 'u');
+    await cache.set('audit-config', cfg);
+    const result = await service.get();
+    expect(result).toBe(cfg);
+    expect(repo.get).not.toHaveBeenCalled();
+  });
+
+  it('should return null when not found', async () => {
+    repo.get.mockResolvedValue(null);
+    const result = await service.get();
+    expect(result).toBeNull();
+  });
+
+  it('should load from repository and cache result', async () => {
+    const cfg = new AuditConfig(1, ['error'], ['system'], new Date(), 'a');
+    repo.get.mockResolvedValue(cfg);
+    const result = await service.get();
+    expect(result).toBe(cfg);
+    expect(await cache.get<AuditConfig>('audit-config')).toBe(cfg);
+  });
+
+  it('should update repository and cache', async () => {
+    const cfg = new AuditConfig(1, ['info'], ['auth'], new Date(), 'u');
+    repo.update.mockResolvedValue(cfg);
+    const result = await service.update(['info'], ['auth'], 'u');
+    expect(result).toBe(cfg);
+    expect(repo.update).toHaveBeenCalledWith(['info'], ['auth'], 'u');
+    expect(await cache.get<AuditConfig>('audit-config')).toBe(cfg);
+  });
+
+  it('should invalidate cache', async () => {
+    await cache.set('audit-config', new AuditConfig(1, [], [], new Date(), 'u'));
+    await service.invalidate();
+    expect(await cache.get('audit-config')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `AuditConfigService` for cached audit configuration
- support prefix injection in `RedisCacheAdapter`
- add Prisma adapter for audit config storage
- test audit config service and adapter

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a1f0ca94c8323b15ab5d5f096f5ab