### PR TITLE
Add audit config permissions

### DIFF
--- a/backend/domain/entities/AuditEventType.ts
+++ b/backend/domain/entities/AuditEventType.ts
@@ -24,6 +24,9 @@ export class AuditEventType {
   /** Event recorded when a configuration entry is deleted. */
   static readonly CONFIG_DELETED = 'config.deleted';
 
+  /** Event recorded when the audit configuration is updated. */
+  static readonly AUDIT_CONFIG_UPDATED = 'auditConfig.updated';
+
   /** Event recorded when a sensitive route is accessed. */
   static readonly SENSITIVE_ROUTE_ACCESSED = 'sensitiveRoute.accessed';
 

--- a/backend/domain/entities/PermissionKeys.ts
+++ b/backend/domain/entities/PermissionKeys.ts
@@ -116,6 +116,12 @@ export class PermissionKeys {
   /** Allows updating user profile pictures. */
   static readonly UPDATE_USER_PICTURE = 'update-user-picture';
 
+  /** Allows viewing the audit logging configuration. */
+  static readonly READ_AUDIT_CONFIG = 'read-audit-config';
+
+  /** Allows modifying the audit logging configuration. */
+  static readonly WRITE_AUDIT_CONFIG = 'write-audit-config';
+
   /** Allows reading application configuration values. */
   static readonly READ_CONFIG = 'read-config';
 

--- a/backend/tests/domain/entities/AuditEventTypeConstants.test.ts
+++ b/backend/tests/domain/entities/AuditEventTypeConstants.test.ts
@@ -1,0 +1,7 @@
+import { AuditEventType } from '../../../domain/entities/AuditEventType';
+
+describe('AuditEventType constants', () => {
+  it('should include audit config updated event', () => {
+    expect(AuditEventType.AUDIT_CONFIG_UPDATED).toBe('auditConfig.updated');
+  });
+});

--- a/backend/tests/domain/entities/PermissionKeys.test.ts
+++ b/backend/tests/domain/entities/PermissionKeys.test.ts
@@ -1,0 +1,8 @@
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+
+describe('PermissionKeys constants', () => {
+  it('should include audit config permissions', () => {
+    expect(PermissionKeys.READ_AUDIT_CONFIG).toBe('read-audit-config');
+    expect(PermissionKeys.WRITE_AUDIT_CONFIG).toBe('write-audit-config');
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `READ_AUDIT_CONFIG` and `WRITE_AUDIT_CONFIG` permission keys
- support new audit event type `AUDIT_CONFIG_UPDATED`
- test the new constants

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_688a20bff2a4832381e676fc7fa29c1a