### PR TITLE
Implement audit log filtering

### DIFF
--- a/backend/adapters/controllers/rest/auditController.ts
+++ b/backend/adapters/controllers/rest/auditController.ts
@@ -7,6 +7,7 @@ import { LoggerPort } from '../../../domain/ports/LoggerPort';
 import { getContext } from '../../../infrastructure/loggerContext';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { GetAuditLogsUseCase } from '../../../usecases/audit/GetAuditLogsUseCase';
+import { AuditConfigService } from '../../../domain/services/AuditConfigService';
 import { User } from '../../../domain/entities/User';
 import { TokenExpiredException } from '../../../domain/errors/TokenExpiredException';
 
@@ -69,6 +70,7 @@ export function createAuditRouter(
   users: UserRepositoryPort,
   audit: AuditPort,
   logger: LoggerPort,
+  configService: AuditConfigService,
 ): Router {
   const router = express.Router();
 
@@ -183,7 +185,7 @@ export function createAuditRouter(
     const page = parseInt(req.query.page as string) || 1;
     const limit = parseInt(req.query.limit as string) || 20;
     const checker = new PermissionChecker((req as AuthedRequest).user);
-    const useCase = new GetAuditLogsUseCase(audit, checker);
+    const useCase = new GetAuditLogsUseCase(audit, checker, configService);
     const result = await useCase.execute({
       page,
       limit,

--- a/backend/tests/adapters/controllers/rest/auditController.test.ts
+++ b/backend/tests/adapters/controllers/rest/auditController.test.ts
@@ -7,6 +7,7 @@ import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort'
 import { AuditPort } from '../../../../domain/ports/AuditPort';
 import { LoggerPort } from '../../../../domain/ports/LoggerPort';
 import { AuditEvent } from '../../../../domain/entities/AuditEvent';
+import { AuditConfigService } from '../../../../domain/services/AuditConfigService';
 import { User } from '../../../../domain/entities/User';
 import { Department } from '../../../../domain/entities/Department';
 import { Site } from '../../../../domain/entities/Site';
@@ -20,12 +21,14 @@ describe('Audit REST controller', () => {
   let users: DeepMockProxy<UserRepositoryPort>;
   let audit: DeepMockProxy<AuditPort>;
   let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let config: DeepMockProxy<AuditConfigService>;
 
   beforeEach(() => {
     auth = mockDeep<AuthServicePort>();
     users = mockDeep<UserRepositoryPort>();
     audit = mockDeep<AuditPort>();
     logger = mockDeep<LoggerPort>();
+    config = mockDeep<AuditConfigService>();
 
     auth.verifyToken.mockResolvedValue({ id: 'u' } as any);
     const site = new Site('s', 'Site');
@@ -37,7 +40,7 @@ describe('Audit REST controller', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/api', createAuditRouter(auth, users, audit, logger));
+    app.use('/api', createAuditRouter(auth, users, audit, logger, config));
   });
 
   it('should list audit logs', async () => {

--- a/backend/tests/usecases/audit/getAuditLogsUseCase.test.ts
+++ b/backend/tests/usecases/audit/getAuditLogsUseCase.test.ts
@@ -4,6 +4,8 @@ import { AuditPort } from '../../../domain/ports/AuditPort';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
 import { AuditEvent } from '../../../domain/entities/AuditEvent';
+import { AuditConfigService } from '../../../domain/services/AuditConfigService';
+import { AuditConfig } from '../../../domain/entities/AuditConfig';
 import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
@@ -15,6 +17,7 @@ describe('GetAuditLogsUseCase', () => {
   let checker: PermissionChecker;
   let useCase: GetAuditLogsUseCase;
   let event: AuditEvent;
+  let config: DeepMockProxy<AuditConfigService>;
 
   beforeEach(() => {
     port = mockDeep<AuditPort>();
@@ -24,7 +27,8 @@ describe('GetAuditLogsUseCase', () => {
     const role = new Role('r', 'Role', [perm]);
     const user = new User('u', 'John', 'Doe', 'j@example.com', [role], 'active', dept, site);
     checker = new PermissionChecker(user);
-    useCase = new GetAuditLogsUseCase(port, checker);
+    config = mockDeep<AuditConfigService>();
+    useCase = new GetAuditLogsUseCase(port, checker, config);
     event = new AuditEvent(new Date('2024-01-01T00:00:00Z'), 'u', 'user', 'action');
   });
 
@@ -40,10 +44,63 @@ describe('GetAuditLogsUseCase', () => {
   it('should throw when permission denied', async () => {
     const denied = mockDeep<PermissionChecker>();
     denied.check.mockImplementation(() => { throw new Error('Forbidden'); });
-    useCase = new GetAuditLogsUseCase(port, denied);
+    useCase = new GetAuditLogsUseCase(port, denied, config);
 
     await expect(useCase.execute({ page: 1, limit: 20 })).rejects.toThrow('Forbidden');
     expect(port.findPaginated).not.toHaveBeenCalled();
+  });
+
+  it('should filter events by level', async () => {
+    const e1 = new AuditEvent(new Date('2024-01-02T00:00:00Z'), 'u', 'user', 'auth.refresh', undefined, undefined, { level: 'info' });
+    const e2 = new AuditEvent(new Date('2024-01-03T00:00:00Z'), 'u', 'user', 'auth.refresh', undefined, undefined, { level: 'error' });
+    port.findPaginated.mockResolvedValue({ items: [e1, e2], page: 1, limit: 20, total: 2 });
+    config.get.mockResolvedValue(new AuditConfig(1, ['error'], ['auth'], new Date(), 'u'));
+
+    const result = await useCase.execute({ page: 1, limit: 20 });
+
+    expect(result.items).toEqual([e2]);
+  });
+
+  it('should filter events by category', async () => {
+    const e1 = new AuditEvent(new Date('2024-01-04T00:00:00Z'), 'u', 'user', 'user.loginFailed', undefined, undefined, { level: 'info' });
+    const e2 = new AuditEvent(new Date('2024-01-05T00:00:00Z'), 'u', 'user', 'auth.refresh', undefined, undefined, { level: 'info' });
+    port.findPaginated.mockResolvedValue({ items: [e1, e2], page: 1, limit: 20, total: 2 });
+    config.get.mockResolvedValue(new AuditConfig(1, ['info'], ['user'], new Date(), 'u'));
+
+    const result = await useCase.execute({ page: 1, limit: 20 });
+
+    expect(result.items).toEqual([e1]);
+  });
+
+  it('should return all events when config disabled', async () => {
+    const e1 = new AuditEvent(new Date('2024-01-06T00:00:00Z'), 'u', 'user', 'auth.refresh', undefined, undefined, { level: 'info' });
+    const e2 = new AuditEvent(new Date('2024-01-07T00:00:00Z'), 'u', 'user', 'user.loginFailed', undefined, undefined, { level: 'error' });
+    port.findPaginated.mockResolvedValue({ items: [e1, e2], page: 1, limit: 20, total: 2 });
+    config.get.mockResolvedValue(new AuditConfig(1, [], [], new Date(), 'u'));
+
+    const result = await useCase.execute({ page: 1, limit: 20 });
+
+    expect(result.items).toEqual([e1, e2]);
+  });
+
+  it('should return unfiltered when config missing', async () => {
+    const e1 = new AuditEvent(new Date('2024-01-08T00:00:00Z'), 'u', 'user', 'auth.refresh');
+    port.findPaginated.mockResolvedValue({ items: [e1], page: 1, limit: 20, total: 1 });
+    config.get.mockResolvedValue(null);
+
+    const result = await useCase.execute({ page: 1, limit: 20 });
+
+    expect(result.items).toEqual([e1]);
+  });
+
+  it('should default level to info when missing', async () => {
+    const e1 = new AuditEvent(new Date('2024-01-09T00:00:00Z'), 'u', 'user', 'auth.refresh');
+    port.findPaginated.mockResolvedValue({ items: [e1], page: 1, limit: 20, total: 1 });
+    config.get.mockResolvedValue(new AuditConfig(1, ['info'], ['auth'], new Date(), 'u'));
+
+    const result = await useCase.execute({ page: 1, limit: 20 });
+
+    expect(result.items).toEqual([e1]);
   });
 });
 


### PR DESCRIPTION
## Summary
- inject `AuditConfigService` into `GetAuditLogsUseCase`
- filter audit logs based on configured levels and categories
- wire audit config into REST controller
- update related tests with new filtering behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a22c8754083238e9864d1cbea75c8