### PR TITLE
Implement audit config use cases

### DIFF
--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -25,6 +25,8 @@ import { PrismaRefreshTokenRepository } from '../adapters/repositories/PrismaRef
 import { PrismaAudit } from '../adapters/audit/PrismaAudit';
 import { PrismaAuditConfigAdapter } from '../adapters/audit/PrismaAuditConfigAdapter';
 import { AuditConfigService } from '../domain/services/AuditConfigService';
+import { GetAuditConfigUseCase } from '../usecases/audit/GetAuditConfigUseCase';
+import { UpdateAuditConfigUseCase } from '../usecases/audit/UpdateAuditConfigUseCase';
 import { createPrisma } from './createPrisma';
 import { withContext, getContext } from './loggerContext';
 
@@ -78,6 +80,11 @@ async function bootstrap(): Promise<void> {
     : new InMemoryCacheAdapter();
   const auditConfigRepo = new PrismaAuditConfigAdapter(prisma, logger);
   const auditConfigService = new AuditConfigService(cache, auditConfigRepo);
+  const getAuditConfigUseCase = new GetAuditConfigUseCase(auditConfigService);
+  const updateAuditConfigUseCase = new UpdateAuditConfigUseCase(
+    auditConfigService,
+    audit,
+  );
   const configService = new ConfigService(cache, configRepo);
   const passwordValidator = new PasswordValidator(configService);
   const mfaService = new TOTPAdapter(
@@ -163,8 +170,8 @@ async function bootstrap(): Promise<void> {
   app.use(
     '/api',
     createAuditConfigRouter(
-      auditConfigService,
-      audit,
+      getAuditConfigUseCase,
+      updateAuditConfigUseCase,
       logger,
     ),
   );

--- a/backend/tests/usecases/audit/getAuditConfigUseCase.test.ts
+++ b/backend/tests/usecases/audit/getAuditConfigUseCase.test.ts
@@ -1,0 +1,32 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { GetAuditConfigUseCase } from '../../../usecases/audit/GetAuditConfigUseCase';
+import { AuditConfigService } from '../../../domain/services/AuditConfigService';
+import { AuditConfig } from '../../../domain/entities/AuditConfig';
+
+describe('GetAuditConfigUseCase', () => {
+  let service: DeepMockProxy<AuditConfigService>;
+  let useCase: GetAuditConfigUseCase;
+
+  beforeEach(() => {
+    service = mockDeep<AuditConfigService>();
+    useCase = new GetAuditConfigUseCase(service);
+  });
+
+  it('should return config from service', async () => {
+    const cfg = new AuditConfig(1, ['info'], ['auth'], new Date(), 'u');
+    service.get.mockResolvedValue(cfg);
+
+    const result = await useCase.execute();
+
+    expect(result).toBe(cfg);
+    expect(service.get).toHaveBeenCalled();
+  });
+
+  it('should return null when missing', async () => {
+    service.get.mockResolvedValue(null);
+
+    const result = await useCase.execute();
+
+    expect(result).toBeNull();
+  });
+});

--- a/backend/tests/usecases/audit/updateAuditConfigUseCase.test.ts
+++ b/backend/tests/usecases/audit/updateAuditConfigUseCase.test.ts
@@ -1,0 +1,35 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { UpdateAuditConfigUseCase } from '../../../usecases/audit/UpdateAuditConfigUseCase';
+import { AuditConfigService } from '../../../domain/services/AuditConfigService';
+import { AuditPort } from '../../../domain/ports/AuditPort';
+import { AuditConfig } from '../../../domain/entities/AuditConfig';
+import { AuditEvent } from '../../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../../domain/entities/AuditEventType';
+
+describe('UpdateAuditConfigUseCase', () => {
+  let service: DeepMockProxy<AuditConfigService>;
+  let audit: DeepMockProxy<AuditPort>;
+  let useCase: UpdateAuditConfigUseCase;
+
+  beforeEach(() => {
+    service = mockDeep<AuditConfigService>();
+    audit = mockDeep<AuditPort>();
+    useCase = new UpdateAuditConfigUseCase(service, audit);
+  });
+
+  it('should update service and log event', async () => {
+    const cfg = new AuditConfig(1, ['warn'], ['system'], new Date(), 'u');
+    service.update.mockResolvedValue(cfg);
+
+    const result = await useCase.execute(['warn'], ['system'], 'u');
+
+    expect(result).toBe(cfg);
+    expect(service.update).toHaveBeenCalledWith(['warn'], ['system'], 'u');
+    expect(audit.log).toHaveBeenCalledWith(expect.any(AuditEvent));
+    const event = audit.log.mock.calls[0][0] as AuditEvent;
+    expect(event.action).toBe(AuditEventType.AUDIT_CONFIG_UPDATED);
+    expect(event.actorId).toBe('u');
+    expect(event.actorType).toBe('user');
+    expect(event.targetType).toBe('audit-config');
+  });
+});

--- a/backend/usecases/audit/GetAuditConfigUseCase.ts
+++ b/backend/usecases/audit/GetAuditConfigUseCase.ts
@@ -1,0 +1,18 @@
+import { AuditConfigService } from '../../domain/services/AuditConfigService';
+import { AuditConfig } from '../../domain/entities/AuditConfig';
+
+/**
+ * Retrieve the audit configuration using the configured service.
+ */
+export class GetAuditConfigUseCase {
+  constructor(private readonly service: AuditConfigService) {}
+
+  /**
+   * Execute the retrieval.
+   *
+   * @returns The current {@link AuditConfig} or `null` if none exists.
+   */
+  async execute(): Promise<AuditConfig | null> {
+    return this.service.get();
+  }
+}

--- a/backend/usecases/audit/UpdateAuditConfigUseCase.ts
+++ b/backend/usecases/audit/UpdateAuditConfigUseCase.ts
@@ -1,0 +1,41 @@
+import { AuditConfigService } from '../../domain/services/AuditConfigService';
+import { AuditConfig } from '../../domain/entities/AuditConfig';
+import { AuditPort } from '../../domain/ports/AuditPort';
+import { AuditEvent } from '../../domain/entities/AuditEvent';
+import { AuditEventType } from '../../domain/entities/AuditEventType';
+
+/**
+ * Persist audit configuration changes and log the update.
+ */
+export class UpdateAuditConfigUseCase {
+  constructor(
+    private readonly service: AuditConfigService,
+    private readonly audit: AuditPort,
+  ) {}
+
+  /**
+   * Update the configuration and record the change.
+   *
+   * @param levels - Enabled audit levels.
+   * @param categories - Event categories to record.
+   * @param updatedBy - Identifier of the user applying the update.
+   * @returns The updated {@link AuditConfig} instance.
+   */
+  async execute(
+    levels: string[],
+    categories: string[],
+    updatedBy: string,
+  ): Promise<AuditConfig> {
+    const cfg = await this.service.update(levels, categories, updatedBy);
+    await this.audit.log(
+      new AuditEvent(
+        new Date(),
+        updatedBy,
+        'user',
+        AuditEventType.AUDIT_CONFIG_UPDATED,
+        'audit-config',
+      ),
+    );
+    return cfg;
+  }
+}


### PR DESCRIPTION
## Summary
- instantiate `AuditConfigService` with cache and Prisma adapter
- create `GetAuditConfigUseCase` and `UpdateAuditConfigUseCase`
- wire new use cases into audit config controller and server
- keep audit logging middleware unaffected
- update related tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a3c61cd28832386cd1ac249be14c2