### PR TITLE
Switch email adapter to Nodemailer when SMTP configured

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,5 +48,15 @@ REDIS_PORT=6379
 REDIS_USERNAME=
 REDIS_PASSWORD=
 
+# SMTP configuration
+# If SMTP_HOST is empty, emails are logged to the console
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USERNAME=
+SMTP_PASSWORD=
+# Directory containing email templates
+EMAIL_TEMPLATES_PATH=./templates
+
 # Port the HTTP server listens on
 PORT=3000


### PR DESCRIPTION
## Summary
- initialize NodemailerEmailServiceAdapter when SMTP_HOST is provided
- document SMTP settings in `.env.example`

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_688a47b8b1c0832391dcfe682d236add