### PR TITLE
Add RealtimePort interface

### DIFF
--- a/backend/domain/ports/RealtimePort.ts
+++ b/backend/domain/ports/RealtimePort.ts
@@ -1,0 +1,26 @@
+/**
+ * Abstraction for real-time communication methods used by the application.
+ */
+export interface RealtimePort {
+  /**
+   * Emit an event to a specific client or room.
+   *
+   * Implementations should deliver the event only to the targeted
+   * recipient(s), similar to socket.io's `emit`.
+   *
+   * @param event - Name identifying the event to send.
+   * @param payload - Data associated with the event.
+   */
+  emit(event: string, payload: unknown): Promise<void>;
+
+  /**
+   * Broadcast an event to all connected clients.
+   *
+   * Implementations should deliver the event to every subscriber or
+   * connected client.
+   *
+   * @param event - Name identifying the broadcast event.
+   * @param payload - Data associated with the event.
+   */
+  broadcast(event: string, payload: unknown): Promise<void>;
+}

--- a/backend/tests/domain/ports/RealtimePort.test.ts
+++ b/backend/tests/domain/ports/RealtimePort.test.ts
@@ -1,0 +1,25 @@
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
+
+class MockRealtime implements RealtimePort {
+  public emitted: { event: string; payload: unknown }[] = [];
+  public broadcasted: { event: string; payload: unknown }[] = [];
+
+  async emit(event: string, payload: unknown): Promise<void> {
+    this.emitted.push({ event, payload });
+  }
+
+  async broadcast(event: string, payload: unknown): Promise<void> {
+    this.broadcasted.push({ event, payload });
+  }
+}
+
+describe('RealtimePort Interface', () => {
+  it('should record emit and broadcast events', async () => {
+    const rt = new MockRealtime();
+    await rt.emit('ping', { a: 1 });
+    await rt.broadcast('msg', { b: 2 });
+
+    expect(rt.emitted).toEqual([{ event: 'ping', payload: { a: 1 } }]);
+    expect(rt.broadcasted).toEqual([{ event: 'msg', payload: { b: 2 } }]);
+  });
+});


### PR DESCRIPTION
## Summary
- provide `RealtimePort` interface for websocket/event implementations
- test interface behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5140711883238986910aa878cada