### PR TITLE
Implement socket.io realtime adapter

### DIFF
--- a/backend/adapters/realtime/SocketIORealtimeAdapter.ts
+++ b/backend/adapters/realtime/SocketIORealtimeAdapter.ts
@@ -1,0 +1,59 @@
+import { Server } from 'socket.io';
+import { RealtimePort } from '../../domain/ports/RealtimePort';
+import { LoggerPort } from '../../domain/ports/LoggerPort';
+import { getContext } from '../../infrastructure/loggerContext';
+
+/**
+ * Socket.IO implementation of {@link RealtimePort}.
+ *
+ * Provides methods to emit events to specific clients or broadcast
+ * to all connected clients using a Socket.IO {@link Server} instance.
+ */
+export class SocketIORealtimeAdapter implements RealtimePort {
+  /**
+   * Create a new adapter bound to the provided Socket.IO server.
+   *
+   * @param io - Socket.IO server used to dispatch events.
+   * @param logger - Logger instance for debug tracing.
+   */
+  constructor(
+    private readonly io: Server,
+    private readonly logger: LoggerPort,
+  ) {}
+
+  /**
+   * Emit an event to a specific connected client.
+   *
+   * @param socketId - Identifier of the target socket.
+   * @param event - Name of the event to emit.
+   * @param payload - Data associated with the event.
+   */
+  async emit(socketId: string, event: string, payload: unknown): Promise<void>;
+  /** @internal */
+  async emit(event: string, payload: unknown): Promise<void>;
+  async emit(a: string, b: unknown, c?: unknown): Promise<void> {
+    if (c === undefined) {
+      const event = a;
+      const payload = b;
+      this.logger.debug(`Realtime emit ${event}`, getContext());
+      this.io.emit(event, payload);
+    } else {
+      const socketId = a;
+      const event = b as string;
+      const payload = c;
+      this.logger.debug(`Realtime emit to ${socketId} ${event}`, getContext());
+      this.io.to(socketId).emit(event, payload);
+    }
+  }
+
+  /**
+   * Broadcast an event to all connected clients.
+   *
+   * @param event - Name identifying the broadcast event.
+   * @param payload - Data associated with the event.
+   */
+  async broadcast(event: string, payload: unknown): Promise<void> {
+    this.logger.debug(`Realtime broadcast ${event}`, getContext());
+    this.io.emit(event, payload);
+  }
+}

--- a/backend/tests/adapters/realtime/SocketIORealtimeAdapter.test.ts
+++ b/backend/tests/adapters/realtime/SocketIORealtimeAdapter.test.ts
@@ -1,0 +1,44 @@
+import { SocketIORealtimeAdapter } from '../../../adapters/realtime/SocketIORealtimeAdapter';
+import { Server } from 'socket.io';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+
+describe('SocketIORealtimeAdapter', () => {
+  let io: DeepMockProxy<Server> & { to: jest.Mock };
+  let logger: DeepMockProxy<LoggerPort>;
+  let adapter: SocketIORealtimeAdapter;
+
+  beforeEach(() => {
+    io = {
+      to: jest.fn(),
+      emit: jest.fn(),
+    } as unknown as DeepMockProxy<Server> & { to: jest.Mock };
+    logger = mockDeep<LoggerPort>();
+    adapter = new SocketIORealtimeAdapter(io as unknown as Server, logger);
+  });
+
+  it('should emit to specific socket', async () => {
+    const target = { emit: jest.fn() };
+    io.to.mockReturnValue(target as unknown as any);
+
+    await adapter.emit('sock1', 'evt', { a: 1 });
+
+    expect(io.to).toHaveBeenCalledWith('sock1');
+    expect(target.emit).toHaveBeenCalledWith('evt', { a: 1 });
+    expect(logger.debug).toHaveBeenCalledWith('Realtime emit to sock1 evt', undefined);
+  });
+
+  it('should emit using two-argument signature', async () => {
+    await adapter.emit('evt2', { c: 3 });
+
+    expect(io.emit).toHaveBeenCalledWith('evt2', { c: 3 });
+    expect(logger.debug).toHaveBeenCalledWith('Realtime emit evt2', undefined);
+  });
+
+  it('should broadcast to all sockets', async () => {
+    await adapter.broadcast('news', { b: 2 });
+
+    expect(io.emit).toHaveBeenCalledWith('news', { b: 2 });
+    expect(logger.debug).toHaveBeenCalledWith('Realtime broadcast news', undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- add SocketIORealtimeAdapter implementing RealtimePort
- log debug traces during emit and broadcast
- test SocketIORealtimeAdapter

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a53dea74c83238259d13b86da9f42