### PR TITLE
Add group websocket gateway

### DIFF
--- a/backend/adapters/controllers/websocket/groupGateway.ts
+++ b/backend/adapters/controllers/websocket/groupGateway.ts
@@ -1,0 +1,423 @@
+/* istanbul ignore file */
+import { Server, Socket } from 'socket.io';
+import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
+import { UserGroupRepositoryPort } from '../../../domain/ports/UserGroupRepositoryPort';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { getContext } from '../../../infrastructure/loggerContext';
+import { User } from '../../../domain/entities/User';
+import { UserGroup } from '../../../domain/entities/UserGroup';
+import { CreateUserGroupUseCase } from '../../../usecases/group/CreateUserGroupUseCase';
+import { GetUserGroupsUseCase } from '../../../usecases/group/GetUserGroupsUseCase';
+import { UpdateUserGroupUseCase } from '../../../usecases/group/UpdateUserGroupUseCase';
+import { RemoveUserGroupUseCase } from '../../../usecases/group/RemoveUserGroupUseCase';
+import { AddGroupUserUseCase } from '../../../usecases/group/AddGroupUserUseCase';
+import { RemoveGroupUserUseCase } from '../../../usecases/group/RemoveGroupUserUseCase';
+import { AddGroupResponsibleUseCase } from '../../../usecases/group/AddGroupResponsibleUseCase';
+import { RemoveGroupResponsibleUseCase } from '../../../usecases/group/RemoveGroupResponsibleUseCase';
+import { GetGroupMembersUseCase } from '../../../usecases/group/GetGroupMembersUseCase';
+import { GetGroupResponsiblesUseCase } from '../../../usecases/group/GetGroupResponsiblesUseCase';
+
+interface AuthedSocket extends Socket {
+  user: User;
+}
+
+interface ListParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+}
+
+interface GroupPayload {
+  id: string;
+  name: string;
+  description?: string;
+  responsibleIds?: string[];
+}
+
+export function registerGroupGateway(
+  io: Server,
+  authService: AuthServicePort,
+  logger: LoggerPort,
+  realtime: RealtimePort,
+  groupRepository: UserGroupRepositoryPort,
+  userRepository: UserRepositoryPort,
+): void {
+  io.use(async (socket, next): Promise<void> => {
+    logger.debug('WebSocket auth middleware', getContext());
+    const token = socket.handshake.auth?.token;
+    if (!token) {
+      return next(new Error('Unauthorized'));
+    }
+    try {
+      const user = await authService.verifyToken(token);
+      (socket as AuthedSocket).user = user;
+      logger.debug('WebSocket auth success', getContext());
+      next();
+    } catch {
+      logger.warn('WebSocket auth failed', getContext());
+      next(new Error('Unauthorized'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const authed = socket as AuthedSocket;
+    const checker = new PermissionChecker(authed.user);
+
+    socket.on('ping', () => {
+      socket.emit('pong', { userId: authed.user.id });
+    });
+
+    socket.on('group-list-request', async (params: ListParams) => {
+      logger.info('group-list-request', getContext());
+      const page = Number(params?.page ?? 1);
+      const limit = Number(params?.limit ?? 20);
+      if (Number.isNaN(page) || page < 1 || Number.isNaN(limit) || limit < 1) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const useCase = new GetUserGroupsUseCase(groupRepository, checker);
+      try {
+        const result = await useCase.execute({
+          page,
+          limit,
+          filters: { search: params?.search },
+        });
+        socket.emit('group-list-response', result);
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        logger.error('group-list-request failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('group-get', async (payload: { id: string }) => {
+      logger.info('group-get', getContext());
+      if (!payload || typeof payload.id !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check('read-group');
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const group = await groupRepository.findById(payload.id);
+      if (!group) {
+        socket.emit('error', { error: 'Not found' });
+        return;
+      }
+      socket.emit('group-get-response', group);
+    });
+
+    socket.on(
+      'group-members-request',
+      async (payload: { id: string } & ListParams) => {
+        logger.info('group-members-request', getContext());
+        const page = Number(payload?.page ?? 1);
+        const limit = Number(payload?.limit ?? 20);
+        if (
+          !payload ||
+          typeof payload.id !== 'string' ||
+          Number.isNaN(page) ||
+          page < 1 ||
+          Number.isNaN(limit) ||
+          limit < 1
+        ) {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const useCase = new GetGroupMembersUseCase(groupRepository, checker);
+        try {
+          const result = await useCase.execute(payload.id, {
+            page,
+            limit,
+            filters: { search: payload.search },
+          });
+          socket.emit('group-members-response', result);
+        } catch (err) {
+          if ((err as Error).message === 'Forbidden') {
+            socket.emit('error', { error: 'Forbidden' });
+            return;
+          }
+          logger.error('group-members-request failed', {
+            ...getContext(),
+            error: err,
+          });
+        }
+      },
+    );
+
+    socket.on(
+      'group-responsibles-request',
+      async (payload: { id: string } & ListParams) => {
+        logger.info('group-responsibles-request', getContext());
+        const page = Number(payload?.page ?? 1);
+        const limit = Number(payload?.limit ?? 20);
+        if (
+          !payload ||
+          typeof payload.id !== 'string' ||
+          Number.isNaN(page) ||
+          page < 1 ||
+          Number.isNaN(limit) ||
+          limit < 1
+        ) {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const useCase = new GetGroupResponsiblesUseCase(groupRepository, checker);
+        try {
+          const result = await useCase.execute(payload.id, {
+            page,
+            limit,
+            filters: { search: payload.search },
+          });
+          socket.emit('group-responsibles-response', result);
+        } catch (err) {
+          if ((err as Error).message === 'Forbidden') {
+            socket.emit('error', { error: 'Forbidden' });
+            return;
+          }
+          logger.error('group-responsibles-request failed', {
+            ...getContext(),
+            error: err,
+          });
+        }
+      },
+    );
+
+    socket.on('group-create', async (payload: GroupPayload) => {
+      logger.info('group-create', getContext());
+      if (!payload || typeof payload.id !== 'string' || typeof payload.name !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const responsibles = await Promise.all(
+        (payload.responsibleIds ?? []).map((id) => userRepository.findById(id)),
+      );
+      const valid = responsibles.filter((u): u is User => !!u);
+      const group = new UserGroup(payload.id, payload.name, valid, [], payload.description);
+      const useCase = new CreateUserGroupUseCase(groupRepository, checker);
+      try {
+        const created = await useCase.execute(group);
+        socket.emit('group-create-response', created);
+        await realtime.broadcast('group-changed', { id: created.id });
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        logger.error('group-create failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('group-update', async (payload: GroupPayload) => {
+      logger.info('group-update', getContext());
+      if (!payload || typeof payload.id !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const group = await groupRepository.findById(payload.id);
+      if (!group) {
+        socket.emit('error', { error: 'Not found' });
+        return;
+      }
+      if (!group.responsibleUsers.some((u) => u.id === authed.user.id)) {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      group.name = payload.name ?? group.name;
+      group.description = payload.description ?? group.description;
+      const useCase = new UpdateUserGroupUseCase(groupRepository, checker);
+      try {
+        const updated = await useCase.execute(group);
+        socket.emit('group-update-response', updated);
+        await realtime.broadcast('group-changed', { id: updated.id });
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        logger.error('group-update failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('group-delete', async (payload: { id: string }) => {
+      logger.info('group-delete', getContext());
+      if (!payload || typeof payload.id !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const group = await groupRepository.findById(payload.id);
+      if (!group) {
+        socket.emit('error', { error: 'Not found' });
+        return;
+      }
+      if (!group.responsibleUsers.some((u) => u.id === authed.user.id)) {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const useCase = new RemoveUserGroupUseCase(groupRepository, checker);
+      try {
+        await useCase.execute(payload.id);
+        socket.emit('group-delete-response', { id: payload.id });
+        await realtime.broadcast('group-changed', { id: payload.id });
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        logger.error('group-delete failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on(
+      'group-add-user',
+      async (payload: { groupId: string; userId: string }) => {
+        logger.info('group-add-user', getContext());
+        if (!payload || typeof payload.groupId !== 'string' || typeof payload.userId !== 'string') {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const group = await groupRepository.findById(payload.groupId);
+        if (!group) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        if (!group.responsibleUsers.some((u) => u.id === authed.user.id)) {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        const useCase = new AddGroupUserUseCase(groupRepository, userRepository, checker);
+        try {
+          const updated = await useCase.execute(payload.groupId, payload.userId);
+          if (!updated) {
+            socket.emit('error', { error: 'Not found' });
+            return;
+          }
+          socket.emit('group-add-user-response', updated);
+          await realtime.broadcast('group-changed', { id: updated.id });
+        } catch (err) {
+          if ((err as Error).message === 'Forbidden') {
+            socket.emit('error', { error: 'Forbidden' });
+            return;
+          }
+          logger.error('group-add-user failed', { ...getContext(), error: err });
+        }
+      },
+    );
+
+    socket.on(
+      'group-remove-user',
+      async (payload: { groupId: string; userId: string }) => {
+        logger.info('group-remove-user', getContext());
+        if (!payload || typeof payload.groupId !== 'string' || typeof payload.userId !== 'string') {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const group = await groupRepository.findById(payload.groupId);
+        if (!group) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        if (!group.responsibleUsers.some((u) => u.id === authed.user.id)) {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        const useCase = new RemoveGroupUserUseCase(groupRepository, userRepository, checker);
+        try {
+          const updated = await useCase.execute(payload.groupId, payload.userId);
+          if (!updated) {
+            socket.emit('error', { error: 'Not found' });
+            return;
+          }
+          socket.emit('group-remove-user-response', updated);
+          await realtime.broadcast('group-changed', { id: updated.id });
+        } catch (err) {
+          if ((err as Error).message === 'Forbidden') {
+            socket.emit('error', { error: 'Forbidden' });
+            return;
+          }
+          logger.error('group-remove-user failed', { ...getContext(), error: err });
+        }
+      },
+    );
+
+    socket.on(
+      'group-add-responsible',
+      async (payload: { groupId: string; userId: string }) => {
+        logger.info('group-add-responsible', getContext());
+        if (!payload || typeof payload.groupId !== 'string' || typeof payload.userId !== 'string') {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const group = await groupRepository.findById(payload.groupId);
+        if (!group) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        if (!group.responsibleUsers.some((u) => u.id === authed.user.id)) {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        const useCase = new AddGroupResponsibleUseCase(groupRepository, userRepository, checker);
+        try {
+          const updated = await useCase.execute(payload.groupId, payload.userId);
+          if (!updated) {
+            socket.emit('error', { error: 'Not found' });
+            return;
+          }
+          socket.emit('group-add-responsible-response', updated);
+          await realtime.broadcast('group-changed', { id: updated.id });
+        } catch (err) {
+          if ((err as Error).message === 'Forbidden') {
+            socket.emit('error', { error: 'Forbidden' });
+            return;
+          }
+          logger.error('group-add-responsible failed', { ...getContext(), error: err });
+        }
+      },
+    );
+
+    socket.on(
+      'group-remove-responsible',
+      async (payload: { groupId: string; userId: string }) => {
+        logger.info('group-remove-responsible', getContext());
+        if (!payload || typeof payload.groupId !== 'string' || typeof payload.userId !== 'string') {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const group = await groupRepository.findById(payload.groupId);
+        if (!group) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        if (!group.responsibleUsers.some((u) => u.id === authed.user.id)) {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        const useCase = new RemoveGroupResponsibleUseCase(groupRepository, userRepository, checker);
+        try {
+          const updated = await useCase.execute(payload.groupId, payload.userId);
+          if (!updated) {
+            socket.emit('error', { error: 'Not found' });
+            return;
+          }
+          socket.emit('group-remove-responsible-response', updated);
+          await realtime.broadcast('group-changed', { id: updated.id });
+        } catch (err) {
+          if ((err as Error).message === 'Forbidden') {
+            socket.emit('error', { error: 'Forbidden' });
+            return;
+          }
+          logger.error('group-remove-responsible failed', { ...getContext(), error: err });
+        }
+      },
+    );
+  });
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -11,12 +11,14 @@ import { createRoleRouter } from '../adapters/controllers/rest/roleController';
 import { createAuditRouter } from '../adapters/controllers/rest/auditController';
 import { registerUserGateway } from '../adapters/controllers/websocket/userGateway';
 import { registerDepartmentGateway } from '../adapters/controllers/websocket/departmentGateway';
+import { registerGroupGateway } from '../adapters/controllers/websocket/groupGateway';
 import { SocketIORealtimeAdapter } from '../adapters/realtime/SocketIORealtimeAdapter';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
 import { PrismaRoleRepository } from '../adapters/repositories/PrismaRoleRepository';
 import { PrismaPermissionRepository } from '../adapters/repositories/PrismaPermissionRepository';
 import { PrismaDepartmentRepository } from '../adapters/repositories/PrismaDepartmentRepository';
+import { PrismaUserGroupRepository } from '../adapters/repositories/PrismaUserGroupRepository';
 import { JWTAuthServiceAdapter } from '../adapters/auth/JWTAuthServiceAdapter';
 import { JWTTokenServiceAdapter } from '../adapters/token/JWTTokenServiceAdapter';
 import { ConsoleLoggerAdapter } from '../adapters/logger/ConsoleLoggerAdapter';
@@ -59,6 +61,7 @@ async function bootstrap(): Promise<void> {
   const invitationRepository = new PrismaInvitationRepository(prisma, logger);
   const permissionRepository = new PrismaPermissionRepository(prisma, logger);
   const departmentRepository = new PrismaDepartmentRepository(prisma, logger);
+  const groupRepository = new PrismaUserGroupRepository(prisma, logger);
   const emailService = process.env.SMTP_HOST && process.env.SMTP_HOST.trim()
     ? new NodemailerEmailServiceAdapter(
       {
@@ -220,6 +223,14 @@ async function bootstrap(): Promise<void> {
     logger,
     realtime,
     departmentRepository,
+    userRepository,
+  );
+  registerGroupGateway(
+    io,
+    authService,
+    logger,
+    realtime,
+    groupRepository,
     userRepository,
   );
 

--- a/backend/tests/adapters/controllers/websocket/groupGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/groupGateway.test.ts
@@ -1,0 +1,232 @@
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import * as ioClient from 'socket.io-client';
+import { registerGroupGateway } from '../../../../adapters/controllers/websocket/groupGateway';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
+import { RealtimePort } from '../../../../domain/ports/RealtimePort';
+import { UserGroupRepositoryPort } from '../../../../domain/ports/UserGroupRepositoryPort';
+import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { UserGroup } from '../../../../domain/entities/UserGroup';
+import { User } from '../../../../domain/entities/User';
+import { Role } from '../../../../domain/entities/Role';
+import { Department } from '../../../../domain/entities/Department';
+import { Site } from '../../../../domain/entities/Site';
+import { Permission } from '../../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
+
+describe('Group WebSocket gateway', () => {
+  let io: Server;
+  let httpServer: ReturnType<typeof createServer>;
+  let url: string;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let realtime: DeepMockProxy<RealtimePort>;
+  let groupRepo: DeepMockProxy<UserGroupRepositoryPort>;
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let site: Site;
+  let dept: Department;
+  let role: Role;
+  let user: User;
+  let group: UserGroup;
+
+  beforeEach((done) => {
+    httpServer = createServer();
+    io = new Server(httpServer);
+    auth = mockDeep<AuthServicePort>();
+    logger = mockDeep<LoggerPort>();
+    realtime = mockDeep<RealtimePort>();
+    groupRepo = mockDeep<UserGroupRepositoryPort>();
+    userRepo = mockDeep<UserRepositoryPort>();
+    site = new Site('s', 'Site');
+    dept = new Department('d', 'Dept', null, null, site);
+    role = new Role('r', 'Role', [
+      new Permission('p1', PermissionKeys.READ_GROUPS, ''),
+      new Permission('p2', PermissionKeys.CREATE_GROUP, ''),
+      new Permission('p3', PermissionKeys.UPDATE_GROUP, ''),
+      new Permission('p4', PermissionKeys.DELETE_GROUP, ''),
+      new Permission('p5', PermissionKeys.MANAGE_GROUP_MEMBERS, ''),
+      new Permission('p6', PermissionKeys.MANAGE_GROUP_RESPONSIBLES, ''),
+      new Permission('p7', PermissionKeys.READ_GROUP, ''),
+    ]);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
+    group = new UserGroup('g', 'Group', [user], [user]);
+    auth.verifyToken.mockResolvedValue(user);
+    registerGroupGateway(io, auth, logger, realtime, groupRepo, userRepo);
+    httpServer.listen(() => {
+      const address = httpServer.address() as any;
+      url = `http://localhost:${address.port}`;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    io.close();
+    httpServer.close(done);
+  });
+
+  it('should authenticate socket connections', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('ping');
+    });
+    client.on('pong', (data: unknown) => {
+      expect(data).toEqual({ userId: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('emits group list when permitted', (done) => {
+    groupRepo.findPage.mockResolvedValue({ items: [group], page: 1, limit: 20, total: 1 });
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-list-request', { page: 1, limit: 20 });
+    });
+    client.on('group-list-response', (data: any) => {
+      expect(data.items[0].id).toBe('g');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits group get', (done) => {
+    groupRepo.findById.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-get', { id: 'g' });
+    });
+    client.on('group-get-response', (data: any) => {
+      expect(data.id).toBe('g');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits group members', (done) => {
+    groupRepo.listMembers.mockResolvedValue({ items: [user], page: 1, limit: 20, total: 1 });
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-members-request', { id: 'g', page: 1, limit: 20 });
+    });
+    client.on('group-members-response', (data: any) => {
+      expect(data.items[0].id).toBe('u');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits group responsibles', (done) => {
+    groupRepo.listResponsibles.mockResolvedValue({ items: [user], page: 1, limit: 20, total: 1 });
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-responsibles-request', { id: 'g', page: 1, limit: 20 });
+    });
+    client.on('group-responsibles-response', (data: any) => {
+      expect(data.items[0].id).toBe('u');
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts group-changed on create', (done) => {
+    groupRepo.create.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-create', { id: 'g', name: 'Group' });
+    });
+    client.on('group-create-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('group-changed', { id: 'g' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts group-changed on update', (done) => {
+    groupRepo.findById.mockResolvedValue(group);
+    groupRepo.update.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-update', { id: 'g', name: 'Group' });
+    });
+    client.on('group-update-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('group-changed', { id: 'g' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts group-changed on delete', (done) => {
+    groupRepo.findById.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-delete', { id: 'g' });
+    });
+    client.on('group-delete-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('group-changed', { id: 'g' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts group-changed on add user', (done) => {
+    groupRepo.findById.mockResolvedValue(group);
+    userRepo.findById.mockResolvedValue(user);
+    groupRepo.addUser.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-add-user', { groupId: 'g', userId: 'u2' });
+    });
+    client.on('group-add-user-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('group-changed', { id: 'g' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts group-changed on remove user', (done) => {
+    groupRepo.findById.mockResolvedValue(group);
+    userRepo.findById.mockResolvedValue(user);
+    groupRepo.removeUser.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-remove-user', { groupId: 'g', userId: 'u2' });
+    });
+    client.on('group-remove-user-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('group-changed', { id: 'g' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts group-changed on add responsible', (done) => {
+    groupRepo.findById.mockResolvedValue(group);
+    userRepo.findById.mockResolvedValue(user);
+    groupRepo.addResponsible.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-add-responsible', { groupId: 'g', userId: 'u2' });
+    });
+    client.on('group-add-responsible-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('group-changed', { id: 'g' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts group-changed on remove responsible', (done) => {
+    groupRepo.findById.mockResolvedValue(group);
+    userRepo.findById.mockResolvedValue(user);
+    groupRepo.removeResponsible.mockResolvedValue(group);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('group-remove-responsible', { groupId: 'g', userId: 'u2' });
+    });
+    client.on('group-remove-responsible-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('group-changed', { id: 'g' });
+      client.close();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `groupGateway` websocket controller
- expose group gateway in server bootstrap
- test the group gateway websocket handlers

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a66461c50832388e3e2ff5692ccf1