### PR TITLE
Add websocket site gateway

### DIFF
--- a/backend/adapters/controllers/websocket/siteGateway.ts
+++ b/backend/adapters/controllers/websocket/siteGateway.ts
@@ -1,0 +1,190 @@
+/* istanbul ignore file */
+import { Server, Socket } from 'socket.io';
+import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
+import { SiteRepositoryPort } from '../../../domain/ports/SiteRepositoryPort';
+import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
+import { DepartmentRepositoryPort } from '../../../domain/ports/DepartmentRepositoryPort';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { getContext } from '../../../infrastructure/loggerContext';
+import { User } from '../../../domain/entities/User';
+import { Site } from '../../../domain/entities/Site';
+import { CreateSiteUseCase } from '../../../usecases/site/CreateSiteUseCase';
+import { UpdateSiteUseCase } from '../../../usecases/site/UpdateSiteUseCase';
+import { RemoveSiteUseCase } from '../../../usecases/site/RemoveSiteUseCase';
+import { GetSitesUseCase } from '../../../usecases/site/GetSitesUseCase';
+import { GetSiteUseCase } from '../../../usecases/site/GetSiteUseCase';
+
+interface AuthedSocket extends Socket {
+  user: User;
+}
+
+interface ListParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+}
+
+interface SitePayload {
+  id: string;
+  label: string;
+}
+
+export function registerSiteGateway(
+  io: Server,
+  authService: AuthServicePort,
+  logger: LoggerPort,
+  realtime: RealtimePort,
+  siteRepository: SiteRepositoryPort,
+  userRepository: UserRepositoryPort,
+  departmentRepository: DepartmentRepositoryPort,
+): void {
+  io.use(async (socket, next): Promise<void> => {
+    logger.debug('WebSocket auth middleware', getContext());
+    const token = socket.handshake.auth?.token;
+    if (!token) {
+      return next(new Error('Unauthorized'));
+    }
+    try {
+      const user = await authService.verifyToken(token);
+      (socket as AuthedSocket).user = user;
+      logger.debug('WebSocket auth success', getContext());
+      next();
+    } catch {
+      logger.warn('WebSocket auth failed', getContext());
+      next(new Error('Unauthorized'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const authed = socket as AuthedSocket;
+    const checker = new PermissionChecker(authed.user);
+
+    socket.on('ping', () => {
+      socket.emit('pong', { userId: authed.user.id });
+    });
+
+    socket.on('site-list-request', async (params: ListParams) => {
+      logger.info('site-list-request', getContext());
+      const page = Number(params?.page ?? 1);
+      const limit = Number(params?.limit ?? 20);
+      if (Number.isNaN(page) || page < 1 || Number.isNaN(limit) || limit < 1) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.READ_SITES);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const useCase = new GetSitesUseCase(siteRepository);
+      try {
+        const result = await useCase.execute({
+          page,
+          limit,
+          filters: { search: params?.search },
+        });
+        socket.emit('site-list-response', result);
+      } catch (err) {
+        logger.error('site-list-request failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('site-get', async (payload: { id: string }) => {
+      logger.info('site-get', getContext());
+      if (!payload || typeof payload.id !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.READ_SITE);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const useCase = new GetSiteUseCase(siteRepository);
+      try {
+        const site = await useCase.execute(payload.id);
+        if (!site) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        socket.emit('site-get-response', site);
+      } catch (err) {
+        logger.error('site-get failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('site-create', async (payload: SitePayload) => {
+      logger.info('site-create', getContext());
+      if (!payload || typeof payload.id !== 'string' || typeof payload.label !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.MANAGE_SITES);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const site = new Site(payload.id, payload.label);
+      const useCase = new CreateSiteUseCase(siteRepository);
+      try {
+        const created = await useCase.execute(site);
+        socket.emit('site-create-response', created);
+        await realtime.broadcast('site-changed', { id: created.id });
+      } catch (err) {
+        logger.error('site-create failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('site-update', async (payload: SitePayload) => {
+      logger.info('site-update', getContext());
+      if (!payload || typeof payload.id !== 'string' || typeof payload.label !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.MANAGE_SITES);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const site = new Site(payload.id, payload.label);
+      const useCase = new UpdateSiteUseCase(siteRepository);
+      try {
+        const updated = await useCase.execute(site);
+        socket.emit('site-update-response', updated);
+        await realtime.broadcast('site-changed', { id: updated.id });
+      } catch (err) {
+        logger.error('site-update failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('site-delete', async (payload: { id: string }) => {
+      logger.info('site-delete', getContext());
+      if (!payload || typeof payload.id !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.MANAGE_SITES);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const useCase = new RemoveSiteUseCase(siteRepository, userRepository, departmentRepository);
+      try {
+        await useCase.execute(payload.id);
+        socket.emit('site-delete-response', { id: payload.id });
+        await realtime.broadcast('site-changed', { id: payload.id });
+      } catch (err) {
+        socket.emit('error', { error: (err as Error).message });
+        logger.error('site-delete failed', { ...getContext(), error: err });
+      }
+    });
+  });
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -14,6 +14,7 @@ import { registerDepartmentGateway } from '../adapters/controllers/websocket/dep
 import { registerGroupGateway } from '../adapters/controllers/websocket/groupGateway';
 import { registerRoleGateway } from '../adapters/controllers/websocket/roleGateway';
 import { registerInvitationGateway } from '../adapters/controllers/websocket/invitationGateway';
+import { registerSiteGateway } from '../adapters/controllers/websocket/siteGateway';
 import { SocketIORealtimeAdapter } from '../adapters/realtime/SocketIORealtimeAdapter';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
@@ -21,6 +22,7 @@ import { PrismaRoleRepository } from '../adapters/repositories/PrismaRoleReposit
 import { PrismaPermissionRepository } from '../adapters/repositories/PrismaPermissionRepository';
 import { PrismaDepartmentRepository } from '../adapters/repositories/PrismaDepartmentRepository';
 import { PrismaUserGroupRepository } from '../adapters/repositories/PrismaUserGroupRepository';
+import { PrismaSiteRepository } from '../adapters/repositories/PrismaSiteRepository';
 import { JWTAuthServiceAdapter } from '../adapters/auth/JWTAuthServiceAdapter';
 import { JWTTokenServiceAdapter } from '../adapters/token/JWTTokenServiceAdapter';
 import { ConsoleLoggerAdapter } from '../adapters/logger/ConsoleLoggerAdapter';
@@ -64,6 +66,7 @@ async function bootstrap(): Promise<void> {
   const permissionRepository = new PrismaPermissionRepository(prisma, logger);
   const departmentRepository = new PrismaDepartmentRepository(prisma, logger);
   const groupRepository = new PrismaUserGroupRepository(prisma, logger);
+  const siteRepository = new PrismaSiteRepository(prisma, logger);
   const emailService = process.env.SMTP_HOST && process.env.SMTP_HOST.trim()
     ? new NodemailerEmailServiceAdapter(
       {
@@ -226,6 +229,15 @@ async function bootstrap(): Promise<void> {
     realtime,
     departmentRepository,
     userRepository,
+  );
+  registerSiteGateway(
+    io,
+    authService,
+    logger,
+    realtime,
+    siteRepository,
+    userRepository,
+    departmentRepository,
   );
   registerGroupGateway(
     io,

--- a/backend/tests/adapters/controllers/websocket/siteGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/siteGateway.test.ts
@@ -1,0 +1,212 @@
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import * as ioClient from 'socket.io-client';
+import { registerSiteGateway } from '../../../../adapters/controllers/websocket/siteGateway';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
+import { RealtimePort } from '../../../../domain/ports/RealtimePort';
+import { SiteRepositoryPort } from '../../../../domain/ports/SiteRepositoryPort';
+import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort';
+import { DepartmentRepositoryPort } from '../../../../domain/ports/DepartmentRepositoryPort';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { Site } from '../../../../domain/entities/Site';
+import { Department } from '../../../../domain/entities/Department';
+import { Role } from '../../../../domain/entities/Role';
+import { User } from '../../../../domain/entities/User';
+import { Permission } from '../../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
+
+describe('Site WebSocket gateway', () => {
+  let io: Server;
+  let httpServer: ReturnType<typeof createServer>;
+  let url: string;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let realtime: DeepMockProxy<RealtimePort>;
+  let siteRepo: DeepMockProxy<SiteRepositoryPort>;
+  let userRepo: DeepMockProxy<UserRepositoryPort>;
+  let deptRepo: DeepMockProxy<DepartmentRepositoryPort>;
+  let site: Site;
+  let department: Department;
+  let role: Role;
+  let user: User;
+
+  beforeEach((done) => {
+    httpServer = createServer();
+    io = new Server(httpServer);
+    auth = mockDeep<AuthServicePort>();
+    logger = mockDeep<LoggerPort>();
+    realtime = mockDeep<RealtimePort>();
+    siteRepo = mockDeep<SiteRepositoryPort>();
+    userRepo = mockDeep<UserRepositoryPort>();
+    deptRepo = mockDeep<DepartmentRepositoryPort>();
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+    role = new Role('r', 'Role', [
+      new Permission('p1', PermissionKeys.READ_SITES, ''),
+      new Permission('p2', PermissionKeys.READ_SITE, ''),
+      new Permission('p3', PermissionKeys.MANAGE_SITES, ''),
+    ]);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+    auth.verifyToken.mockResolvedValue(user);
+    registerSiteGateway(io, auth, logger, realtime, siteRepo, userRepo, deptRepo);
+    httpServer.listen(() => {
+      const address = httpServer.address() as any;
+      url = `http://localhost:${address.port}`;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    io.close();
+    httpServer.close(done);
+  });
+
+  it('should authenticate socket connections', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('ping');
+    });
+    client.on('pong', (data: unknown) => {
+      expect(data).toEqual({ userId: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject invalid token', (done) => {
+    auth.verifyToken.mockRejectedValue(new Error('bad'));
+    const client = ioClient.connect(url, { auth: { token: 'bad' } });
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject connection without token', (done) => {
+    const client = ioClient.connect(url);
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits site list when permitted', (done) => {
+    siteRepo.findPage.mockResolvedValue({ items: [site], page: 1, limit: 20, total: 1 });
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-list-request', { page: 1, limit: 20 });
+    });
+    client.on('site-list-response', (data: any) => {
+      expect(data.items[0].id).toBe('s');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid list parameters', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-list-request', { page: 'a' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits site get', (done) => {
+    siteRepo.findById.mockResolvedValue(site);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-get', { id: 's' });
+    });
+    client.on('site-get-response', (data: any) => {
+      expect(data.id).toBe('s');
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts site-changed on create', (done) => {
+    siteRepo.create.mockResolvedValue(site);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-create', { id: 's', label: 'Site' });
+    });
+    client.on('site-create-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('site-changed', { id: 's' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts site-changed on update', (done) => {
+    siteRepo.update.mockResolvedValue(site);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-update', { id: 's', label: 'Site' });
+    });
+    client.on('site-update-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('site-changed', { id: 's' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts site-changed on delete', (done) => {
+    siteRepo.delete.mockResolvedValue();
+    userRepo.findBySiteId.mockResolvedValue([]);
+    deptRepo.findBySiteId.mockResolvedValue([]);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-delete', { id: 's' });
+    });
+    client.on('site-delete-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('site-changed', { id: 's' });
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 't' } });
+    client.on('connect', () => {
+      client.emit('site-list-request', { page: 1, limit: 20 });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects create when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-create', { id: 's', label: 'Site' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid create payload', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('site-create', { bad: true });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add websocket gateway for site CRUD operations
- test websocket site gateway
- hook up site gateway in the server bootstrap

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a6d4dd114832394203d9f1bc788c8