### PR TITLE
Add permission websocket gateway

### DIFF
--- a/backend/adapters/controllers/websocket/permissionGateway.ts
+++ b/backend/adapters/controllers/websocket/permissionGateway.ts
@@ -1,0 +1,170 @@
+/* istanbul ignore file */
+import { Server, Socket } from 'socket.io';
+import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
+import { PermissionRepositoryPort } from '../../../domain/ports/PermissionRepositoryPort';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { getContext } from '../../../infrastructure/loggerContext';
+import { User } from '../../../domain/entities/User';
+import { Permission } from '../../../domain/entities/Permission';
+import { GetPermissionsUseCase } from '../../../usecases/permission/GetPermissionsUseCase';
+import { CreatePermissionUseCase } from '../../../usecases/permission/CreatePermissionUseCase';
+import { UpdatePermissionUseCase } from '../../../usecases/permission/UpdatePermissionUseCase';
+import { RemovePermissionUseCase } from '../../../usecases/permission/RemovePermissionUseCase';
+
+interface AuthedSocket extends Socket {
+  user: User;
+}
+
+interface ListParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+}
+
+interface PermissionPayload {
+  id: string;
+  permissionKey: string;
+  description: string;
+}
+
+export function registerPermissionGateway(
+  io: Server,
+  authService: AuthServicePort,
+  logger: LoggerPort,
+  realtime: RealtimePort,
+  permissionRepository: PermissionRepositoryPort,
+): void {
+  io.use(async (socket, next): Promise<void> => {
+    logger.debug('WebSocket auth middleware', getContext());
+    const token = socket.handshake.auth?.token;
+    if (!token) {
+      return next(new Error('Unauthorized'));
+    }
+    try {
+      const user = await authService.verifyToken(token);
+      (socket as AuthedSocket).user = user;
+      logger.debug('WebSocket auth success', getContext());
+      next();
+    } catch {
+      logger.warn('WebSocket auth failed', getContext());
+      next(new Error('Unauthorized'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const authed = socket as AuthedSocket;
+    const checker = new PermissionChecker(authed.user);
+
+    socket.on('ping', () => {
+      socket.emit('pong', { userId: authed.user.id });
+    });
+
+    socket.on('permission-list-request', async (params: ListParams) => {
+      logger.info('permission-list-request', getContext());
+      const page = Number(params?.page ?? 1);
+      const limit = Number(params?.limit ?? 20);
+      if (Number.isNaN(page) || page < 1 || Number.isNaN(limit) || limit < 1) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.READ_PERMISSIONS);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const useCase = new GetPermissionsUseCase(permissionRepository);
+      try {
+        const result = await useCase.execute({
+          page,
+          limit,
+          filters: { search: params?.search },
+        });
+        socket.emit('permission-list-response', result);
+      } catch (err) {
+        logger.error('permission-list-request failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('permission-create', async (payload: PermissionPayload) => {
+      logger.info('permission-create', getContext());
+      if (
+        !payload ||
+        typeof payload.id !== 'string' ||
+        typeof payload.permissionKey !== 'string' ||
+        typeof payload.description !== 'string'
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.CREATE_PERMISSION);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const permission = new Permission(payload.id, payload.permissionKey, payload.description);
+      const useCase = new CreatePermissionUseCase(permissionRepository);
+      try {
+        const created = await useCase.execute(permission);
+        socket.emit('permission-create-response', created);
+        await realtime.broadcast('permission-changed', { id: created.id });
+      } catch (err) {
+        logger.error('permission-create failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('permission-update', async (payload: PermissionPayload) => {
+      logger.info('permission-update', getContext());
+      if (
+        !payload ||
+        typeof payload.id !== 'string' ||
+        typeof payload.permissionKey !== 'string' ||
+        typeof payload.description !== 'string'
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.UPDATE_PERMISSION);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const permission = new Permission(payload.id, payload.permissionKey, payload.description);
+      const useCase = new UpdatePermissionUseCase(permissionRepository);
+      try {
+        const updated = await useCase.execute(permission);
+        socket.emit('permission-update-response', updated);
+        await realtime.broadcast('permission-changed', { id: updated.id });
+      } catch (err) {
+        logger.error('permission-update failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('permission-delete', async (payload: { id: string }) => {
+      logger.info('permission-delete', getContext());
+      if (!payload || typeof payload.id !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.DELETE_PERMISSION);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const useCase = new RemovePermissionUseCase(permissionRepository);
+      try {
+        await useCase.execute(payload.id);
+        socket.emit('permission-delete-response', { id: payload.id });
+        await realtime.broadcast('permission-changed', { id: payload.id });
+      } catch (err) {
+        logger.error('permission-delete failed', { ...getContext(), error: err });
+      }
+    });
+  });
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -15,6 +15,7 @@ import { registerGroupGateway } from '../adapters/controllers/websocket/groupGat
 import { registerRoleGateway } from '../adapters/controllers/websocket/roleGateway';
 import { registerInvitationGateway } from '../adapters/controllers/websocket/invitationGateway';
 import { registerSiteGateway } from '../adapters/controllers/websocket/siteGateway';
+import { registerPermissionGateway } from '../adapters/controllers/websocket/permissionGateway';
 import { SocketIORealtimeAdapter } from '../adapters/realtime/SocketIORealtimeAdapter';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
@@ -254,6 +255,13 @@ async function bootstrap(): Promise<void> {
     realtime,
     roleRepository,
     userRepository,
+  );
+  registerPermissionGateway(
+    io,
+    authService,
+    logger,
+    realtime,
+    permissionRepository,
   );
   registerInvitationGateway(
     io,

--- a/backend/tests/adapters/controllers/websocket/permissionGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/permissionGateway.test.ts
@@ -1,0 +1,194 @@
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import * as ioClient from 'socket.io-client';
+import { registerPermissionGateway } from '../../../../adapters/controllers/websocket/permissionGateway';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
+import { RealtimePort } from '../../../../domain/ports/RealtimePort';
+import { PermissionRepositoryPort } from '../../../../domain/ports/PermissionRepositoryPort';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { Permission } from '../../../../domain/entities/Permission';
+import { Role } from '../../../../domain/entities/Role';
+import { User } from '../../../../domain/entities/User';
+import { Department } from '../../../../domain/entities/Department';
+import { Site } from '../../../../domain/entities/Site';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
+
+describe('Permission WebSocket gateway', () => {
+  let io: Server;
+  let httpServer: ReturnType<typeof createServer>;
+  let url: string;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let realtime: DeepMockProxy<RealtimePort>;
+  let permRepo: DeepMockProxy<PermissionRepositoryPort>;
+  let permission: Permission;
+  let role: Role;
+  let user: User;
+  let site: Site;
+  let department: Department;
+
+  beforeEach((done) => {
+    httpServer = createServer();
+    io = new Server(httpServer);
+    auth = mockDeep<AuthServicePort>();
+    logger = mockDeep<LoggerPort>();
+    realtime = mockDeep<RealtimePort>();
+    permRepo = mockDeep<PermissionRepositoryPort>();
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+    permission = new Permission('p', 'TEST', 'desc');
+    role = new Role('r', 'Role', [
+      new Permission('p1', PermissionKeys.READ_PERMISSIONS, ''),
+      new Permission('p2', PermissionKeys.CREATE_PERMISSION, ''),
+      new Permission('p3', PermissionKeys.UPDATE_PERMISSION, ''),
+      new Permission('p4', PermissionKeys.DELETE_PERMISSION, ''),
+    ]);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+    auth.verifyToken.mockResolvedValue(user);
+    registerPermissionGateway(io, auth, logger, realtime, permRepo);
+    httpServer.listen(() => {
+      const address = httpServer.address() as any;
+      url = `http://localhost:${address.port}`;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    io.close();
+    httpServer.close(done);
+  });
+
+  it('should authenticate socket connections', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('ping');
+    });
+    client.on('pong', (data: unknown) => {
+      expect(data).toEqual({ userId: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject invalid token', (done) => {
+    auth.verifyToken.mockRejectedValue(new Error('bad'));
+    const client = ioClient.connect(url, { auth: { token: 'bad' } });
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject connection without token', (done) => {
+    const client = ioClient.connect(url);
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits permission list when permitted', (done) => {
+    permRepo.findPage.mockResolvedValue({ items: [permission], page: 1, limit: 20, total: 1 });
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-list-request', { page: 1, limit: 20 });
+    });
+    client.on('permission-list-response', (data: any) => {
+      expect(data.items[0].id).toBe('p');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid list parameters', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-list-request', { page: 'a' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts permission-changed on create', (done) => {
+    permRepo.create.mockResolvedValue(permission);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-create', { id: 'p', permissionKey: 'TEST', description: 'desc' });
+    });
+    client.on('permission-create-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('permission-changed', { id: 'p' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts permission-changed on update', (done) => {
+    permRepo.update.mockResolvedValue(permission);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-update', { id: 'p', permissionKey: 'TEST', description: 'desc' });
+    });
+    client.on('permission-update-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('permission-changed', { id: 'p' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts permission-changed on delete', (done) => {
+    permRepo.delete.mockResolvedValue();
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-delete', { id: 'p' });
+    });
+    client.on('permission-delete-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('permission-changed', { id: 'p' });
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-list-request', { page: 1, limit: 20 });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects create when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-create', { id: 'p', permissionKey: 'T', description: 'd' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid create payload', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-create', { bad: true });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement websocket gateway for permissions
- add permission gateway tests
- register the permission gateway in the server

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a71108ef883238300b1e7750329d3