### PR TITLE
Add config websocket gateway

### DIFF
--- a/backend/adapters/controllers/websocket/configGateway.ts
+++ b/backend/adapters/controllers/websocket/configGateway.ts
@@ -1,0 +1,147 @@
+/* istanbul ignore file */
+import { Server, Socket } from 'socket.io';
+import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
+import { GetConfigUseCase } from '../../../usecases/config/GetConfigUseCase';
+import { UpdateConfigUseCase } from '../../../usecases/config/UpdateConfigUseCase';
+import { DeleteConfigUseCase } from '../../../usecases/config/DeleteConfigUseCase';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { getContext } from '../../../infrastructure/loggerContext';
+import { User } from '../../../domain/entities/User';
+
+interface AuthedSocket extends Socket {
+  user: User;
+}
+
+interface GetPayload {
+  key: string;
+}
+
+interface UpdatePayload {
+  key: string;
+  value: unknown;
+  updatedBy: string;
+}
+
+interface DeletePayload {
+  key: string;
+  deletedBy: string;
+}
+
+export function registerConfigGateway(
+  io: Server,
+  authService: AuthServicePort,
+  logger: LoggerPort,
+  realtime: RealtimePort,
+  getUseCase: GetConfigUseCase,
+  updateUseCase: UpdateConfigUseCase,
+  deleteUseCase: DeleteConfigUseCase,
+): void {
+  io.use(async (socket, next): Promise<void> => {
+    logger.debug('WebSocket auth middleware', getContext());
+    const token = socket.handshake.auth?.token;
+    if (!token) {
+      return next(new Error('Unauthorized'));
+    }
+    try {
+      const user = await authService.verifyToken(token);
+      (socket as AuthedSocket).user = user;
+      logger.debug('WebSocket auth success', getContext());
+      next();
+    } catch {
+      logger.warn('WebSocket auth failed', getContext());
+      next(new Error('Unauthorized'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const authed = socket as AuthedSocket;
+    const checker = new PermissionChecker(authed.user);
+
+    socket.on('ping', () => {
+      socket.emit('pong', { userId: authed.user.id });
+    });
+
+    socket.on('config-get', async (payload: GetPayload) => {
+      logger.info('config-get', getContext());
+      if (!payload || typeof payload.key !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.READ_CONFIG);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      try {
+        const value = await getUseCase.execute(payload.key);
+        if (value === null) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        socket.emit('config-get-response', { key: payload.key, value });
+      } catch (err) {
+        logger.error('config-get failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('config-update', async (payload: UpdatePayload) => {
+      logger.info('config-update', getContext());
+      if (
+        !payload ||
+        typeof payload.key !== 'string' ||
+        typeof payload.updatedBy !== 'string' ||
+        payload.value === undefined
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.UPDATE_CONFIG);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      try {
+        await updateUseCase.execute(payload.key, payload.value, payload.updatedBy);
+        socket.emit('config-update-response', {
+          key: payload.key,
+          value: payload.value,
+        });
+        await realtime.broadcast('config-changed', { key: payload.key });
+      } catch (err) {
+        logger.error('config-update failed', { ...getContext(), error: err });
+        socket.emit('error', { error: (err as Error).message });
+      }
+    });
+
+    socket.on('config-delete', async (payload: DeletePayload) => {
+      logger.info('config-delete', getContext());
+      if (
+        !payload ||
+        typeof payload.key !== 'string' ||
+        typeof payload.deletedBy !== 'string'
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.DELETE_CONFIG);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      try {
+        await deleteUseCase.execute(payload.key, payload.deletedBy);
+        socket.emit('config-delete-response', { key: payload.key });
+        await realtime.broadcast('config-changed', { key: payload.key });
+      } catch (err) {
+        logger.error('config-delete failed', { ...getContext(), error: err });
+        socket.emit('error', { error: (err as Error).message });
+      }
+    });
+  });
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -16,6 +16,7 @@ import { registerRoleGateway } from '../adapters/controllers/websocket/roleGatew
 import { registerInvitationGateway } from '../adapters/controllers/websocket/invitationGateway';
 import { registerSiteGateway } from '../adapters/controllers/websocket/siteGateway';
 import { registerPermissionGateway } from '../adapters/controllers/websocket/permissionGateway';
+import { registerConfigGateway } from '../adapters/controllers/websocket/configGateway';
 import { SocketIORealtimeAdapter } from '../adapters/realtime/SocketIORealtimeAdapter';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
@@ -48,6 +49,8 @@ import { RedisCacheAdapter } from '../adapters/cache/RedisCacheAdapter';
 import IORedis from 'ioredis';
 import { ConfigService } from '../domain/services/ConfigService';
 import { GetConfigUseCase } from '../usecases/config/GetConfigUseCase';
+import { UpdateConfigUseCase } from '../usecases/config/UpdateConfigUseCase';
+import { DeleteConfigUseCase } from '../usecases/config/DeleteConfigUseCase';
 import { BootstapService } from '../domain/services/BootstapService';
 import { PasswordValidator } from '../domain/services/PasswordValidator';
 import { NodeCronScheduler } from '../adapters/scheduler/NodeCronScheduler';
@@ -125,6 +128,8 @@ async function bootstrap(): Promise<void> {
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'.slice(0, 64),
   );
   const getConfigUseCase = new GetConfigUseCase(configService);
+  const updateConfigUseCase = new UpdateConfigUseCase(configService, audit);
+  const deleteConfigUseCase = new DeleteConfigUseCase(configService, audit);
   const bootstrapService = new BootstapService(
     configService,
     logger,
@@ -262,6 +267,15 @@ async function bootstrap(): Promise<void> {
     logger,
     realtime,
     permissionRepository,
+  );
+  registerConfigGateway(
+    io,
+    authService,
+    logger,
+    realtime,
+    getConfigUseCase,
+    updateConfigUseCase,
+    deleteConfigUseCase,
   );
   registerInvitationGateway(
     io,

--- a/backend/tests/adapters/controllers/websocket/configGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/configGateway.test.ts
@@ -1,0 +1,204 @@
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import * as ioClient from 'socket.io-client';
+import { registerConfigGateway } from '../../../../adapters/controllers/websocket/configGateway';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
+import { RealtimePort } from '../../../../domain/ports/RealtimePort';
+import { GetConfigUseCase } from '../../../../usecases/config/GetConfigUseCase';
+import { UpdateConfigUseCase } from '../../../../usecases/config/UpdateConfigUseCase';
+import { DeleteConfigUseCase } from '../../../../usecases/config/DeleteConfigUseCase';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { User } from '../../../../domain/entities/User';
+import { Role } from '../../../../domain/entities/Role';
+import { Department } from '../../../../domain/entities/Department';
+import { Site } from '../../../../domain/entities/Site';
+import { Permission } from '../../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
+
+describe('Config WebSocket gateway', () => {
+  let io: Server;
+  let httpServer: ReturnType<typeof createServer>;
+  let url: string;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let realtime: DeepMockProxy<RealtimePort>;
+  let getUseCase: DeepMockProxy<GetConfigUseCase>;
+  let updateUseCase: DeepMockProxy<UpdateConfigUseCase>;
+  let deleteUseCase: DeepMockProxy<DeleteConfigUseCase>;
+  let role: Role;
+  let user: User;
+  let site: Site;
+  let department: Department;
+
+  beforeEach((done) => {
+    httpServer = createServer();
+    io = new Server(httpServer);
+    auth = mockDeep<AuthServicePort>();
+    logger = mockDeep<LoggerPort>();
+    realtime = mockDeep<RealtimePort>();
+    getUseCase = mockDeep<GetConfigUseCase>();
+    updateUseCase = mockDeep<UpdateConfigUseCase>();
+    deleteUseCase = mockDeep<DeleteConfigUseCase>();
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+    role = new Role('r', 'Role', [
+      new Permission('p1', PermissionKeys.READ_CONFIG, ''),
+      new Permission('p2', PermissionKeys.UPDATE_CONFIG, ''),
+      new Permission('p3', PermissionKeys.DELETE_CONFIG, ''),
+    ]);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+    auth.verifyToken.mockResolvedValue(user);
+    registerConfigGateway(
+      io,
+      auth,
+      logger,
+      realtime,
+      getUseCase,
+      updateUseCase,
+      deleteUseCase,
+    );
+    httpServer.listen(() => {
+      const address = httpServer.address() as any;
+      url = `http://localhost:${address.port}`;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    io.close();
+    httpServer.close(done);
+  });
+
+  it('should authenticate socket connections', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('ping');
+    });
+    client.on('pong', (data: unknown) => {
+      expect(data).toEqual({ userId: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject invalid token', (done) => {
+    auth.verifyToken.mockRejectedValue(new Error('bad'));
+    const client = ioClient.connect(url, { auth: { token: 'bad' } });
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject connection without token', (done) => {
+    const client = ioClient.connect(url);
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits configuration value when permitted', (done) => {
+    getUseCase.execute.mockResolvedValue('v');
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-get', { key: 'k' });
+    });
+    client.on('config-get-response', (data: any) => {
+      expect(data).toEqual({ key: 'k', value: 'v' });
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid get parameters', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-get', { bad: true });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts config-changed on update', (done) => {
+    updateUseCase.execute.mockResolvedValue();
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-update', { key: 'k', value: 'v', updatedBy: 'u' });
+    });
+    client.on('config-update-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('config-changed', { key: 'k' });
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts config-changed on delete', (done) => {
+    deleteUseCase.execute.mockResolvedValue();
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-delete', { key: 'k', deletedBy: 'u' });
+    });
+    client.on('config-delete-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('config-changed', { key: 'k' });
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-get', { key: 'k' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects update when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-update', { key: 'k', value: 'v', updatedBy: 'u' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid update payload', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-update', { bad: true });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid delete payload', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('config-delete', { bad: true });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement configGateway websocket controller
- test websocket config gateway behaviours
- register gateway in server bootstrap

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a73a4038c83239dcc932ba6279678