### PR TITLE
Add WebSocket Audit Gateway

### DIFF
--- a/backend/adapters/controllers/websocket/auditGateway.ts
+++ b/backend/adapters/controllers/websocket/auditGateway.ts
@@ -1,0 +1,129 @@
+/* istanbul ignore file */
+import { Server, Socket } from 'socket.io';
+import { AuthServicePort } from '../../../domain/ports/AuthServicePort';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
+import { AuditPort } from '../../../domain/ports/AuditPort';
+import { AuditConfigService } from '../../../domain/services/AuditConfigService';
+import { PermissionChecker } from '../../../domain/services/PermissionChecker';
+import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { getContext } from '../../../infrastructure/loggerContext';
+import { User } from '../../../domain/entities/User';
+import { GetAuditLogsUseCase } from '../../../usecases/audit/GetAuditLogsUseCase';
+import { UpdateAuditConfigUseCase } from '../../../usecases/audit/UpdateAuditConfigUseCase';
+
+interface AuthedSocket extends Socket {
+  user: User;
+}
+
+interface LogParams {
+  page?: number;
+  limit?: number;
+  actorId?: string;
+  action?: string;
+  targetType?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+interface ConfigPayload {
+  levels: string[];
+  categories: string[];
+  updatedBy: string;
+}
+
+export function registerAuditGateway(
+  io: Server,
+  authService: AuthServicePort,
+  logger: LoggerPort,
+  realtime: RealtimePort,
+  audit: AuditPort,
+  configService: AuditConfigService,
+): void {
+  io.use(async (socket, next): Promise<void> => {
+    logger.debug('WebSocket auth middleware', getContext());
+    const token = socket.handshake.auth?.token;
+    if (!token) {
+      return next(new Error('Unauthorized'));
+    }
+    try {
+      const user = await authService.verifyToken(token);
+      (socket as AuthedSocket).user = user;
+      logger.debug('WebSocket auth success', getContext());
+      next();
+    } catch {
+      logger.warn('WebSocket auth failed', getContext());
+      next(new Error('Unauthorized'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const authed = socket as AuthedSocket;
+    const checker = new PermissionChecker(authed.user);
+
+    socket.on('ping', () => {
+      socket.emit('pong', { userId: authed.user.id });
+    });
+
+    socket.on('audit-log-request', async (params: LogParams) => {
+      logger.info('audit-log-request', getContext());
+      const page = Number(params?.page ?? 1);
+      const limit = Number(params?.limit ?? 20);
+      if (Number.isNaN(page) || page < 1 || Number.isNaN(limit) || limit < 1) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const useCase = new GetAuditLogsUseCase(audit, checker, configService);
+      try {
+        const result = await useCase.execute({
+          page,
+          limit,
+          actorId: params?.actorId,
+          action: params?.action,
+          targetType: params?.targetType,
+          dateFrom: params?.dateFrom ? new Date(params.dateFrom) : undefined,
+          dateTo: params?.dateTo ? new Date(params.dateTo) : undefined,
+        });
+        socket.emit('audit-log-response', result);
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        logger.error('audit-log-request failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('audit-config-update', async (payload: ConfigPayload) => {
+      logger.info('audit-config-update', getContext());
+      if (
+        !payload ||
+        !Array.isArray(payload.levels) ||
+        !Array.isArray(payload.categories) ||
+        typeof payload.updatedBy !== 'string'
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        checker.check(PermissionKeys.WRITE_AUDIT_CONFIG);
+      } catch {
+        socket.emit('error', { error: 'Forbidden' });
+        return;
+      }
+      const useCase = new UpdateAuditConfigUseCase(configService, audit);
+      try {
+        const cfg = await useCase.execute(
+          payload.levels,
+          payload.categories,
+          payload.updatedBy,
+        );
+        socket.emit('audit-config-update-response', cfg);
+        await realtime.broadcast('audit-config-changed', { updatedBy: cfg.updatedBy });
+      } catch (err) {
+        logger.error('audit-config-update failed', { ...getContext(), error: err });
+        socket.emit('error', { error: (err as Error).message });
+      }
+    });
+  });
+}

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -17,6 +17,7 @@ import { registerInvitationGateway } from '../adapters/controllers/websocket/inv
 import { registerSiteGateway } from '../adapters/controllers/websocket/siteGateway';
 import { registerPermissionGateway } from '../adapters/controllers/websocket/permissionGateway';
 import { registerConfigGateway } from '../adapters/controllers/websocket/configGateway';
+import { registerAuditGateway } from '../adapters/controllers/websocket/auditGateway';
 import { SocketIORealtimeAdapter } from '../adapters/realtime/SocketIORealtimeAdapter';
 import { PrismaUserRepository } from '../adapters/repositories/PrismaUserRepository';
 import { PrismaInvitationRepository } from '../adapters/repositories/PrismaInvitationRepository';
@@ -276,6 +277,14 @@ async function bootstrap(): Promise<void> {
     getConfigUseCase,
     updateConfigUseCase,
     deleteConfigUseCase,
+  );
+  registerAuditGateway(
+    io,
+    authService,
+    logger,
+    realtime,
+    audit,
+    auditConfigService,
   );
   registerInvitationGateway(
     io,

--- a/backend/tests/adapters/controllers/websocket/auditGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/auditGateway.test.ts
@@ -1,0 +1,172 @@
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import * as ioClient from 'socket.io-client';
+import { registerAuditGateway } from '../../../../adapters/controllers/websocket/auditGateway';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
+import { RealtimePort } from '../../../../domain/ports/RealtimePort';
+import { AuditPort } from '../../../../domain/ports/AuditPort';
+import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { AuditConfigService } from '../../../../domain/services/AuditConfigService';
+import { AuditEvent } from '../../../../domain/entities/AuditEvent';
+import { AuditConfig } from '../../../../domain/entities/AuditConfig';
+import { User } from '../../../../domain/entities/User';
+import { Role } from '../../../../domain/entities/Role';
+import { Permission } from '../../../../domain/entities/Permission';
+import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
+import { Department } from '../../../../domain/entities/Department';
+import { Site } from '../../../../domain/entities/Site';
+
+describe('Audit WebSocket gateway', () => {
+  let io: Server;
+  let httpServer: ReturnType<typeof createServer>;
+  let url: string;
+  let auth: DeepMockProxy<AuthServicePort>;
+  let logger: ReturnType<typeof mockDeep<LoggerPort>>;
+  let realtime: DeepMockProxy<RealtimePort>;
+  let audit: DeepMockProxy<AuditPort>;
+  let config: DeepMockProxy<AuditConfigService>;
+  let role: Role;
+  let user: User;
+  let department: Department;
+  let site: Site;
+  let event: AuditEvent;
+
+  beforeEach((done) => {
+    httpServer = createServer();
+    io = new Server(httpServer);
+    auth = mockDeep<AuthServicePort>();
+    logger = mockDeep<LoggerPort>();
+    realtime = mockDeep<RealtimePort>();
+    audit = mockDeep<AuditPort>();
+    config = mockDeep<AuditConfigService>();
+    site = new Site('s', 'Site');
+    department = new Department('d', 'Dept', null, null, site);
+    role = new Role('r', 'Role', [
+      new Permission('p1', PermissionKeys.VIEW_AUDIT_LOGS, ''),
+      new Permission('p2', PermissionKeys.WRITE_AUDIT_CONFIG, ''),
+    ]);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
+    event = new AuditEvent(new Date('2024-01-01T00:00:00Z'), 'u', 'user', 'test');
+    auth.verifyToken.mockResolvedValue(user);
+    registerAuditGateway(io, auth, logger, realtime, audit, config);
+    httpServer.listen(() => {
+      const address = httpServer.address() as any;
+      url = `http://localhost:${address.port}`;
+      done();
+    });
+  });
+
+  afterEach((done) => {
+    io.close();
+    httpServer.close(done);
+  });
+
+  it('should authenticate socket connections', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('ping');
+    });
+    client.on('pong', (data: any) => {
+      expect(data).toEqual({ userId: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject invalid token', (done) => {
+    auth.verifyToken.mockRejectedValue(new Error('bad'));
+    const client = ioClient.connect(url, { auth: { token: 'bad' } });
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('should reject connection without token', (done) => {
+    const client = ioClient.connect(url);
+    client.on('connect_error', (err: Error) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits audit logs when permitted', (done) => {
+    audit.findPaginated.mockResolvedValue({ items: [event], page: 1, limit: 20, total: 1 });
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('audit-log-request', { page: 1, limit: 20 });
+    });
+    client.on('audit-log-response', (data: any) => {
+      expect(data.items[0].action).toBe('test');
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts audit-config-changed on update', (done) => {
+    config.update.mockResolvedValue(new AuditConfig(1, [], [], new Date(), 'u'));
+    audit.log.mockResolvedValue();
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('audit-config-update', { levels: [], categories: [], updatedBy: 'u' });
+    });
+    client.on('audit-config-update-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('audit-config-changed', { updatedBy: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid list parameters', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('audit-log-request', { page: 'x' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('audit-log-request', { page: 1, limit: 20 });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects update when permission missing', (done) => {
+    auth.verifyToken.mockResolvedValue(new User('x', 'A', 'B', 'a@b.c', [], 'active', department, site));
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('audit-config-update', { levels: [], categories: [], updatedBy: 'u' });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Forbidden');
+      client.close();
+      done();
+    });
+  });
+
+  it('rejects invalid update payload', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('audit-config-update', { bad: true });
+    });
+    client.on('error', (err: { error: string }) => {
+      expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `auditGateway` WebSocket controller for retrieving audit logs and updating audit configuration
- test the new gateway
- register the gateway in the server

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a76a6cba883239ad465786f5c84f2