### PR TITLE
Add realtime broadcast to key use cases

### DIFF
--- a/backend/adapters/controllers/rest/departmentController.ts
+++ b/backend/adapters/controllers/rest/departmentController.ts
@@ -10,6 +10,7 @@ import {Permission} from '../../../domain/entities/Permission';
 import {CreateDepartmentUseCase} from '../../../usecases/department/CreateDepartmentUseCase';
 import {UpdateDepartmentUseCase} from '../../../usecases/department/UpdateDepartmentUseCase';
 import {RemoveDepartmentUseCase} from '../../../usecases/department/RemoveDepartmentUseCase';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
 import {SetDepartmentManagerUseCase} from '../../../usecases/department/SetDepartmentManagerUseCase';
 import {RemoveDepartmentManagerUseCase} from '../../../usecases/department/RemoveDepartmentManagerUseCase';
 import {SetDepartmentParentDepartmentUseCase} from '../../../usecases/department/SetDepartmentParentDepartmentUseCase';
@@ -168,6 +169,7 @@ export function createDepartmentRouter(
   departmentRepository: DepartmentRepositoryPort,
   userRepository: UserRepositoryPort,
   logger: LoggerPort,
+  realtime: RealtimePort,
 ): Router {
   const router = express.Router();
 
@@ -683,7 +685,11 @@ export function createDepartmentRouter(
   router.post('/departments', async (req: Request, res: Response): Promise<void> => {
     logger.debug('POST /departments', getContext());
     const checker = new PermissionChecker((req as AuthedRequest).user);
-    const useCase = new CreateDepartmentUseCase(departmentRepository, checker);
+    const useCase = new CreateDepartmentUseCase(
+      departmentRepository,
+      checker,
+      realtime,
+    );
     const department = await useCase.execute(parseDepartment(req.body));
     logger.debug('Department created', getContext());
     res.status(201).json(department);

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -8,6 +8,7 @@ import { AuditPort } from '../../../domain/ports/AuditPort';
 import {AvatarServicePort} from '../../../domain/ports/AvatarServicePort';
 import {TokenServicePort} from '../../../domain/ports/TokenServicePort';
 import { RefreshTokenPort } from '../../../domain/ports/RefreshTokenPort';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
 import {GetCurrentUserProfileUseCase} from '../../../usecases/user/GetCurrentUserProfileUseCase';
 import {RegisterUserUseCase} from '../../../usecases/user/RegisterUserUseCase';
 import {AuthenticateUserUseCase} from '../../../usecases/user/AuthenticateUserUseCase';
@@ -230,6 +231,7 @@ export function createUserRouter(
   getConfigUseCase: GetConfigUseCase,
   passwordValidator: PasswordValidator,
   mfaService: MfaServicePort,
+  realtime: RealtimePort,
 ): Router {
   const router = express.Router();
   const upload = multer();
@@ -365,6 +367,7 @@ export function createUserRouter(
         userRepository,
         tokenService,
         passwordValidator,
+        realtime,
       );
       const result = await useCase.execute(
         parseUser(req.body),
@@ -1190,7 +1193,12 @@ export function createUserRouter(
       logger.debug('PUT /users/:id', getContext());
       const user = parseUser({ ...req.body, id: req.params.id });
       const checker = new PermissionChecker((req as AuthedRequest).user);
-      const useCase = new UpdateUserProfileUseCase(userRepository, checker, audit);
+      const useCase = new UpdateUserProfileUseCase(
+        userRepository,
+        checker,
+        audit,
+        realtime,
+      );
       try {
         const updated = await useCase.execute(user);
         logger.debug('User profile updated', getContext());

--- a/backend/adapters/controllers/websocket/departmentGateway.ts
+++ b/backend/adapters/controllers/websocket/departmentGateway.ts
@@ -133,7 +133,11 @@ export function registerDepartmentGateway(
         new Site(payload.site.id, payload.site.label),
         (payload.permissions ?? []).map((p) => new Permission(p.id, p.permissionKey, p.description)),
       );
-      const useCase = new CreateDepartmentUseCase(departmentRepository, checker);
+      const useCase = new CreateDepartmentUseCase(
+        departmentRepository,
+        checker,
+        realtime,
+      );
       try {
         const created = await useCase.execute(department);
         socket.emit('department-create-response', created);

--- a/backend/adapters/controllers/websocket/userGateway.ts
+++ b/backend/adapters/controllers/websocket/userGateway.ts
@@ -147,7 +147,12 @@ export function registerUserGateway(
           (p) => new Permission(p.id, p.permissionKey, p.description),
         ),
       );
-      const useCase = new UpdateUserProfileUseCase(userRepository, checker, audit);
+      const useCase = new UpdateUserProfileUseCase(
+        userRepository,
+        checker,
+        audit,
+        realtime,
+      );
       try {
         const updated = await useCase.execute(user);
         logger.debug('User updated', getContext());

--- a/backend/tests/adapters/controllers/rest/departmentController.test.ts
+++ b/backend/tests/adapters/controllers/rest/departmentController.test.ts
@@ -5,6 +5,7 @@ import { createDepartmentRouter } from '../../../../adapters/controllers/rest/de
 import { DepartmentRepositoryPort } from '../../../../domain/ports/DepartmentRepositoryPort';
 import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort';
 import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { RealtimePort } from '../../../../domain/ports/RealtimePort';
 import { Department } from '../../../../domain/entities/Department';
 import { Site } from '../../../../domain/entities/Site';
 import { Permission } from '../../../../domain/entities/Permission';
@@ -43,7 +44,8 @@ describe('Department REST controller', () => {
     app = express();
     app.use(express.json());
     app.use((req, _res, next) => { (req as any).user = user; next(); });
-    app.use('/api', createDepartmentRouter(deptRepo, userRepo, logger));
+    const realtime = mockDeep<RealtimePort>();
+    app.use('/api', createDepartmentRouter(deptRepo, userRepo, logger, realtime));
   });
 
   it('should list departments', async () => {

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -18,6 +18,7 @@ import { PermissionKeys } from '../../../../domain/entities/PermissionKeys';
 import { AccountLockedError } from '../../../../domain/errors/AccountLockedError';
 import { TokenExpiredException } from '../../../../domain/errors/TokenExpiredException';
 import { LoggerPort } from '../../../../domain/ports/LoggerPort';
+import { RealtimePort } from '../../../../domain/ports/RealtimePort';
 import { RefreshToken } from '../../../../domain/entities/RefreshToken';
 import { AuditPort } from '../../../../domain/ports/AuditPort';
 import { GetConfigUseCase } from '../../../../usecases/config/GetConfigUseCase';
@@ -93,6 +94,7 @@ describe('User REST controller', () => {
         getConfig,
         passwordValidator,
         mfa,
+        mockDeep<RealtimePort>(),
       ),
     );
   });

--- a/backend/tests/usecases/user/RegisterUserUseCase.test.ts
+++ b/backend/tests/usecases/user/RegisterUserUseCase.test.ts
@@ -8,11 +8,13 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
+import { RealtimePort } from '../../../domain/ports/RealtimePort';
 
 describe('RegisterUserUseCase', () => {
   let repository: DeepMockProxy<UserRepositoryPort>;
   let tokenService: DeepMockProxy<TokenServicePort>;
   let passwordValidator: DeepMockProxy<PasswordValidator>;
+  let realtime: DeepMockProxy<RealtimePort>;
   let useCase: RegisterUserUseCase;
   let user: User;
   let role: Role;
@@ -23,7 +25,13 @@ describe('RegisterUserUseCase', () => {
     repository = mockDeep<UserRepositoryPort>();
     tokenService = mockDeep<TokenServicePort>();
     passwordValidator = mockDeep<PasswordValidator>();
-    useCase = new RegisterUserUseCase(repository, tokenService, passwordValidator);
+    realtime = mockDeep<RealtimePort>();
+    useCase = new RegisterUserUseCase(
+      repository,
+      tokenService,
+      passwordValidator,
+      realtime,
+    );
     role = new Role('role-1', 'Admin');
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
@@ -56,6 +64,7 @@ describe('RegisterUserUseCase', () => {
       '1.1.1.1',
       'agent',
     );
+    expect(realtime.broadcast).toHaveBeenCalledWith('user-changed', { id: user.id });
   });
 
   it('should throw when password invalid', async () => {

--- a/backend/usecases/department/CreateDepartmentUseCase.ts
+++ b/backend/usecases/department/CreateDepartmentUseCase.ts
@@ -2,6 +2,7 @@ import { DepartmentRepositoryPort } from '../../domain/ports/DepartmentRepositor
 import { Department } from '../../domain/entities/Department';
 import { PermissionChecker } from '../../domain/services/PermissionChecker';
 import { PermissionKeys } from '../../domain/entities/PermissionKeys';
+import { RealtimePort } from '../../domain/ports/RealtimePort';
 
 /**
  * Use case responsible for creating a {@link Department}.
@@ -10,6 +11,7 @@ export class CreateDepartmentUseCase {
   constructor(
     private readonly departmentRepository: DepartmentRepositoryPort,
     private readonly checker: PermissionChecker,
+    private readonly realtime: RealtimePort,
   ) {}
 
   /**
@@ -25,6 +27,8 @@ export class CreateDepartmentUseCase {
     department.updatedAt = now;
     department.createdBy = this.checker.currentUser;
     department.updatedBy = this.checker.currentUser;
-    return this.departmentRepository.create(department);
+    const created = await this.departmentRepository.create(department);
+    await this.realtime.broadcast('department-changed', { id: created.id });
+    return created;
   }
 }

--- a/backend/usecases/user/RegisterUserUseCase.ts
+++ b/backend/usecases/user/RegisterUserUseCase.ts
@@ -3,6 +3,7 @@ import { TokenServicePort } from '../../domain/ports/TokenServicePort';
 import { User } from '../../domain/entities/User';
 import { PasswordValidator } from '../../domain/services/PasswordValidator';
 import { InvalidPasswordException } from '../../domain/errors/InvalidPasswordException';
+import { RealtimePort } from '../../domain/ports/RealtimePort';
 
 /**
  * Use case responsible for registering a new {@link User}
@@ -13,6 +14,7 @@ export class RegisterUserUseCase {
     private readonly userRepository: UserRepositoryPort,
     private readonly tokenService: TokenServicePort,
     private readonly passwordValidator: PasswordValidator,
+    private readonly realtime: RealtimePort,
   ) {}
 
   /**
@@ -38,6 +40,7 @@ export class RegisterUserUseCase {
     user.createdBy = null;
     user.updatedBy = null;
     const created = await this.userRepository.create(user);
+    await this.realtime.broadcast('user-changed', { id: created.id });
     const token = this.tokenService.generateAccessToken(created);
     const refreshToken = await this.tokenService.generateRefreshToken(
       created,

--- a/backend/usecases/user/UpdateUserProfileUseCase.ts
+++ b/backend/usecases/user/UpdateUserProfileUseCase.ts
@@ -5,6 +5,7 @@ import { PermissionKeys } from '../../domain/entities/PermissionKeys';
 import { AuditPort } from '../../domain/ports/AuditPort';
 import { AuditEvent } from '../../domain/entities/AuditEvent';
 import { AuditEventType } from '../../domain/entities/AuditEventType';
+import { RealtimePort } from '../../domain/ports/RealtimePort';
 
 /**
  * Use case for updating user profile information.
@@ -14,6 +15,7 @@ export class UpdateUserProfileUseCase {
     private readonly userRepository: UserRepositoryPort,
     private readonly checker: PermissionChecker,
     private readonly auditPort: AuditPort,
+    private readonly realtime: RealtimePort,
   ) {}
 
   /**
@@ -38,6 +40,7 @@ export class UpdateUserProfileUseCase {
         { userId: user.id },
       ),
     );
+    await this.realtime.broadcast('user-changed', { id: updated.id });
     return updated;
   }
 }


### PR DESCRIPTION
## Summary
- notify websocket clients when users or departments change
- mock realtime port in related unit tests
- pass realtime adapter to REST routers and websocket gateways

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a78761268832388a11d805b546d56