### PR TITLE
Add Websocket documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ Le nombre de tentatives de vérification est limité.
 Consultez [backend/docs/MFA.md](backend/docs/MFA.md) pour plus de détails sur la configuration.
 
 Consultez [backend/docs/Audit.md](backend/docs/Audit.md) pour la configuration de l'audit des routes sensibles.
+
+## Temps réel via WebSocket
+
+Le serveur expose une API WebSocket basée sur Socket.IO. Connectez-vous en fournissant un jeton JWT :
+
+```ts
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000', {
+  auth: { token: '<JWT>' }
+});
+```
+
+La liste des événements disponibles est décrite dans [backend/docs/Websocket.md](backend/docs/Websocket.md).

--- a/backend/docs/Websocket.md
+++ b/backend/docs/Websocket.md
@@ -1,0 +1,59 @@
+# API WebSocket
+
+Le backend expose une API temps réel via Socket.IO. Toutes les connexions doivent fournir un jeton JWT valide.
+
+## Connexion
+
+```ts
+import { io } from 'socket.io-client';
+
+const socket = io('https://mon.sovrane', {
+  auth: { token: '<JWT>' }
+});
+```
+
+Sans jeton ou avec un jeton invalide, la connexion est rejetée avec l'erreur `Unauthorized`.
+
+## Événements principaux
+
+### `ping` / `pong`
+Vérifie que la connexion est ouverte.
+
+### `user-list-request` / `user-list-response`
+Demande la liste des utilisateurs.
+
+Exemple de requête :
+```json
+{ "page": 1, "limit": 20 }
+```
+
+Exemple de réponse :
+```json
+{
+  "items": [],
+  "page": 1,
+  "limit": 20,
+  "total": 0
+}
+```
+
+### `user-update` / `user-update-response`
+Met à jour un profil utilisateur.
+
+Exemple de requête :
+```json
+{
+  "id": "u1",
+  "firstName": "Alice",
+  "lastName": "Doe",
+  "email": "alice@example.com",
+  "department": { "id": "d1", "label": "IT", "site": { "id": "s1", "label": "Paris" } },
+  "site": { "id": "s1", "label": "Paris" }
+}
+```
+
+### Diffusion
+
+Quand une ressource est modifiée, un événement `*-changed` est diffusé à tous les clients (par exemple `user-changed`, `role-changed`, `site-changed`).
+
+La liste complète des événements se trouve dans les fichiers du dossier `backend/adapters/controllers/websocket`.


### PR DESCRIPTION
## Summary
- document WebSocket API usage and events
- link to the new doc from README

## Testing
- `npm --prefix backend run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a7ddc6fa08323a0d347349d3ac96c