### PR TITLE
Add get events for roles and permissions

### DIFF
--- a/backend/tests/adapters/controllers/websocket/permissionGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/permissionGateway.test.ts
@@ -40,6 +40,7 @@ describe('Permission WebSocket gateway', () => {
     permission = new Permission('p', 'TEST', 'desc');
     role = new Role('r', 'Role', [
       new Permission('p1', PermissionKeys.READ_PERMISSIONS, ''),
+      new Permission('p5', PermissionKeys.READ_PERMISSION, ''),
       new Permission('p2', PermissionKeys.CREATE_PERMISSION, ''),
       new Permission('p3', PermissionKeys.UPDATE_PERMISSION, ''),
       new Permission('p4', PermissionKeys.DELETE_PERMISSION, ''),
@@ -98,6 +99,19 @@ describe('Permission WebSocket gateway', () => {
     });
     client.on('permission-list-response', (data: any) => {
       expect(data.items[0].id).toBe('p');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits permission get', (done) => {
+    permRepo.findById.mockResolvedValue(permission);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('permission-get', { id: 'p' });
+    });
+    client.on('permission-get-response', (data: any) => {
+      expect(data.id).toBe('p');
       client.close();
       done();
     });

--- a/backend/tests/adapters/controllers/websocket/roleGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/roleGateway.test.ts
@@ -41,6 +41,7 @@ describe('Role WebSocket gateway', () => {
     department = new Department('d', 'Dept', null, null, site);
     role = new Role('r', 'Role', [
       new Permission('p1', PermissionKeys.READ_ROLES, ''),
+      new Permission('p5', PermissionKeys.READ_ROLE, ''),
       new Permission('p2', PermissionKeys.CREATE_ROLE, ''),
       new Permission('p3', PermissionKeys.UPDATE_ROLE, ''),
       new Permission('p4', PermissionKeys.DELETE_ROLE, ''),
@@ -99,6 +100,19 @@ describe('Role WebSocket gateway', () => {
     });
     client.on('role-list-response', (data: any) => {
       expect(data.items[0].id).toBe('r');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits role get', (done) => {
+    roleRepo.findById.mockResolvedValue(role);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('role-get', { id: 'r' });
+    });
+    client.on('role-get-response', (data: any) => {
+      expect(data.id).toBe('r');
       client.close();
       done();
     });


### PR DESCRIPTION
## Summary
- implement role-get and permission-get websocket handlers
- expose new events via roleGateway and permissionGateway
- test fetching a single role and permission over websocket

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8226603c8323aae1e9a502db9580