### PR TITLE
Add WebSocket auth and MFA handlers

### DIFF
--- a/backend/adapters/controllers/websocket/userGateway.ts
+++ b/backend/adapters/controllers/websocket/userGateway.ts
@@ -6,14 +6,29 @@ import { LoggerPort } from '../../../domain/ports/LoggerPort';
 import { RealtimePort } from '../../../domain/ports/RealtimePort';
 import { UserRepositoryPort } from '../../../domain/ports/UserRepositoryPort';
 import { AuditPort } from '../../../domain/ports/AuditPort';
+import { TokenServicePort } from '../../../domain/ports/TokenServicePort';
+import { RefreshTokenPort } from '../../../domain/ports/RefreshTokenPort';
+import { GetConfigUseCase } from '../../../usecases/config/GetConfigUseCase';
+import { PasswordValidator } from '../../../domain/services/PasswordValidator';
+import { MfaServicePort } from '../../../domain/ports/MfaServicePort';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { GetUsersUseCase } from '../../../usecases/user/GetUsersUseCase';
 import { UpdateUserProfileUseCase } from '../../../usecases/user/UpdateUserProfileUseCase';
+import { RegisterUserUseCase } from '../../../usecases/user/RegisterUserUseCase';
+import { AuthenticateUserUseCase } from '../../../usecases/user/AuthenticateUserUseCase';
+import { RequestPasswordResetUseCase } from '../../../usecases/user/RequestPasswordResetUseCase';
+import { ResetPasswordUseCase } from '../../../usecases/user/ResetPasswordUseCase';
+import { SetupTotpUseCase } from '../../../usecases/user/SetupTotpUseCase';
+import { EnableMfaUseCase } from '../../../usecases/user/EnableMfaUseCase';
+import { DisableMfaUseCase } from '../../../usecases/user/DisableMfaUseCase';
+import { VerifyMfaUseCase } from '../../../usecases/user/VerifyMfaUseCase';
+import { GetUserUseCase } from '../../../usecases/user/GetUserUseCase';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { Department } from '../../../domain/entities/Department';
 import { Site } from '../../../domain/entities/Site';
 import { getContext } from '../../../infrastructure/loggerContext';
+import { AccountLockedError } from '../../../domain/errors/AccountLockedError';
 
 /**
  * Register a Socket.IO gateway that authenticates connections and handles basic events.
@@ -51,6 +66,10 @@ interface UpdatePayload {
   permissions?: Array<{ id: string; permissionKey: string; description: string }>;
 }
 
+interface RegisterPayload extends UpdatePayload {
+  password: string;
+}
+
 export function registerUserGateway(
   io: Server,
   authService: AuthServicePort,
@@ -58,6 +77,11 @@ export function registerUserGateway(
   realtime: RealtimePort,
   userRepository: UserRepositoryPort,
   audit: AuditPort,
+  tokenService: TokenServicePort,
+  refreshTokenRepository: RefreshTokenPort,
+  getConfigUseCase: GetConfigUseCase,
+  passwordValidator: PasswordValidator,
+  mfaService: MfaServicePort,
 ): void {
   io.use(async (socket, next): Promise<void> => {
     logger.debug('WebSocket auth middleware', getContext());
@@ -111,6 +135,271 @@ export function registerUserGateway(
         logger.error('user-list-request failed', { ...getContext(), error: err });
       }
     });
+
+    socket.on('user-get', async (payload: { id: string }) => {
+      logger.info('user-get', getContext());
+      if (!payload || typeof payload.id !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const useCase = new GetUserUseCase(userRepository, checker);
+      try {
+        const usr = await useCase.execute(payload.id);
+        if (!usr) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        socket.emit('user-get-response', usr);
+      } catch (err) {
+        /* istanbul ignore next */
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        /* istanbul ignore next */
+        logger.error('user-get failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on('user-create', async (payload: RegisterPayload) => {
+      logger.info('user-create', getContext());
+      if (
+        !payload ||
+        typeof payload.id !== 'string' ||
+        typeof payload.firstName !== 'string' ||
+        typeof payload.lastName !== 'string' ||
+        typeof payload.email !== 'string' ||
+        typeof payload.password !== 'string' ||
+        !payload.department ||
+        !payload.site
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const user = new User(
+        payload.id,
+        payload.firstName,
+        payload.lastName,
+        payload.email,
+        (payload.roles ?? []).map((r) => new Role(r.id, r.label)),
+        payload.status ?? 'active',
+        new Department(
+          payload.department.id,
+          payload.department.label,
+          payload.department.parentDepartmentId ?? null,
+          payload.department.managerUserId ?? null,
+          new Site(payload.department.site.id, payload.department.site.label),
+        ),
+        new Site(payload.site.id, payload.site.label),
+        payload.picture,
+        (payload.permissions ?? []).map(
+          (p) => new Permission(p.id, p.permissionKey, p.description),
+        ),
+      );
+      const useCase = new RegisterUserUseCase(
+        userRepository,
+        tokenService,
+        passwordValidator,
+        realtime,
+      );
+      try {
+        const result = await useCase.execute(
+          user,
+          payload.password,
+          socket.handshake.address,
+          socket.handshake.headers['user-agent'] as string | undefined,
+        );
+        socket.emit('user-create-response', result);
+      } catch (err) {
+        /* istanbul ignore next */
+        logger.error('user-create failed', { ...getContext(), error: err });
+        socket.emit('error', { error: (err as Error).message });
+      }
+    });
+
+    socket.on('auth-login', async (payload: { email: string; password: string }) => {
+      logger.info('auth-login', getContext());
+      if (
+        !payload ||
+        typeof payload.email !== 'string' ||
+        typeof payload.password !== 'string'
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const useCase = new AuthenticateUserUseCase(
+        authService,
+        tokenService,
+        userRepository,
+        audit,
+        logger,
+        getConfigUseCase,
+      );
+      try {
+        const result = await useCase.execute(
+          payload.email,
+          payload.password,
+          socket.handshake.address,
+          socket.handshake.headers['user-agent'] as string | undefined,
+        );
+        socket.emit('auth-login-response', result);
+      } catch (err) {
+        if (err instanceof AccountLockedError) {
+          socket.emit('error', {
+            error: err.message,
+            code: 'account_locked',
+            lockedUntil: err.lockedUntil.toISOString(),
+          });
+          return;
+        }
+        socket.emit('error', { error: (err as Error).message });
+      }
+    });
+
+    socket.on('auth-request-reset', async (payload: { email: string }) => {
+      logger.info('auth-request-reset', getContext());
+      if (!payload || typeof payload.email !== 'string') {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      const useCase = new RequestPasswordResetUseCase(authService);
+      try {
+        await useCase.execute(payload.email);
+        socket.emit('auth-request-reset-response', { success: true });
+      } catch (err) {
+        logger.error('auth-request-reset failed', { ...getContext(), error: err });
+        socket.emit('error', { error: (err as Error).message });
+      }
+    });
+
+    socket.on('auth-reset', async (payload: { token: string; password: string }) => {
+      logger.info('auth-reset', getContext());
+      if (
+        !payload ||
+        typeof payload.token !== 'string' ||
+        typeof payload.password !== 'string'
+      ) {
+        socket.emit('error', { error: 'Invalid parameters' });
+        return;
+      }
+      try {
+        const user = await authService.verifyToken(payload.token);
+        const useCase = new ResetPasswordUseCase(
+          authService,
+          passwordValidator,
+          refreshTokenRepository,
+        );
+        await useCase.execute(user.id, payload.token, payload.password);
+        socket.emit('auth-reset-response', { success: true });
+        await realtime.broadcast('user-changed', { id: user.id });
+      } catch (err) {
+        logger.error('auth-reset failed', { ...getContext(), error: err });
+        socket.emit('error', { error: (err as Error).message });
+      }
+    });
+
+    socket.on('auth-mfa-setup', async () => {
+      logger.info('auth-mfa-setup', getContext());
+      const useCase = new SetupTotpUseCase(mfaService, checker);
+      try {
+        const secret = await useCase.execute(authed.user);
+        socket.emit('auth-mfa-setup-response', { secret });
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        logger.error('auth-mfa-setup failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on(
+      'auth-mfa-enable',
+      async (payload: { type: string; recoveryCodes?: string[] }) => {
+        logger.info('auth-mfa-enable', getContext());
+        if (!payload || typeof payload.type !== 'string') {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const useCase = new EnableMfaUseCase(
+          userRepository,
+          refreshTokenRepository,
+          checker,
+        );
+        try {
+          const updated = await useCase.execute(
+            authed.user,
+            payload.type,
+            payload.recoveryCodes ?? [],
+          );
+          socket.emit('auth-mfa-enable-response', updated);
+          await realtime.broadcast('user-changed', { id: updated.id });
+        } catch (err) {
+          if ((err as Error).message === 'Forbidden') {
+            socket.emit('error', { error: 'Forbidden' });
+            return;
+          }
+          logger.error('auth-mfa-enable failed', { ...getContext(), error: err });
+        }
+      },
+    );
+
+    socket.on('auth-mfa-disable', async () => {
+      logger.info('auth-mfa-disable', getContext());
+      const useCase = new DisableMfaUseCase(
+        userRepository,
+        mfaService,
+        refreshTokenRepository,
+        checker,
+      );
+      try {
+        await useCase.execute(authed.user);
+        socket.emit('auth-mfa-disable-response', { success: true });
+        await realtime.broadcast('user-changed', { id: authed.user.id });
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          socket.emit('error', { error: 'Forbidden' });
+          return;
+        }
+        logger.error('auth-mfa-disable failed', { ...getContext(), error: err });
+      }
+    });
+
+    socket.on(
+      'auth-mfa-verify',
+      async (payload: { userId: string; code: string }) => {
+        logger.info('auth-mfa-verify', getContext());
+        if (
+          !payload ||
+          typeof payload.userId !== 'string' ||
+          typeof payload.code !== 'string'
+        ) {
+          socket.emit('error', { error: 'Invalid parameters' });
+          return;
+        }
+        const user = await userRepository.findById(payload.userId);
+        if (!user) {
+          socket.emit('error', { error: 'Not found' });
+          return;
+        }
+        const useCase = new VerifyMfaUseCase(
+          mfaService,
+          tokenService,
+          userRepository,
+        );
+        try {
+          const result = await useCase.execute(
+            user,
+            payload.code,
+            socket.handshake.address,
+            socket.handshake.headers['user-agent'] as string | undefined,
+          );
+          socket.emit('auth-mfa-verify-response', result);
+        } catch (err) {
+          socket.emit('error', { error: (err as Error).message });
+        }
+      },
+    );
 
     socket.on('user-update', async (payload: UpdatePayload) => {
       logger.info('user-update', getContext());

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -228,6 +228,11 @@ async function bootstrap(): Promise<void> {
     realtime,
     userRepository,
     audit,
+    tokenService,
+    refreshRepo,
+    getConfigUseCase,
+    passwordValidator,
+    mfaService,
   );
   registerDepartmentGateway(
     io,

--- a/backend/tests/adapters/controllers/websocket/userGateway.test.ts
+++ b/backend/tests/adapters/controllers/websocket/userGateway.test.ts
@@ -7,6 +7,11 @@ import { AuthServicePort } from '../../../../domain/ports/AuthServicePort';
 import { RealtimePort } from '../../../../domain/ports/RealtimePort';
 import { UserRepositoryPort } from '../../../../domain/ports/UserRepositoryPort';
 import { AuditPort } from '../../../../domain/ports/AuditPort';
+import { TokenServicePort } from '../../../../domain/ports/TokenServicePort';
+import { RefreshTokenPort } from '../../../../domain/ports/RefreshTokenPort';
+import { GetConfigUseCase } from '../../../../usecases/config/GetConfigUseCase';
+import { PasswordValidator } from '../../../../domain/services/PasswordValidator';
+import { MfaServicePort } from '../../../../domain/ports/MfaServicePort';
 import { User } from '../../../../domain/entities/User';
 import { Role } from '../../../../domain/entities/Role';
 import { Department } from '../../../../domain/entities/Department';
@@ -24,6 +29,11 @@ describe('User WebSocket gateway', () => {
   let realtime: DeepMockProxy<RealtimePort>;
   let userRepo: DeepMockProxy<UserRepositoryPort>;
   let audit: DeepMockProxy<AuditPort>;
+  let tokenService: DeepMockProxy<TokenServicePort>;
+  let refreshRepo: DeepMockProxy<RefreshTokenPort>;
+  let getConfig: DeepMockProxy<GetConfigUseCase>;
+  let passwordValidator: DeepMockProxy<PasswordValidator>;
+  let mfaService: DeepMockProxy<MfaServicePort>;
   let user: User;
   let role: Role;
   let department: Department;
@@ -37,15 +47,41 @@ describe('User WebSocket gateway', () => {
     realtime = mockDeep<RealtimePort>();
     userRepo = mockDeep<UserRepositoryPort>();
     audit = mockDeep<AuditPort>();
+    tokenService = mockDeep<TokenServicePort>();
+    refreshRepo = mockDeep<RefreshTokenPort>();
+    getConfig = mockDeep<GetConfigUseCase>();
+    passwordValidator = mockDeep<PasswordValidator>();
+    mfaService = mockDeep<MfaServicePort>();
+    passwordValidator.validate.mockResolvedValue();
+    tokenService.generateAccessToken.mockReturnValue('t');
+    tokenService.generateRefreshToken.mockResolvedValue('r');
+    auth.authenticate.mockResolvedValue(user);
+    auth.requestPasswordReset.mockResolvedValue();
+    auth.resetPassword.mockResolvedValue();
+    mfaService.generateTotpSecret.mockResolvedValue('sec');
     role = new Role('r', 'Role', [
       new Permission('p1', PermissionKeys.READ_USERS, ''),
       new Permission('p2', PermissionKeys.UPDATE_USER, ''),
+      new Permission('p3', PermissionKeys.READ_USER, ''),
+      new Permission('p4', PermissionKeys.MANAGE_MFA, ''),
     ]);
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
     user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', department, site);
     auth.verifyToken.mockResolvedValue(user);
-    registerUserGateway(io, auth, logger, realtime, userRepo, audit);
+    registerUserGateway(
+      io,
+      auth,
+      logger,
+      realtime,
+      userRepo,
+      audit,
+      tokenService,
+      refreshRepo,
+      getConfig,
+      passwordValidator,
+      mfaService,
+    );
     httpServer.listen(() => {
       const address = httpServer.address() as any;
       url = `http://localhost:${address.port}`;
@@ -177,6 +213,81 @@ describe('User WebSocket gateway', () => {
     });
     client.on('error', (err: { error: string }) => {
       expect(err.error).toBe('Invalid parameters');
+      client.close();
+      done();
+    });
+  });
+
+  it('emits user data on get', (done) => {
+    userRepo.findById.mockResolvedValue(user);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('user-get', { id: 'u' });
+    });
+    client.on('user-get-response', (data: any) => {
+      expect(data.id).toBe('u');
+      client.close();
+      done();
+    });
+  });
+
+  it('broadcasts user-changed on create', (done) => {
+    userRepo.create.mockResolvedValue(user);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('user-create', {
+        id: 'u',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        password: 'secret',
+        department: { id: 'd', label: 'Dept', site: { id: 's', label: 'Site' } },
+        site: { id: 's', label: 'Site' },
+      });
+    });
+    client.on('user-create-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('user-changed', { id: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('responds on login', (done) => {
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('auth-login', { email: 'john@example.com', password: 'secret' });
+    });
+    client.on('auth-login-response', (data: any) => {
+      expect(data.token).toBe('t');
+      client.close();
+      done();
+    });
+  });
+
+  it('handles password reset workflow', (done) => {
+    auth.verifyToken.mockResolvedValue(user);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('auth-reset', { token: 'tok', password: 'new' });
+    });
+    client.on('auth-reset-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('user-changed', { id: 'u' });
+      client.close();
+      done();
+    });
+  });
+
+  it('handles mfa enable/disable', (done) => {
+    userRepo.update.mockResolvedValue(user);
+    const client = ioClient.connect(url, { auth: { token: 'token' } });
+    client.on('connect', () => {
+      client.emit('auth-mfa-enable', { type: 'email' });
+    });
+    client.on('auth-mfa-enable-response', () => {
+      client.emit('auth-mfa-disable');
+    });
+    client.on('auth-mfa-disable-response', () => {
+      expect(realtime.broadcast).toHaveBeenCalledWith('user-changed', { id: 'u' });
       client.close();
       done();
     });


### PR DESCRIPTION
## Summary
- implement additional WebSocket events for user authentication and MFA in `userGateway`
- wire new dependencies in server bootstrap
- test registration/login/password reset/MFA events via websocket

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a894041808323b68305e3554a6db4