### PR TITLE
Add scoped permission assignments

### DIFF
--- a/backend/adapters/controllers/rest/roleController.ts
+++ b/backend/adapters/controllers/rest/roleController.ts
@@ -7,6 +7,7 @@ import {getContext} from '../../../infrastructure/loggerContext';
 import {Role} from '../../../domain/entities/Role';
 import {Permission} from '../../../domain/entities/Permission';
 import {User} from '../../../domain/entities/User';
+import {RolePermissionAssignment} from '../../../domain/entities/RolePermissionAssignment';
 import {PermissionChecker} from '../../../domain/services/PermissionChecker';
 import {PermissionKeys} from '../../../domain/entities/PermissionKeys';
 import {CreateRoleUseCase} from '../../../usecases/role/CreateRoleUseCase';
@@ -64,7 +65,10 @@ import {GetRoleUseCase} from '../../../usecases/role/GetRoleUseCase';
 interface RolePayload {
     id: string;
     label: string;
-    permissions?: Array<{ id: string; permissionKey: string; description: string }>;
+    permissions?: Array<{
+        permission: { id: string; permissionKey: string; description: string };
+        scopeId?: string;
+    }>;
 }
 
 interface AuthedRequest extends Request {
@@ -77,7 +81,11 @@ function parseRole(body: RolePayload): Role {
     body.id,
     body.label,
     (body.permissions ?? []).map(
-      (p) => new Permission(p.id, p.permissionKey, p.description),
+      (p) =>
+        new RolePermissionAssignment(
+          new Permission(p.permission.id, p.permission.permissionKey, p.permission.description),
+          p.scopeId,
+        ),
     ),
   );
 }

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -35,6 +35,7 @@ import {Role} from '../../../domain/entities/Role';
 import {Department} from '../../../domain/entities/Department';
 import {Site} from '../../../domain/entities/Site';
 import {Permission} from '../../../domain/entities/Permission';
+import {UserPermissionAssignment} from '../../../domain/entities/UserPermissionAssignment';
 import {PermissionChecker} from '../../../domain/services/PermissionChecker';
 import {PermissionKeys} from '../../../domain/entities/PermissionKeys';
 import { PasswordValidator } from '../../../domain/services/PasswordValidator';
@@ -252,7 +253,11 @@ export function createUserRouter(
         };
         site: { id: string; label: string };
         picture?: string;
-        permissions?: Array<{ id: string; permissionKey: string; description: string }>;
+        permissions?: Array<{
+            permission: { id: string; permissionKey: string; description: string };
+            scopeId?: string;
+            denyPermission?: boolean;
+        }>;
     }
 
     /* istanbul ignore next */
@@ -274,7 +279,16 @@ export function createUserRouter(
         new Site(body.site.id, body.site.label),
         body.picture,
         (body.permissions ?? []).map(
-          (p) => new Permission(p.id, p.permissionKey, p.description),
+          (p) =>
+            new UserPermissionAssignment(
+              new Permission(
+                p.permission.id,
+                p.permission.permissionKey,
+                p.permission.description,
+              ),
+              p.scopeId,
+              p.denyPermission ?? false,
+            ),
         ),
       );
     }

--- a/backend/adapters/orm/prisma/migrations/20250730160500_add_scopeid/migration.sql
+++ b/backend/adapters/orm/prisma/migrations/20250730160500_add_scopeid/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "UserPermission" ADD COLUMN "scopeId" TEXT;
+ALTER TABLE "RolePermission" ADD COLUMN "scopeId" TEXT;

--- a/backend/adapters/orm/prisma/schema.prisma
+++ b/backend/adapters/orm/prisma/schema.prisma
@@ -121,6 +121,7 @@ model UserPermission {
   userId       String
   permission   Permission @relation(fields: [permissionId], references: [id])
   permissionId String
+  scopeId      String?
 
   @@id([userId, permissionId])
 }
@@ -130,6 +131,7 @@ model RolePermission {
   roleId       String
   permission   Permission @relation(fields: [permissionId], references: [id])
   permissionId String
+  scopeId      String?
 
   @@id([roleId, permissionId])
 }

--- a/backend/domain/entities/Role.ts
+++ b/backend/domain/entities/Role.ts
@@ -1,7 +1,7 @@
 /**
  * Describes a role that can be assigned to a user.
  */
-import { Permission } from './Permission';
+import { RolePermissionAssignment } from './RolePermissionAssignment';
 import { User } from './User';
 
 export class Role {
@@ -10,12 +10,12 @@ export class Role {
    *
    * @param id - Unique identifier of the role.
    * @param label - Human readable label for the role.
-   * @param permissions - Collection of {@link Permission} associated with the role.
+   * @param permissions - Collection of permission assignments associated with the role.
    */
   constructor(
     public readonly id: string,
     public label: string,
-    public permissions: Permission[] = [],
+    public permissions: RolePermissionAssignment[] = [],
     /** Date when the role was created. */
     public createdAt: Date = new Date(),
     /** Date when the role was last updated. Defaults to {@link createdAt}. */

--- a/backend/domain/entities/RolePermissionAssignment.ts
+++ b/backend/domain/entities/RolePermissionAssignment.ts
@@ -1,0 +1,17 @@
+/**
+ * Represents a permission granted to a role.
+ */
+import { Permission } from './Permission';
+
+export class RolePermissionAssignment {
+  /**
+   * Create a new role permission assignment.
+   *
+   * @param permission - Permission associated with the role.
+   * @param scopeId - Optional scope identifier for the permission.
+   */
+  constructor(
+    public permission: Permission,
+    public scopeId?: string,
+  ) {}
+}

--- a/backend/domain/entities/User.ts
+++ b/backend/domain/entities/User.ts
@@ -1,6 +1,6 @@
 import { Role } from './Role';
 import { Department } from './Department';
-import { Permission } from './Permission';
+import { UserPermissionAssignment } from './UserPermissionAssignment';
 import { Site } from './Site';
 
 /**
@@ -19,7 +19,7 @@ export class User {
    * @param department - {@link Department} the user belongs to.
    * @param site - {@link Site} where the user is located.
    * @param picture - Optional profile picture URL.
-   * @param permissions - Collection of {@link Permission} granted directly to the user.
+   * @param permissions - Collection of permission assignments granted directly to the user.
    * @param mfaEnabled - Flag indicating whether multi-factor authentication is enabled.
    * @param mfaType - Selected type of multi-factor authentication or `null` if not configured.
    * @param mfaSecret - Secret used for the MFA mechanism when applicable.
@@ -39,7 +39,7 @@ export class User {
     public department: Department,
     public site: Site,
     public picture?: string,
-    public permissions: Permission[] = [],
+    public permissions: UserPermissionAssignment[] = [],
     /** Date and time of the user's last successful login. */
     public lastLogin: Date | null = null,
     /** Date and time of the user's last activity (login or token refresh). */

--- a/backend/domain/entities/UserPermissionAssignment.ts
+++ b/backend/domain/entities/UserPermissionAssignment.ts
@@ -1,0 +1,19 @@
+/**
+ * Represents a permission directly assigned to a user.
+ */
+import { Permission } from './Permission';
+
+export class UserPermissionAssignment {
+  /**
+   * Create a new user permission assignment.
+   *
+   * @param permission - Permission granted or denied.
+   * @param scopeId - Optional scope identifier for the permission.
+   * @param denyPermission - Whether this assignment denies the permission.
+   */
+  constructor(
+    public permission: Permission,
+    public scopeId?: string,
+    public denyPermission = false,
+  ) {}
+}

--- a/backend/domain/services/PermissionChecker.ts
+++ b/backend/domain/services/PermissionChecker.ts
@@ -28,17 +28,17 @@ export class PermissionChecker {
    * @returns `true` if the user has the permission.
    */
   has(key: string): boolean {
-    if (this.user.permissions.some(p => p.permissionKey === PermissionKeys.ROOT)) {
+    if (this.user.permissions.some(p => !p.denyPermission && p.permission.permissionKey === PermissionKeys.ROOT)) {
       return true;
     }
-    if (this.user.permissions.some(p => p.permissionKey === key)) {
+    if (this.user.permissions.some(p => !p.denyPermission && p.permission.permissionKey === key)) {
       return true;
     }
     for (const role of this.user.roles) {
-      if (role.permissions.some(p => p.permissionKey === PermissionKeys.ROOT)) {
+      if (role.permissions.some(p => p.permission.permissionKey === PermissionKeys.ROOT)) {
         return true;
       }
-      if (role.permissions.some(p => p.permissionKey === key)) {
+      if (role.permissions.some(p => p.permission.permissionKey === key)) {
         return true;
       }
     }

--- a/backend/tests/adapters/controllers/rest/roleController.test.ts
+++ b/backend/tests/adapters/controllers/rest/roleController.test.ts
@@ -83,7 +83,7 @@ describe('Role REST controller', () => {
       .send({
         id: 'r',
         label: 'Role',
-        permissions: [{ id: 'p', permissionKey: 'P', description: 'desc' }],
+        permissions: [{ permission: { id: 'p', permissionKey: 'P', description: 'desc' }, scopeId: 's1' }],
       });
 
     expect(res.status).toBe(201);
@@ -95,7 +95,7 @@ describe('Role REST controller', () => {
       .put('/api/roles/r')
       .send({
         label: 'Role',
-        permissions: [{ id: 'p', permissionKey: 'P', description: 'desc' }],
+        permissions: [{ permission: { id: 'p', permissionKey: 'P', description: 'desc' }, scopeId: 's1' }],
       });
 
     expect(res.status).toBe(200);

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -212,7 +212,7 @@ describe('User REST controller', () => {
     tokenService.generateRefreshToken.mockResolvedValue('r');
     const res = await request(app)
       .post('/api/users')
-      .send({ id: 'u', firstName: 'John', lastName: 'Doe', email: 'john@example.com', roles: [{ id: 'r', label: 'Role' }], status: 'active', permissions: [{ id: 'p', permissionKey: 'k', description: 'd' }], department: { id: 'd', label: 'Dept', site: { id: 's', label: 'Site' } }, site: { id: 's', label: 'Site' }, password: 'Password1!' });
+      .send({ id: 'u', firstName: 'John', lastName: 'Doe', email: 'john@example.com', roles: [{ id: 'r', label: 'Role' }], status: 'active', permissions: [{ permission: { id: 'p', permissionKey: 'k', description: 'd' }, scopeId: 's1' }], department: { id: 'd', label: 'Dept', site: { id: 's', label: 'Site' } }, site: { id: 's', label: 'Site' }, password: 'Password1!' });
 
     expect(res.status).toBe(201);
     const expectedUser = {
@@ -592,7 +592,7 @@ describe('User REST controller', () => {
     const res = await request(app)
       .put('/api/users/u')
       .set('Authorization', 'Bearer token')
-      .send({ firstName: 'Jane', lastName: 'Doe', email: 'john@example.com', roles: [{ id: 'r', label: 'Role' }], status: 'active', permissions: [{ id: 'p', permissionKey: 'k', description: 'd' }], department: { id: 'd', label: 'Dept', site: { id: 's', label: 'Site' } }, site: { id: 's', label: 'Site' } });
+      .send({ firstName: 'Jane', lastName: 'Doe', email: 'john@example.com', roles: [{ id: 'r', label: 'Role' }], status: 'active', permissions: [{ permission: { id: 'p', permissionKey: 'k', description: 'd' }, scopeId: 's1' }], department: { id: 'd', label: 'Dept', site: { id: 's', label: 'Site' } }, site: { id: 's', label: 'Site' } });
 
     expect(res.status).toBe(200);
     expect(repo.update).toHaveBeenCalled();

--- a/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
@@ -5,6 +5,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Department } from '../../../domain/entities/Department';
 import { Permission } from '../../../domain/entities/Permission';
+import { UserPermissionAssignment } from '../../../domain/entities/UserPermissionAssignment';
 import { Site } from '../../../domain/entities/Site';
 import { LoggerPort } from '../../../domain/ports/LoggerPort';
 
@@ -347,7 +348,7 @@ describe('PrismaUserRepository', () => {
 
     it('should create user with permissions', async () => {
       const perm = new Permission('perm-1', 'READ', 'read');
-      mockUser.permissions = [perm];
+      mockUser.permissions = [new UserPermissionAssignment(perm, 's1')];
 
       const mockPrismaCreatedUserPerm = {
         id: 'user-123',
@@ -394,7 +395,7 @@ describe('PrismaUserRepository', () => {
           passwordChangedAt: expect.any(Date),
           createdById: undefined,
           updatedById: undefined,
-          permissions: { create: [{ permission: { connect: { id: 'perm-1' } } }] },
+          permissions: { create: [{ scopeId: 's1', permission: { connect: { id: 'perm-1' } } }] },
           status: 'active',
           roles: {
             create: [{ role: { connect: { id: 'role-123' } } }],
@@ -647,7 +648,7 @@ describe('PrismaUserRepository', () => {
         department,
         site,
         undefined,
-        [perm]
+        [new UserPermissionAssignment(perm, 's2')]
       );
 
       const mockPrismaUpdatedPermUser = {
@@ -694,7 +695,7 @@ describe('PrismaUserRepository', () => {
           mfaRecoveryCodes: [],
           passwordChangedAt: expect.any(Date),
           updatedById: undefined,
-          permissions: { deleteMany: {}, create: [{ permission: { connect: { id: 'perm-2' } } }] },
+          permissions: { deleteMany: {}, create: [{ scopeId: 's2', permission: { connect: { id: 'perm-2' } } }] },
           roles: {
             deleteMany: {},
             create: [{ role: { connect: { id: 'role-123' } } }],


### PR DESCRIPTION
## Summary
- support scoped role and user permissions
- update Prisma schema and add migration for scopeId
- map new permission assignments in Prisma repositories
- parse/serialize assignments in controllers
- add domain classes for permission assignments
- update unit tests

## Testing
- `npm run lint`
- `npm test` *(fails: TypeScript errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688aa44fa3508323bc79430ed4267d84