### PR TITLE
Fix TypeScript errors in department use case tests

### DIFF
--- a/backend/tests/usecases/department/AddChildDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/AddChildDepartmentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('AddChildDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -28,7 +29,11 @@ describe('AddChildDepartmentUseCase', () => {
           new Role(
             'admin',
             'Admin',
-            [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')],
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, ''),
+              ),
+            ],
           ),
         ],
         'active',

--- a/backend/tests/usecases/department/AddDepartmentUserUseCase.test.ts
+++ b/backend/tests/usecases/department/AddDepartmentUserUseCase.test.ts
@@ -9,6 +9,7 @@ import { Site } from '../../../domain/entities/Site';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('AddDepartmentUserUseCase', () => {
   let userRepo: DeepMockProxy<UserRepositoryPort>;
@@ -34,7 +35,11 @@ describe('AddDepartmentUserUseCase', () => {
           new Role(
             'admin',
             'Admin',
-            [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')],
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, ''),
+              ),
+            ],
           ),
         ],
         'active',

--- a/backend/tests/usecases/department/CreateDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/CreateDepartmentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 import { RealtimePort } from '../../../domain/ports/RealtimePort';
 
 describe('CreateDepartmentUseCase', () => {
@@ -23,7 +24,11 @@ describe('CreateDepartmentUseCase', () => {
     realtime = mockDeep<RealtimePort>();
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
-    const role = new Role('r', 'Role', [new Permission('p', PermissionKeys.CREATE_DEPARTMENT, 'create')]);
+    const role = new Role(
+      'r',
+      'Role',
+      [new RolePermissionAssignment(new Permission('p', PermissionKeys.CREATE_DEPARTMENT, 'create'))],
+    );
     permissionChecker = new PermissionChecker(
       new User(
         'u',

--- a/backend/tests/usecases/department/GetDepartmentChildrenUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentChildrenUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('GetDepartmentChildrenUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -26,7 +27,17 @@ describe('GetDepartmentChildrenUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.READ_DEPARTMENTS, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.READ_DEPARTMENTS, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/GetDepartmentManagerUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentManagerUseCase.test.ts
@@ -9,6 +9,7 @@ import { Site } from '../../../domain/entities/Site';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 
 describe('GetDepartmentManagerUseCase', () => {
@@ -30,7 +31,17 @@ describe('GetDepartmentManagerUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.READ_DEPARTMENT, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.READ_DEPARTMENT, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/GetDepartmentParentUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentParentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 
 describe('GetDepartmentParentUseCase', () => {
@@ -26,7 +27,17 @@ describe('GetDepartmentParentUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.READ_DEPARTMENT, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.READ_DEPARTMENT, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/GetDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('GetDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -20,7 +21,11 @@ describe('GetDepartmentUseCase', () => {
     repository = mockDeep<DepartmentRepositoryPort>();
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
-    const role = new Role('r', 'Role', [new Permission('p', PermissionKeys.READ_DEPARTMENT, 'read')]);
+    const role = new Role(
+      'r',
+      'Role',
+      [new RolePermissionAssignment(new Permission('p', PermissionKeys.READ_DEPARTMENT, 'read'))],
+    );
     permissionChecker = new PermissionChecker(
       new User(
         'u',

--- a/backend/tests/usecases/department/GetDepartmentUsersUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentUsersUseCase.test.ts
@@ -8,6 +8,7 @@ import { Site } from '../../../domain/entities/Site';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('GetDepartmentUsersUseCase', () => {
   let repo: DeepMockProxy<UserRepositoryPort>;
@@ -26,7 +27,17 @@ describe('GetDepartmentUsersUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.READ_USERS, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.READ_USERS, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/GetDepartmentsUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentsUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('GetDepartmentsUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -20,7 +21,11 @@ describe('GetDepartmentsUseCase', () => {
     repository = mockDeep<DepartmentRepositoryPort>();
     site = new Site('s', 'Site');
     department = new Department('d', 'Dept', null, null, site);
-    const role = new Role('r', 'Role', [new Permission('p', PermissionKeys.READ_DEPARTMENTS, 'read')]);
+    const role = new Role(
+      'r',
+      'Role',
+      [new RolePermissionAssignment(new Permission('p', PermissionKeys.READ_DEPARTMENTS, 'read'))],
+    );
     permissionChecker = new PermissionChecker(
       new User(
         'u',

--- a/backend/tests/usecases/department/RemoveChildDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveChildDepartmentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('RemoveChildDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -24,7 +25,17 @@ describe('RemoveChildDepartmentUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/RemoveDepartmentManagerUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentManagerUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('RemoveDepartmentManagerUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -24,7 +25,17 @@ describe('RemoveDepartmentManagerUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/RemoveDepartmentParentDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentParentDepartmentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('RemoveDepartmentParentDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -24,7 +25,17 @@ describe('RemoveDepartmentParentDepartmentUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/RemoveDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentUseCase.test.ts
@@ -9,6 +9,7 @@ import { Site } from '../../../domain/entities/Site';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('RemoveDepartmentUseCase', () => {
   let deptRepo: DeepMockProxy<DepartmentRepositoryPort>;
@@ -29,7 +30,17 @@ describe('RemoveDepartmentUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.DELETE_DEPARTMENT, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.DELETE_DEPARTMENT, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/RemoveDepartmentUserUseCase.test.ts
+++ b/backend/tests/usecases/department/RemoveDepartmentUserUseCase.test.ts
@@ -8,6 +8,7 @@ import { Site } from '../../../domain/entities/Site';
 import { PermissionChecker } from '../../../domain/services/PermissionChecker';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('RemoveDepartmentUserUseCase', () => {
   let userRepo: DeepMockProxy<UserRepositoryPort>;
@@ -26,7 +27,17 @@ describe('RemoveDepartmentUserUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/SetDepartmentManagerUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentManagerUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('SetDepartmentManagerUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -24,7 +25,17 @@ describe('SetDepartmentManagerUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_USERS, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/SetDepartmentParentDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/SetDepartmentParentDepartmentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('SetDepartmentParentDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -24,7 +25,17 @@ describe('SetDepartmentParentDepartmentUseCase', () => {
         'A',
         'B',
         'a@b.c',
-        [new Role('admin', 'Admin', [new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, '')])],
+        [
+          new Role(
+            'admin',
+            'Admin',
+            [
+              new RolePermissionAssignment(
+                new Permission('p', PermissionKeys.MANAGE_DEPARTMENT_HIERARCHY, ''),
+              ),
+            ],
+          ),
+        ],
         'active',
         new Department('d', 'Dept', null, null, new Site('s', 'Site')),
         new Site('s', 'Site'),

--- a/backend/tests/usecases/department/UpdateDepartmentUseCase.test.ts
+++ b/backend/tests/usecases/department/UpdateDepartmentUseCase.test.ts
@@ -8,6 +8,7 @@ import { User } from '../../../domain/entities/User';
 import { Role } from '../../../domain/entities/Role';
 import { Permission } from '../../../domain/entities/Permission';
 import { PermissionKeys } from '../../../domain/entities/PermissionKeys';
+import { RolePermissionAssignment } from '../../../domain/entities/RolePermissionAssignment';
 
 describe('UpdateDepartmentUseCase', () => {
   let repository: DeepMockProxy<DepartmentRepositoryPort>;
@@ -20,7 +21,11 @@ describe('UpdateDepartmentUseCase', () => {
     repository = mockDeep<DepartmentRepositoryPort>();
     site = new Site('site-1', 'HQ');
     department = new Department('dept-1', 'IT', null, null, site);
-    const role = new Role('r', 'Role', [new Permission('p', PermissionKeys.UPDATE_DEPARTMENT, 'update')]);
+    const role = new Role(
+      'r',
+      'Role',
+      [new RolePermissionAssignment(new Permission('p', PermissionKeys.UPDATE_DEPARTMENT, 'update'))],
+    );
     permissionChecker = new PermissionChecker(
       new User(
         'u',


### PR DESCRIPTION
## Summary
- fix TypeScript errors in department use case tests by using `RolePermissionAssignment`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b23c99f648323997327dbf79ba9ba