### PR TITLE
Add missing unit tests for cron and password expiry warnings

### DIFF
--- a/backend/adapters/repositories/PrismaUserGroupRepository.ts
+++ b/backend/adapters/repositories/PrismaUserGroupRepository.ts
@@ -14,7 +14,6 @@ import { ListParams, PaginatedResult } from '../../domain/dtos/PaginatedResult';
 import { UserGroup } from '../../domain/entities/UserGroup';
 import { User } from '../../domain/entities/User';
 import { Role } from '../../domain/entities/Role';
-import { RolePermissionAssignment } from '../../domain/entities/RolePermissionAssignment';
 import { UserPermissionAssignment } from '../../domain/entities/UserPermissionAssignment';
 import { Department } from '../../domain/entities/Department';
 import { Site } from '../../domain/entities/Site';

--- a/backend/tests/usecases/SendPasswordExpiryWarningsUseCase.test.ts
+++ b/backend/tests/usecases/SendPasswordExpiryWarningsUseCase.test.ts
@@ -1,0 +1,62 @@
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { SendPasswordExpiryWarningsUseCase } from '../..//usecases/SendPasswordExpiryWarningsUseCase';
+import { UserRepositoryPort } from '../../domain/ports/UserRepositoryPort';
+import { EmailServicePort } from '../../domain/ports/EmailServicePort';
+import { GetConfigUseCase } from '../../usecases/config/GetConfigUseCase';
+import { User } from '../../domain/entities/User';
+import { Role } from '../../domain/entities/Role';
+import { Department } from '../../domain/entities/Department';
+import { Site } from '../../domain/entities/Site';
+
+describe('SendPasswordExpiryWarningsUseCase', () => {
+  const fixedDate = new Date('2024-01-01T00:00:00Z');
+  let repo: DeepMockProxy<UserRepositoryPort>;
+  let mailer: DeepMockProxy<EmailServicePort>;
+  let config: DeepMockProxy<GetConfigUseCase>;
+  let useCase: SendPasswordExpiryWarningsUseCase;
+  let user: User;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(fixedDate);
+    repo = mockDeep<UserRepositoryPort>();
+    mailer = mockDeep<EmailServicePort>();
+    config = mockDeep<GetConfigUseCase>();
+    useCase = new SendPasswordExpiryWarningsUseCase(repo, mailer, config);
+    const role = new Role('r', 'Role');
+    const site = new Site('s', 'Site');
+    const dept = new Department('d', 'Dept', null, null, site);
+    user = new User('u', 'John', 'Doe', 'john@example.com', [role], 'active', dept, site);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should send warnings using defaults when config missing', async () => {
+    config.execute.mockResolvedValue(null);
+    user.passwordChangedAt = new Date(fixedDate.getTime() - 85 * 24 * 60 * 60 * 1000);
+    repo.findUsersWithPasswordChangedBefore.mockResolvedValue([user]);
+
+    await useCase.execute();
+
+    const threshold = new Date(fixedDate);
+    threshold.setDate(threshold.getDate() - (90 - 7));
+    expect(repo.findUsersWithPasswordChangedBefore).toHaveBeenCalledWith(threshold);
+    expect(mailer.sendMail).toHaveBeenCalledWith({
+      to: user.email,
+      subject: 'Votre mot de passe expire bientôt',
+      template: 'password-expiry-warning',
+      variables: { username: user.firstName, daysLeft: 5 },
+    });
+  });
+
+  it('should not send when password already expired', async () => {
+    config.execute.mockResolvedValue(null);
+    user.passwordChangedAt = new Date(fixedDate.getTime() - 90 * 24 * 60 * 60 * 1000);
+    repo.findUsersWithPasswordChangedBefore.mockResolvedValue([user]);
+
+    await useCase.execute();
+
+    expect(mailer.sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usecases/cron/DummyCronUseCase.test.ts
+++ b/backend/tests/usecases/cron/DummyCronUseCase.test.ts
@@ -1,0 +1,14 @@
+import { mockDeep } from 'jest-mock-extended';
+import { DummyCronUseCase } from '../../../usecases/cron/DummyCronUseCase';
+import { LoggerPort } from '../../../domain/ports/LoggerPort';
+
+describe('DummyCronUseCase', () => {
+  it('should log execution', async () => {
+    const logger = mockDeep<LoggerPort>();
+    const useCase = new DummyCronUseCase(logger);
+
+    await useCase.execute();
+
+    expect(logger.info).toHaveBeenCalledWith('DummyCronUseCase executed');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for SendPasswordExpiryWarningsUseCase
- add unit test for DummyCronUseCase
- remove unused import in PrismaUserGroupRepository

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b397eabd48323b5de9874bd94c1c4