### PR TITLE
Add CORS support for backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,3 +60,13 @@ EMAIL_TEMPLATES_PATH=./templates
 
 # Port the HTTP server listens on
 PORT=3000
+
+# CORS configuration
+## Allowed origins (comma separated)
+CORS_ORIGIN=*
+## Allowed HTTP methods
+CORS_METHODS=GET,HEAD,PUT,PATCH,POST,DELETE
+## Additional allowed headers
+CORS_ALLOWED_HEADERS=Content-Type,Authorization
+## Whether to allow credentials
+CORS_ALLOW_CREDENTIALS=false

--- a/backend/infrastructure/server.ts
+++ b/backend/infrastructure/server.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 import express from 'express';
+import cors from 'cors';
 import http from 'http';
 import { Server as SocketIOServer } from 'socket.io';
 import { createAdapter as createSocketIORedisAdapter } from '@socket.io/redis-adapter';
@@ -155,6 +156,13 @@ async function bootstrap(): Promise<void> {
 
   const app = express();
   app.use(express.json());
+  const corsOptions = {
+    origin: (process.env.CORS_ORIGIN ?? '*').split(','),
+    methods: process.env.CORS_METHODS ?? 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    allowedHeaders: process.env.CORS_ALLOWED_HEADERS ?? 'Content-Type,Authorization',
+    credentials: process.env.CORS_ALLOW_CREDENTIALS === 'true',
+  };
+  app.use(cors(corsOptions));
   app.use((req, _res, next) => {
     withContext({ requestId: randomUUID() }, () => next());
   });

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
   testMatch: [
-    '**/tests/**/*.ts',
     '**/?(*.)+(spec|test).ts'
   ],
   transform: {


### PR DESCRIPTION
## Summary
- configure CORS through environment variables in the backend
- expose CORS settings in `.env.example`
- fix Jest configuration so setup file isn't treated as a test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b60598fac83238e3a0f3f44c6d428