### PR TITLE
Fix /api/users/me route resolution

### DIFF
--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -1116,29 +1116,6 @@ export function createUserRouter(
      *       403:
      *         description: User lacks required permission.
      */
-    router.get('/users/:id', async (req: Request, res: Response): Promise<void> => {
-      logger.debug('GET /users/:id', getContext());
-      const checker = new PermissionChecker((req as AuthedRequest).user);
-      const useCase = new GetUserUseCase(userRepository, checker);
-      try {
-        const user = await useCase.execute(req.params.id);
-        if (!user) {
-          logger.warn('User not found', getContext());
-          res.status(404).end();
-          return;
-        }
-        logger.debug('User retrieved', getContext());
-        res.json(user);
-      } catch (err) {
-        if ((err as Error).message === 'Forbidden') {
-          logger.warn('Permission denied getting user', { ...getContext(), error: err });
-          res.status(403).json({ error: 'Forbidden' });
-          return;
-        }
-        throw err;
-      }
-    });
-
     /**
      * @openapi
      * /users/me:
@@ -1182,6 +1159,29 @@ export function createUserRouter(
       } catch (err) {
         if ((err as Error).message === 'Forbidden') {
           logger.warn('Permission denied current profile', { ...getContext(), error: err });
+          res.status(403).json({ error: 'Forbidden' });
+          return;
+        }
+        throw err;
+      }
+    });
+
+    router.get('/users/:id', async (req: Request, res: Response): Promise<void> => {
+      logger.debug('GET /users/:id', getContext());
+      const checker = new PermissionChecker((req as AuthedRequest).user);
+      const useCase = new GetUserUseCase(userRepository, checker);
+      try {
+        const user = await useCase.execute(req.params.id);
+        if (!user) {
+          logger.warn('User not found', getContext());
+          res.status(404).end();
+          return;
+        }
+        logger.debug('User retrieved', getContext());
+        res.json(user);
+      } catch (err) {
+        if ((err as Error).message === 'Forbidden') {
+          logger.warn('Permission denied getting user', { ...getContext(), error: err });
           res.status(403).json({ error: 'Forbidden' });
           return;
         }


### PR DESCRIPTION
## Summary
- move `/users/me` route before parameterized `/users/:id` route in REST controller
- run linter and tests

## Testing
- `npm run lint --silent --prefix backend`
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_688b6a23865083239a042ae6a6c81b0f