### PR TITLE
feat: support multi-id filters for users

### DIFF
--- a/backend/adapters/controllers/rest/departmentController.ts
+++ b/backend/adapters/controllers/rest/departmentController.ts
@@ -518,18 +518,20 @@ export function createDepartmentRouter(
      *           type: string
      *         description: Filter by user name or email.
      *       - in: query
-     *         name: status
+     *         name: statuses
      *         schema:
      *           type: string
-     *           enum: [active, suspended, archived]
+     *         description: Semicolon-separated list of user statuses (active, suspended, archived).
      *       - in: query
-     *         name: siteId
+     *         name: siteIds
      *         schema:
      *           type: string
+     *         description: Semicolon-separated list of site identifiers.
      *       - in: query
-     *         name: roleId
+     *         name: roleIds
      *         schema:
      *           type: string
+     *         description: Semicolon-separated list of role identifiers.
      *     responses:
      *       200:
      *         description: Paginated users list.
@@ -568,9 +570,17 @@ export function createDepartmentRouter(
       limit,
       filters: {
         search: req.query.search as string | undefined,
-        status: req.query.status as 'active' | 'suspended' | 'archived' | undefined,
-        siteId: req.query.siteId as string | undefined,
-        roleId: req.query.roleId as string | undefined,
+        statuses: req.query.statuses
+          ? ((req.query.statuses as string).split(';').filter(Boolean) as Array<
+              'active' | 'suspended' | 'archived'
+            >)
+          : undefined,
+        siteIds: req.query.siteIds
+          ? (req.query.siteIds as string).split(';').filter(Boolean)
+          : undefined,
+        roleIds: req.query.roleIds
+          ? (req.query.roleIds as string).split(';').filter(Boolean)
+          : undefined,
       },
     });
     logger.debug('Department users retrieved', getContext());

--- a/backend/adapters/controllers/rest/userController.ts
+++ b/backend/adapters/controllers/rest/userController.ts
@@ -993,26 +993,25 @@ export function createUserRouter(
      *           type: string
      *         description: Search term to filter users by name or email.
      *       - in: query
-     *         name: status
+     *         name: statuses
      *         schema:
      *           type: string
-     *           enum: [active, suspended, archived]
-     *         description: Filter users by status.
+     *         description: Semicolon-separated list of user statuses (active, suspended, archived).
      *       - in: query
-     *         name: departmentId
+     *         name: departmentIds
      *         schema:
      *           type: string
-     *         description: Filter by department identifier.
+     *         description: Semicolon-separated list of department identifiers.
      *       - in: query
-     *         name: siteId
+     *         name: siteIds
      *         schema:
      *           type: string
-     *         description: Filter by site identifier.
+     *         description: Semicolon-separated list of site identifiers.
      *       - in: query
-     *         name: roleId
+     *         name: roleIds
      *         schema:
      *           type: string
-     *         description: Filter by role identifier.
+     *         description: Semicolon-separated list of role identifiers.
      *     responses:
      *       200:
      *         description: Paginated user list
@@ -1057,14 +1056,20 @@ export function createUserRouter(
           limit,
           filters: {
             search: req.query.search as string | undefined,
-            status: req.query.status as
-                      | 'active'
-                      | 'suspended'
-                      | 'archived'
-                      | undefined,
-            departmentId: req.query.departmentId as string | undefined,
-            siteId: req.query.siteId as string | undefined,
-            roleId: req.query.roleId as string | undefined,
+            statuses: req.query.statuses
+              ? ((req.query.statuses as string).split(';').filter(Boolean) as Array<
+                  'active' | 'suspended' | 'archived'
+                >)
+              : undefined,
+            departmentIds: req.query.departmentIds
+              ? (req.query.departmentIds as string).split(';').filter(Boolean)
+              : undefined,
+            siteIds: req.query.siteIds
+              ? (req.query.siteIds as string).split(';').filter(Boolean)
+              : undefined,
+            roleIds: req.query.roleIds
+              ? (req.query.roleIds as string).split(';').filter(Boolean)
+              : undefined,
           },
         });
         logger.debug('Users retrieved', getContext());

--- a/backend/adapters/repositories/PrismaUserGroupRepository.ts
+++ b/backend/adapters/repositories/PrismaUserGroupRepository.ts
@@ -254,17 +254,17 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
         { email: { contains: params.filters.search, mode: 'insensitive' } },
       ];
     }
-    if (params.filters?.status) {
-      where.status = params.filters.status;
+    if (params.filters?.statuses && params.filters.statuses.length > 0) {
+      where.status = { in: params.filters.statuses };
     }
-    if (params.filters?.departmentId) {
-      where.departmentId = params.filters.departmentId;
+    if (params.filters?.departmentIds && params.filters.departmentIds.length > 0) {
+      where.departmentId = { in: params.filters.departmentIds };
     }
-    if (params.filters?.siteId) {
-      where.siteId = params.filters.siteId;
+    if (params.filters?.siteIds && params.filters.siteIds.length > 0) {
+      where.siteId = { in: params.filters.siteIds };
     }
-    if (params.filters?.roleId) {
-      where.roles = { some: { roleId: params.filters.roleId } };
+    if (params.filters?.roleIds && params.filters.roleIds.length > 0) {
+      where.roles = { some: { roleId: { in: params.filters.roleIds } } };
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const records = await (this.prisma as any).user.findMany({
@@ -305,17 +305,17 @@ export class PrismaUserGroupRepository implements UserGroupRepositoryPort {
         { email: { contains: params.filters.search, mode: 'insensitive' } },
       ];
     }
-    if (params.filters?.status) {
-      where.status = params.filters.status;
+    if (params.filters?.statuses && params.filters.statuses.length > 0) {
+      where.status = { in: params.filters.statuses };
     }
-    if (params.filters?.departmentId) {
-      where.departmentId = params.filters.departmentId;
+    if (params.filters?.departmentIds && params.filters.departmentIds.length > 0) {
+      where.departmentId = { in: params.filters.departmentIds };
     }
-    if (params.filters?.siteId) {
-      where.siteId = params.filters.siteId;
+    if (params.filters?.siteIds && params.filters.siteIds.length > 0) {
+      where.siteId = { in: params.filters.siteIds };
     }
-    if (params.filters?.roleId) {
-      where.roles = { some: { roleId: params.filters.roleId } };
+    if (params.filters?.roleIds && params.filters.roleIds.length > 0) {
+      where.roles = { some: { roleId: { in: params.filters.roleIds } } };
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const records = await (this.prisma as any).user.findMany({

--- a/backend/adapters/repositories/PrismaUserRepository.ts
+++ b/backend/adapters/repositories/PrismaUserRepository.ts
@@ -144,17 +144,17 @@ export class PrismaUserRepository implements UserRepositoryPort {
         { email: { contains: params.filters.search, mode: 'insensitive' } },
       ];
     }
-    if (params.filters?.status) {
-      where.status = params.filters.status;
+    if (params.filters?.statuses && params.filters.statuses.length > 0) {
+      where.status = { in: params.filters.statuses };
     }
-    if (params.filters?.departmentId) {
-      where.departmentId = params.filters.departmentId;
+    if (params.filters?.departmentIds && params.filters.departmentIds.length > 0) {
+      where.departmentId = { in: params.filters.departmentIds };
     }
-    if (params.filters?.siteId) {
-      where.siteId = params.filters.siteId;
+    if (params.filters?.siteIds && params.filters.siteIds.length > 0) {
+      where.siteId = { in: params.filters.siteIds };
     }
-    if (params.filters?.roleId) {
-      where.roles = { some: { roleId: params.filters.roleId } };
+    if (params.filters?.roleIds && params.filters.roleIds.length > 0) {
+      where.roles = { some: { roleId: { in: params.filters.roleIds } } };
     }
     const records = await this.prisma.user.findMany({
       skip: (params.page - 1) * params.limit,

--- a/backend/docs/bruno/Department/List department users.bru
+++ b/backend/docs/bruno/Department/List department users.bru
@@ -11,12 +11,12 @@ get {
 }
 
 params:query {
-  ~page: 
-  ~limit: 
-  ~search: 
-  ~status: 
-  ~siteId: 
-  ~roleId: 
+  ~page:
+  ~limit:
+  ~search:
+  ~statuses:
+  ~siteIds:
+  ~roleIds:
 }
 
 params:path {

--- a/backend/docs/bruno/User/Get all users.bru
+++ b/backend/docs/bruno/User/Get all users.bru
@@ -11,12 +11,13 @@ get {
 }
 
 params:query {
-  ~page: 
-  ~limit: 
-  ~search: 
-  ~status: 
-  ~departmentId: 
-  ~siteId: 
+  ~page:
+  ~limit:
+  ~search:
+  ~statuses:
+  ~departmentIds:
+  ~siteIds:
+  ~roleIds:
 }
 
 auth:bearer {

--- a/backend/domain/ports/UserRepositoryPort.ts
+++ b/backend/domain/ports/UserRepositoryPort.ts
@@ -7,14 +7,14 @@ import { ListParams, PaginatedResult } from '../dtos/PaginatedResult';
 export interface UserFilters {
   /** Free text search across name and email. */
   search?: string;
-  /** Filter by user status. */
-  status?: 'active' | 'suspended' | 'archived';
-  /** Restrict to a specific department. */
-  departmentId?: string;
-  /** Restrict to a specific site. */
-  siteId?: string;
-  /** Restrict to users having the given role. */
-  roleId?: string;
+  /** Filter by user statuses. */
+  statuses?: Array<'active' | 'suspended' | 'archived'>;
+  /** Restrict to specific departments. */
+  departmentIds?: string[];
+  /** Restrict to specific sites. */
+  siteIds?: string[];
+  /** Restrict to users having any of the given roles. */
+  roleIds?: string[];
 }
 
 /**

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1130,29 +1130,27 @@
           },
           {
             "in": "query",
-            "name": "status",
+            "name": "statuses",
             "schema": {
-              "type": "string",
-              "enum": [
-                "active",
-                "suspended",
-                "archived"
-              ]
-            }
+              "type": "string"
+            },
+            "description": "Semicolon-separated list of user statuses (active, suspended, archived)."
           },
           {
             "in": "query",
-            "name": "siteId",
+            "name": "siteIds",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Semicolon-separated list of site identifiers."
           },
           {
             "in": "query",
-            "name": "roleId",
+            "name": "roleIds",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Semicolon-separated list of role identifiers."
           }
         ],
         "responses": {
@@ -3186,40 +3184,35 @@
           },
           {
             "in": "query",
-            "name": "status",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "active",
-                "suspended",
-                "archived"
-              ]
-            },
-            "description": "Filter users by status."
-          },
-          {
-            "in": "query",
-            "name": "departmentId",
+            "name": "statuses",
             "schema": {
               "type": "string"
             },
-            "description": "Filter by department identifier."
+            "description": "Semicolon-separated list of user statuses (active, suspended, archived)."
           },
           {
             "in": "query",
-            "name": "siteId",
+            "name": "departmentIds",
             "schema": {
               "type": "string"
             },
-            "description": "Filter by site identifier."
+            "description": "Semicolon-separated list of department identifiers."
           },
           {
             "in": "query",
-            "name": "roleId",
+            "name": "siteIds",
             "schema": {
               "type": "string"
             },
-            "description": "Filter by role identifier."
+            "description": "Semicolon-separated list of site identifiers."
+          },
+          {
+            "in": "query",
+            "name": "roleIds",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Semicolon-separated list of role identifiers."
           }
         ],
         "responses": {

--- a/backend/tests/adapters/controllers/rest/userController.test.ts
+++ b/backend/tests/adapters/controllers/rest/userController.test.ts
@@ -539,10 +539,52 @@ describe('User REST controller', () => {
       limit: 20,
       filters: {
         search: undefined,
-        status: undefined,
-        departmentId: undefined,
-        siteId: undefined,
-        roleId: undefined,
+        statuses: undefined,
+        departmentIds: undefined,
+        siteIds: undefined,
+        roleIds: undefined,
+      },
+    });
+  });
+
+  it('should filter users by multiple ids', async () => {
+    repo.findPage.mockResolvedValue({ items: [user], page: 1, limit: 20, total: 1 });
+
+    const res = await request(app)
+      .get('/api/users?departmentIds=d1;d2&siteIds=s1;s2&roleIds=r1;r2')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(repo.findPage).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      filters: {
+        search: undefined,
+        statuses: undefined,
+        departmentIds: ['d1', 'd2'],
+        siteIds: ['s1', 's2'],
+        roleIds: ['r1', 'r2'],
+      },
+    });
+  });
+
+  it('should filter users by multiple statuses', async () => {
+    repo.findPage.mockResolvedValue({ items: [user], page: 1, limit: 20, total: 1 });
+
+    const res = await request(app)
+      .get('/api/users?statuses=active;archived')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(repo.findPage).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      filters: {
+        search: undefined,
+        statuses: ['active', 'archived'],
+        departmentIds: undefined,
+        siteIds: undefined,
+        roleIds: undefined,
       },
     });
   });
@@ -665,10 +707,10 @@ describe('User REST controller', () => {
       limit: 20,
       filters: {
         search: undefined,
-        status: undefined,
-        departmentId: undefined,
-        siteId: undefined,
-        roleId: undefined,
+        statuses: undefined,
+        departmentIds: undefined,
+        siteIds: undefined,
+        roleIds: undefined,
       },
     });
   });

--- a/backend/tests/adapters/repositories/PrismaUserGroupRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserGroupRepository.test.ts
@@ -235,10 +235,10 @@ describe('PrismaUserGroupRepository', () => {
       limit: 5,
       filters: {
         search: 'john',
-        status: 'active',
-        departmentId: 'd',
-        siteId: 's',
-        roleId: 'r',
+        statuses: ['active'],
+        departmentIds: ['d'],
+        siteIds: ['s'],
+        roleIds: ['r'],
       },
     });
     expect(result).toEqual({ items: [user], page: 1, limit: 5, total: 1 });
@@ -263,10 +263,10 @@ describe('PrismaUserGroupRepository', () => {
       limit: 5,
       filters: {
         search: 'john',
-        status: 'active',
-        departmentId: 'd',
-        siteId: 's',
-        roleId: 'r',
+        statuses: ['active'],
+        departmentIds: ['d'],
+        siteIds: ['s'],
+        roleIds: ['r'],
       },
     });
     expect(result).toEqual({ items: [user], page: 1, limit: 5, total: 1 });

--- a/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
+++ b/backend/tests/adapters/repositories/PrismaUserRepository.test.ts
@@ -973,6 +973,42 @@ describe('PrismaUserRepository', () => {
     expect(prismaClient.user.count).toHaveBeenCalled();
   });
 
+  it('should filter users by ids in pagination', async () => {
+    prismaClient.user.findMany.mockResolvedValue([] as any);
+    prismaClient.user.count.mockResolvedValue(0 as any);
+    await repository.findPage({
+      page: 1,
+      limit: 10,
+      filters: { departmentIds: ['d1', 'd2'], siteIds: ['s1'], roleIds: ['r1', 'r2'] },
+    });
+    expect(prismaClient.user.findMany).toHaveBeenCalledWith({
+      skip: 0,
+      take: 10,
+      where: {
+        departmentId: { in: ['d1', 'd2'] },
+        siteId: { in: ['s1'] },
+        roles: { some: { roleId: { in: ['r1', 'r2'] } } },
+      },
+      include: includeRelations,
+    });
+  });
+
+  it('should filter users by statuses in pagination', async () => {
+    prismaClient.user.findMany.mockResolvedValue([] as any);
+    prismaClient.user.count.mockResolvedValue(0 as any);
+    await repository.findPage({
+      page: 1,
+      limit: 10,
+      filters: { statuses: ['active', 'archived'] },
+    });
+    expect(prismaClient.user.findMany).toHaveBeenCalledWith({
+      skip: 0,
+      take: 10,
+      where: { status: { in: ['active', 'archived'] } },
+      include: includeRelations,
+    });
+  });
+
   it('should return all users', async () => {
     prismaClient.user.findMany.mockResolvedValue([
       {

--- a/backend/tests/usecases/department/GetDepartmentUsersUseCase.test.ts
+++ b/backend/tests/usecases/department/GetDepartmentUsersUseCase.test.ts
@@ -51,7 +51,7 @@ describe('GetDepartmentUsersUseCase', () => {
     const result = await useCase.execute('d', { page:1, limit:20, filters:{ search:'john' } });
 
     expect(result.items).toEqual([user]);
-    expect(repo.findPage).toHaveBeenCalledWith({ page:1, limit:20, filters:{ search:'john', departmentId:'d' } });
+    expect(repo.findPage).toHaveBeenCalledWith({ page:1, limit:20, filters:{ search:'john', departmentIds:['d'] } });
   });
 
   it('should handle missing filters', async () => {
@@ -60,6 +60,6 @@ describe('GetDepartmentUsersUseCase', () => {
     const result = await useCase.execute('d', { page:1, limit:20 });
 
     expect(result.items).toEqual([user]);
-    expect(repo.findPage).toHaveBeenCalledWith({ page:1, limit:20, filters:{ departmentId:'d' } });
+    expect(repo.findPage).toHaveBeenCalledWith({ page:1, limit:20, filters:{ departmentIds:['d'] } });
   });
 });

--- a/backend/usecases/department/GetDepartmentUsersUseCase.ts
+++ b/backend/usecases/department/GetDepartmentUsersUseCase.ts
@@ -26,7 +26,7 @@ export class GetDepartmentUsersUseCase {
   ): Promise<PaginatedResult<User>> {
     this.checker.check(PermissionKeys.READ_USERS);
     /* istanbul ignore next */
-    const filters = { ...(params.filters || {}), departmentId };
+    const filters = { ...(params.filters || {}), departmentIds: [departmentId] };
     return this.userRepository.findPage({ ...params, filters });
   }
 }

--- a/frontend/src/components/ui/datatable/AppDataTableExample.vue
+++ b/frontend/src/components/ui/datatable/AppDataTableExample.vue
@@ -81,8 +81,8 @@ async function queryFunction(params: DataTableQueryParams): Promise<DataTableQue
         )
       }
 
-      if (params.filters.status) {
-        const statusFilter = params.filters.status as string[]
+      if (params.filters.statuses) {
+        const statusFilter = params.filters.statuses as string[]
         if (statusFilter.length > 0) {
           filteredData = filteredData.filter(item =>
             statusFilter.includes(item.status)


### PR DESCRIPTION
## Summary
- allow filtering users by multiple department, site, or role IDs via semicolon-separated `departmentIds`, `siteIds`, and `roleIds` query params
- enable passing a semicolon-separated list of user `statuses` to filter by multiple account states
- propagate new list-based filters through controllers, use cases, repositories, OpenAPI specs, tests, and docs

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fc127c5248323ae1fefed5ced6ad2